### PR TITLE
release: build native ARM64 wheels

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -14,7 +14,7 @@
 #
 # The wheels carry the +g<sha> stamp from scripts/build-release-wheels.sh, so a
 # nightly is fully identified by the commit it was built from. Nights where HEAD is
-# already published are skipped before the EC2 node is ever started.
+# already published are skipped before the trusted build runner is touched.
 #
 # Formal (tagged) releases are out of scope here for now -- this workflow is the
 # nightly channel only.
@@ -65,7 +65,7 @@ jobs:
           # workflow only builds linux, so compare the linux runtime wheel only.
           published_stamp="$(gh api "repos/$WEB_REPO/releases/tags/$WEB_TAG" \
             --jq '.assets[].name' 2>/dev/null \
-            | grep -E '^sparklab-.*linux_x86_64\.whl$' \
+            | grep -E '^sparklab-.*linux_aarch64\.whl$' \
             | grep -oE '\+g[0-9a-f]{7,}' | head -1 || true)"
           echo "HEAD: $head_stamp  published: ${published_stamp:-<none>}"
           if [ "$FORCE" = "true" ] || [ "$head_stamp" != "$published_stamp" ]; then
@@ -78,7 +78,7 @@ jobs:
   build:
     needs: check
     if: needs.check.outputs.build == 'true'
-    runs-on: [self-hosted, linux, engine-build]
+    runs-on: [self-hosted, linux, ARM64, engine-build]
     timeout-minutes: 40
     steps:
       # The build container runs as root; an interrupted build can leave root-owned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 # this in SPARKLAB_BUILD_RELEASE mode and refuses otherwise.
 #
 # This lane is separate from nightly-wheels.yml on purpose:
-#   - nightly ships +g<sha>-stamped, linux_x86_64-tagged cp312 wheels to the
+#   - nightly ships +g<sha>-stamped, linux_aarch64-tagged cp312 wheels to the
 #     SixteenMiles Labs rolling `beta` release, which legacy Desktops resolve by
 #     asset name -- that channel's naming must not change.
 #   - release ships bare-versioned, manylinux-retagged cp310-cp313 wheels, which
@@ -57,7 +57,7 @@ jobs:
     if: >-
       github.repository == 'sixteen-miles-labs/sparklab' &&
       (github.event_name == 'push' || inputs.testpypi_rehearsal)
-    runs-on: [self-hosted, linux, engine-build]
+    runs-on: [self-hosted, linux, ARM64, engine-build]
     timeout-minutes: 60
     steps:
       # The build container runs as root; an interrupted build can leave root-owned
@@ -90,10 +90,10 @@ jobs:
       - name: Check the wheel set
         run: |
           ls -l dist/
-          rt="$(ls dist/sparklab-*manylinux*.whl 2>/dev/null | wc -l)"
-          kc="$(ls dist/sparklab_kernel_cache-*.whl 2>/dev/null | wc -l)"
-          [ "$rt" -eq 4 ] || { echo "expected 4 manylinux runtime wheels, got $rt" >&2; exit 1; }
-          [ "$kc" -eq 1 ] || { echo "expected 1 kernel-cache wheel, got $kc" >&2; exit 1; }
+          rt="$(ls dist/sparklab-*manylinux*aarch64.whl 2>/dev/null | wc -l)"
+          kc="$(ls dist/sparklab_kernel_cache-*linux_aarch64.whl 2>/dev/null | wc -l)"
+          [ "$rt" -eq 4 ] || { echo "expected 4 ARM64 manylinux runtime wheels, got $rt" >&2; exit 1; }
+          [ "$kc" -eq 1 ] || { echo "expected 1 ARM64 kernel-cache wheel, got $kc" >&2; exit 1; }
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: release-wheels
@@ -122,7 +122,7 @@ jobs:
       - name: Select the PyPI wheel set (runtime only, no local versions)
         run: |
           mkdir pypi-dist
-          cp dist/sparklab-*manylinux*.whl pypi-dist/
+          cp dist/sparklab-*manylinux*aarch64.whl pypi-dist/
           # The kernel-cache wheel stays on GitHub releases; a +local version
           # here would be rejected by (Test)PyPI anyway -- fail early and loudly.
           if ls pypi-dist/ | grep -qF '+'; then
@@ -156,7 +156,7 @@ jobs:
       - name: Select the PyPI wheel set (runtime only, no local versions)
         run: |
           mkdir pypi-dist
-          cp dist/sparklab-*manylinux*.whl pypi-dist/
+          cp dist/sparklab-*manylinux*aarch64.whl pypi-dist/
           if ls pypi-dist/ | grep -qF '+'; then
             echo "local-versioned wheel in the PyPI upload set:" >&2; ls pypi-dist/ >&2; exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,13 @@ product-layer changes, run:
 GPU, checkpoint, and slow tests have explicit markers and environment requirements; see
 [tests/README.md](tests/README.md).
 
