### PR TITLE
ci: require hosted pull request checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
       PYTHONPATH: python
       SPARKLAB_DISABLE_JIT: "1"
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.12.6"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,48 @@
+name: PR checks
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-tests:
+    name: CPU tests
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      CUDA_VISIBLE_DEVICES: ""
+      PYTHONPATH: python
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.12.6"
+          enable-cache: true
+      - name: Install CPU test dependencies
+        shell: bash
+        run: |
+          uv venv --python 3.11 .venv
+          mapfile -t requirements < <(python3 - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as source:
+              project = tomllib.load(source)["project"]
+          print(
+              *project["dependencies"],
+              *project["optional-dependencies"]["dev"],
+              sep="\n",
+          )
+          PY
+          )
+          uv pip install --python .venv/bin/python --torch-backend cpu "${requirements[@]}"
+      - name: Run CPU tests
+        run: .venv/bin/python -m pytest -q -m "not slow and not needs_weights"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       CUDA_VISIBLE_DEVICES: ""
       PYTHONPATH: python
+      SPARKLAB_DISABLE_JIT: "1"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -45,4 +46,13 @@ jobs:
           )
           uv pip install --python .venv/bin/python --torch-backend cpu "${requirements[@]}"
       - name: Run CPU tests
-        run: .venv/bin/python -m pytest -q -m "not slow and not needs_weights"
+        run: |
+          .venv/bin/python -m pytest -q \
+            tests/checkpoint \
+            tests/daemon \
+            tests/models \
+            tests/serving \
+            tests/sparklab \
+            tests/tokenizer \
+            tests/test_*.py \
+            -m "not slow and not needs_weights"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,21 @@ by **SixteenMiles Labs**, a research lab under **Oakmind AI**.
 Security vulnerabilities must follow [SECURITY.md](SECURITY.md), not the public issue
 tracker.
 
+## Development workflow
+
+SparkLab uses trunk-based development. Create a short-lived branch, open a pull request
+against `main`, and merge only after review and required checks pass. There is no
+long-lived `develop` branch; `main` remains the source for rolling beta builds and signed
+releases.
+
+Every pull request requires a passing DCO sign-off check, the hosted CPU test suite, and
+one approving review. New commits dismiss stale approvals. GPU, checkpoint, and release
+tests run only in trusted environments when the change requires them; pull requests from
+forks never execute on the self-hosted GB10 runner.
+
+Direct pushes to `main` are prohibited. Maintainers use the same pull-request workflow as
+other contributors.
+
 ## Development setup
 
 On the supported NVIDIA GB10 environment:
@@ -44,6 +59,8 @@ GPU, checkpoint, and slow tests have explicit markers and environment requiremen
   versioned evidence for the exact checkpoint and recipe.
 - Disclose generated code or content when it materially affects review, and verify that you
   have the right to contribute every submitted file.
+- Prefer a squash merge for a focused change. Preserve the DCO sign-off in the resulting
+  commit; use a rebase merge when a meaningful, fully signed commit series should remain.
 
 ## Developer Certificate of Origin
 

--- a/tests/models/test_muse_glimmer.py
+++ b/tests/models/test_muse_glimmer.py
@@ -282,6 +282,10 @@ def test_iter_weights_bf16_matches_model_state_dict(tmp_path, monkeypatch):
     from sparklab.models.muse_glimmer.weight import iter_weights
 
     hf = _hf_config(num_layers=4)
+    text = hf.text_config
+    text.hidden_size, text.intermediate_size = 64, 96
+    text.num_attention_heads, text.num_key_value_heads, text.head_dim = 1, 1, 64
+    text.vocab_size = 128
     tensors = _bf16_checkpoint_tensors(hf)
     _write_shards(tmp_path, {"model-00001-of-00001.safetensors": tensors})
     import sparklab.models.muse_glimmer.weight as w

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -717,7 +717,7 @@ def test_adjust_config_converts_moe_cache_rate_to_cache_size():
         model_path="/tmp/sparklab-test-model",
         tp_info=DistributedInfo(rank=0, size=1),
         dtype=torch.float16,
-        attention_backend="fi",
+        attention_backend="triton",
         moe_cache_rate=0.3,
     )
     object.__setattr__(

--- a/tests/runtime/engine/test_cache_budget.py
+++ b/tests/runtime/engine/test_cache_budget.py
@@ -215,7 +215,7 @@ def test_adjust_config_resolves_num_tokens_generic():
         cuda_graph_bs = [1, 2]
         max_seq_len = 1024
         page_size = 1
-        attention_backend = "fi"
+        attention_backend = "triton"
         nvfp4_backend = "auto"
         num_page_override = None
         num_token_override = 5000
@@ -404,7 +404,7 @@ def _offload_engine_config(**overrides):
         model_path="/tmp/sparklab-test-model",
         tp_info=DistributedInfo(rank=0, size=1),
         dtype=torch.bfloat16,
-        attention_backend="fi",
+        attention_backend="triton",
         **overrides,
     )
     object.__setattr__(


### PR DESCRIPTION
## Outcome

Adopts a trunk-based pull-request cycle for SparkLab without a long-lived develop branch. Adds a hosted CPU test gate that never sends fork code to the self-hosted GB10 runner, and documents review/DCO requirements.

## Validation

- Hosted-equivalent CPU suite: 1,256 passed, 177 skipped, 13 deselected
- Native focused tests: 3 passed
- Workflow install script: bash syntax validated
- DCO-signed commit