+Contributors can run SparkLab from source and build native development wheels on their
+own machines; release credentials and the trusted runner are not required. On a supported
+DGX Spark, `scripts/build-release-wheels.sh` produces local `linux_aarch64` wheels, while
+`scripts/ci/manylinux-build.sh` uses the architecture-matched container when a
+PyPI-compatible development wheel is needed. Formal wheels are built only from protected
+`main` or a protected release tag. Fork pull requests never run either release workflow.
+
 ## Pull requests
 
 - Explain the user-visible outcome and important tradeoffs.

--- a/scripts/ci/manylinux-build.sh
+++ b/scripts/ci/manylinux-build.sh
@@ -11,16 +11,17 @@
 # SPARKLAB_IN_CONTAINER guard runs in the container as root.
 #
 # Environment (host side):
-#   SPARKLAB_BUILDER_IMAGE   builder image (default: pytorch/manylinux2_28-builder:cuda13.0)
+#   SPARKLAB_BUILDER_IMAGE   builder image override. By default, select PyTorch's
+#                      CUDA 13 manylinux_2_28 image for the host architecture.
 #   SPARKLAB_CI_CACHE_DIR    persistent cache dir on the host, holds the uv binary and
 #                      uv's package cache across builds (default: ~/.cache/sparklab-ci)
 #   SPARKLAB_OUT_DIR         host dir that receives the wheels (default: <repo>/dist)
 #   SPARKLAB_PYTHON_MATRIX   space-separated cp tags to build the runtime wheel for
 #                      (default: cp312 -- the nightly/Desktop channel is cp312-only;
 #                      the release lane passes "cp310 cp311 cp312 cp313")
-#   SPARKLAB_MANYLINUX_RETAG retag runtime wheels linux_x86_64 -> detected manylinux (default: 0).
-#                      Release/PyPI lane only: shipped Desktops resolve the nightly
-#                      release's assets by name and expect linux_x86_64.
+#   SPARKLAB_MANYLINUX_RETAG retag native linux wheels -> detected manylinux (default: 0).
+#                      Release/PyPI lane only: rolling beta assets keep native
+#                      linux tags for compatibility with the installer.
 #   SPARKLAB_BUILD_NO_STAMP / _RELEASE / _DEV_STAMP / _STRIP and
 #   SPARKLAB_KERNEL_CACHE_* are forwarded into the container. Other
 #   SPARKLAB_BUILD_* vars are NOT: _CLEAN is set by this script per matrix
@@ -29,10 +30,25 @@
 set -euo pipefail
 
 say() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+default_builder_image() {
+  case "$(uname -m)" in
+    aarch64 | arm64)
+      # Pin the ARM64 CUDA 13 image used for the 0.1 release lane. A floating
+      # cuda13.0 tag can change the compiler and wheel bytes between rebuilds.
+      echo "pytorch/manylinuxaarch64-builder:cuda13.0@sha256:4b78d6020590313ec106ffe4a64a21f8cdee943991c46fcd31a99486777e1d0f"
+      ;;
+    x86_64 | amd64)
+      echo "pytorch/manylinux2_28-builder:cuda13.0@sha256:c82aaf3a4cd5db38eed631b2901a9253a5808f1f9a00fee5839c9c9aaf959870"
+      ;;
+    *) die "no default manylinux CUDA builder for host architecture $(uname -m)" ;;
+  esac
+}
 
 if [[ -z "${SPARKLAB_IN_CONTAINER:-}" ]]; then
   ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
-  IMAGE="${SPARKLAB_BUILDER_IMAGE:-pytorch/manylinux2_28-builder:cuda13.0}"
+  IMAGE="${SPARKLAB_BUILDER_IMAGE:-$(default_builder_image)}"
   CACHE_DIR="${SPARKLAB_CI_CACHE_DIR:-$HOME/.cache/sparklab-ci}"
   OUT_DIR="${SPARKLAB_OUT_DIR:-$ROOT/dist}"
   mkdir -p "$CACHE_DIR" "$OUT_DIR"
@@ -119,11 +135,11 @@ case " 1 true yes on " in *" $(printf '%s' "$RETAG" | tr '[:upper:]' '[:lower:]'
   say "retagging runtime wheels to their detected manylinux policy"
   uv pip install --quiet --python "$VENV/bin/python" "auditwheel==6.6.0"
   found=0
-  for whl in /ci-out/sparklab-*linux_x86_64.whl; do
+  for whl in /ci-out/sparklab-*linux_*.whl; do
     [[ -e "$whl" ]] || continue
     "$VENV/bin/python" scripts/ci/retag-manylinux.py "$whl"
     found=1
   done
-  [[ "$found" == 1 ]] || { echo "SPARKLAB_MANYLINUX_RETAG set but no linux_x86_64 runtime wheels in /ci-out" >&2; exit 1; }
+  [[ "$found" == 1 ]] || { echo "SPARKLAB_MANYLINUX_RETAG set but no native linux runtime wheels in /ci-out" >&2; exit 1; }
   ;;
 esac

--- a/scripts/ci/retag-manylinux.py
+++ b/scripts/ci/retag-manylinux.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Retag `linux_x86_64` runtime wheels to their detected manylinux policy.
+"""Retag native Linux runtime wheels to their detected manylinux policy.
 
 setuptools tags C-extension wheels `linux_<arch>`, which PyPI rejects at upload.
 The CI build already runs inside the pytorch manylinux_2_28 container, so the
@@ -57,7 +57,7 @@ def detect_platform_tag(wheel: Path) -> str:
     )
     # Deliberately not winfo.overall_policy: that folds in the external-library
     # check, and libtorch/libcudart are not on any manylinux whitelist, so it
-    # always collapses to linux_x86_64. sym_policy (glibc symbols) and
+    # always collapses to a plain linux platform tag. sym_policy (glibc symbols) and
     # machine_policy (required ISA extensions) are the two components that do
     # apply to us. min() by priority picks the stricter one -- the same
     # combinator auditwheel itself uses -- so a future global -march= that

--- a/scripts/publish-wheels.sh
+++ b/scripts/publish-wheels.sh
@@ -35,6 +35,7 @@ wheels=("$DIST"/sparklab-*.whl "$DIST"/sparklab_kernel_cache-*.whl)
 # publish leaves the win_amd64 assets alone.
 platforms="$(for w in "${wheels[@]}"; do
   case "${w##*/}" in
+    *linux_aarch64*) echo linux_aarch64 ;;
     *linux_x86_64*) echo linux_x86_64 ;;
     *win_amd64*) echo win_amd64 ;;
     *) echo UNKNOWN ;;

--- a/sparklab-kernel-cache/README.md
+++ b/sparklab-kernel-cache/README.md
@@ -16,8 +16,8 @@ scripts/build-release-wheels.sh
 By default, artifacts are written to `dist/`:
 
 ```text
-dist/sparklab-<version>-cp312-cp312-linux_x86_64.whl
-dist/sparklab_kernel_cache-<version>+cu130-py3-none-linux_x86_64.whl
+dist/sparklab-<version>-cp312-cp312-linux_aarch64.whl
+dist/sparklab_kernel_cache-<version>+cu130-py3-none-linux_aarch64.whl
 ```
 
 Useful knobs:
@@ -55,8 +55,8 @@ At runtime, `sparklab.kernels.utils.load_jit()` and `load_aot()` look for
 `install.sh` installs both wheels. Pass both explicitly:
 
 ```bash
-SPARKLAB_WHEEL=dist/sparklab-0.1.1-cp312-cp312-linux_x86_64.whl \
-SPARKLAB_KERNEL_CACHE_WHEEL=dist/sparklab_kernel_cache-0.1.1+cu130-py3-none-linux_x86_64.whl \
+SPARKLAB_WHEEL=dist/sparklab-0.1.1-cp312-cp312-linux_aarch64.whl \
+SPARKLAB_KERNEL_CACHE_WHEEL=dist/sparklab_kernel_cache-0.1.1+cu130-py3-none-linux_aarch64.whl \
 bash install.sh
 ```
 

--- a/tests/sparklab/test_project_identity.py
+++ b/tests/sparklab/test_project_identity.py
@@ -33,6 +33,20 @@ def test_release_workflows_are_guarded_for_the_current_repository():
     assert 'gh release create "$TAG"' in publisher
 
 
+def test_release_wheels_target_dgx_spark_arm64():
+    release = _read(".github/workflows/release.yml")
+    nightly = _read(".github/workflows/nightly-wheels.yml")
+    builder = _read("scripts/ci/manylinux-build.sh")
+    publisher = _read("scripts/publish-wheels.sh")
+
+    for workflow in (release, nightly):
+        assert "runs-on: [self-hosted, linux, ARM64, engine-build]" in workflow
+    assert "manylinux*aarch64.whl" in release
+    assert "linux_aarch64" in nightly
+    assert "pytorch/manylinuxaarch64-builder:cuda13.0@sha256:" in builder
+    assert "*linux_aarch64*) echo linux_aarch64" in publisher
+
+
 def test_sparklab_is_the_primary_installer_and_service_identity():
     installer = _read("install.sh")
     service = _read("python/sparklab/daemon/sparklab.service")


### PR DESCRIPTION
## Outcome

- makes formal packages match SparkLab's documented DGX Spark ARM64 target
- selects a digest-pinned PyTorch CUDA 13 manylinux builder for each contributor host architecture
- requires the trusted release runner to carry the ARM64 label
- publishes `manylinux_*_aarch64` runtime wheels and ARM64 kernel-cache assets
- documents contributor-local source and wheel builds

## Validation

- [x] DCO-signed commit
- [x] workflow YAML parsed
- [x] shell syntax checked
- [x] container digests resolved
- [x] `git diff --check`
- [x] focused package tests: 17 passed
