### PR TITLE
chore: prepare repository for public release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Toronto
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: America/Toronto
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,6 +24,20 @@ jobs:
       SPARKLAB_DISABLE_JIT: "1"
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Check public-tree hygiene
+        shell: bash
+        run: |
+          if git grep -I -n -E '/home/[A-Za-z0-9._-]+/' -- .; then
+            echo "::error::replace machine-specific home paths with \$HOME or a documented placeholder"
+            exit 1
+          fi
+
+          tracked_weights="$(git ls-files | grep -E '\.(bin|gguf|pt|pth|safetensors)$' || true)"
+          if [[ -n "$tracked_weights" ]]; then
+            printf '%s\n' "$tracked_weights"
+            echo "::error::model weights and generated binary artifacts must not be committed"
+            exit 1
+          fi
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.12.6"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,6 +35,41 @@ FreeToken research project; that ancestry is preserved in `NOTICE` and project c
 Never build or upload a formal release from a maintainer workstation. Trusted-publisher
 bindings must be scoped to this repository, workflow, and GitHub environment.
 
+## Public visibility cutover
+
+Changing repository visibility is a release operation, not an ordinary settings edit. Before
+the cutover:
+
+1. Stop the self-hosted GB10 runner and confirm that it has no active or queued job.
+2. Scan the current tree and reachable history for credentials, machine-specific paths,
+   generated artifacts, model weights, and author metadata that should remain private.
+3. Review all existing issues, pull requests, Actions logs, and workflow artifacts. Decide
+   explicitly whether to retain or delete private-era workflow history before it becomes
+   public.
+4. Record the current default-branch protection, release-tag ruleset, Actions permissions,
+   environments, and trusted-publisher bindings.
+
+After making the repository public:
+
+1. Re-enable and verify the `v*` release-tag ruleset immediately; GitHub can disable push
+   rulesets during a private-to-public visibility change. Verify the `main` protection and
+   its required `signoff` and `CPU tests` checks as well.
+2. Enable secret scanning, push protection, Dependabot alerts and security updates, CodeQL,
+   and private vulnerability reporting.
+3. Keep the default workflow token read-only, disallow workflows from approving pull
+   requests, allow only the actions used by this repository, and require full commit-SHA
+   action pins.
+4. Confirm that fork pull requests run only on GitHub-hosted runners. Keep the persistent
+   GB10 runner offline by default; start it only after verifying a trusted protected-tag or
+   maintainer-dispatched build, and stop it after the job completes.
+5. Re-check the GitHub community profile, package links, trusted publishing, and artifact
+   attestations from the public repository.
+
+GitHub documents the visibility-change effects in
+[Setting repository visibility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility)
+and the runner threat model in
+[Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use).
+
 ## One-time external setup
 
 Repository owners must configure these outside the source tree:

--- a/benchmarks/gb10/results/GB10-BASELINE-001.json
+++ b/benchmarks/gb10/results/GB10-BASELINE-001.json
@@ -66,7 +66,7 @@
   },
   "source": {
     "summary": "exps/exp_dsv4_gb10.md",
-    "raw_artifact": "/home/lidaiqing/results/dsv4-gb10/stage-a-final-overlap-host4-cache5900-decode64.jsonl",
+    "raw_artifact": "$HOME/results/dsv4-gb10/stage-a-final-overlap-host4-cache5900-decode64.jsonl",
     "raw_artifact_committed": false
   }
 }

--- a/benchmarks/gb10/results/GB10-DSV4-SPARSE-001.json
+++ b/benchmarks/gb10/results/GB10-DSV4-SPARSE-001.json
@@ -119,7 +119,7 @@
   },
   "source": {
     "summary": "exps/exp_dsv4_gb10.md",
-    "raw_artifact": "/home/lidaiqing/results/dsv4-gb10/optimized-sparse-prefill512-auto-confirm-decode64.jsonl"
+    "raw_artifact": "$HOME/results/dsv4-gb10/optimized-sparse-prefill512-auto-confirm-decode64.jsonl"
   },
   "limitations": [
     "This result establishes complete-checkpoint short-prompt performance only; it is not a Frontier certification.",

--- a/benchmarks/gb10/results/GB10-GLM53-KDA-FP8-002.json
+++ b/benchmarks/gb10/results/GB10-GLM53-KDA-FP8-002.json
@@ -132,8 +132,8 @@
   },
   "source": {
     "summary": "KDA W8A16 optimization and controlled BF16-resident comparison",
-    "raw_artifact": "/home/lidaiqing/results/glm5.3-gb10/glm53_nvfp4_kda_fp8_final_mem096_decode256.jsonl",
-    "control_artifact": "/home/lidaiqing/results/glm5.3-gb10/glm53_nvfp4_bf16_control_decode256.jsonl"
+    "raw_artifact": "$HOME/results/glm5.3-gb10/glm53_nvfp4_kda_fp8_final_mem096_decode256.jsonl",
+    "control_artifact": "$HOME/results/glm5.3-gb10/glm53_nvfp4_bf16_control_decode256.jsonl"
   },
   "limitations": [
     "This result establishes complete-checkpoint loading and a controlled performance improvement, not Frontier certification.",

--- a/benchmarks/gb10/results/GB10-GLM53-NVFP4-001.json
+++ b/benchmarks/gb10/results/GB10-GLM53-NVFP4-001.json
@@ -120,7 +120,7 @@
   },
   "source": {
     "summary": "exps/exp_glm5_3_nvfp4_gb10.md",
-    "raw_artifact": "/home/lidaiqing/results/glm5.3-gb10/glm53_nvfp4_optimized_decode256.jsonl"
+    "raw_artifact": "$HOME/results/glm5.3-gb10/glm53_nvfp4_optimized_decode256.jsonl"
   },
   "limitations": [
     "This result establishes complete-checkpoint loading and serving, not Frontier certification.",

--- a/benchmarks/gb10/results/GB10-QWEN36-FAST-001.json
+++ b/benchmarks/gb10/results/GB10-QWEN36-FAST-001.json
@@ -95,7 +95,7 @@
   },
   "source": {
     "summary": "exps/exp_qwen3_6_gb10.md",
-    "raw_artifact": "/home/lidaiqing/results/qwen3.6-gb10/qwen36-nvfp4-cache-full-decode64-isolated.jsonl"
+    "raw_artifact": "$HOME/results/qwen3.6-gb10/qwen36-nvfp4-cache-full-decode64-isolated.jsonl"
   },
   "limitations": [
     "This result establishes Fast-class latency only; it is not a complete Fast certification.",

--- a/benchmarks/gb10/results/GB10-QWEN38-FP8-001.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-FP8-001.json
@@ -109,7 +109,7 @@
   },
   "source": {
     "summary": "exps/exp_qwen3_8_fp8_gb10.md",
-    "raw_artifact": "/home/lidaiqing/results/qwen3.8-gb10/official-fp8-decode64-092d8e2.jsonl"
+    "raw_artifact": "$HOME/results/qwen3.8-gb10/official-fp8-decode64-092d8e2.jsonl"
   },
   "limitations": [
     "This result establishes complete-checkpoint performance only; it is not a Frontier certification.",

--- a/benchmarks/gb10/results/GB10-QWEN38-FRONTIER-001.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-FRONTIER-001.json
@@ -72,26 +72,26 @@
   "sources": [
     {
       "kind": "performance",
-      "path": "/home/lidaiqing/results/qwen3.8-gb10/frontier-speed-72e4ef7.jsonl",
+      "path": "$HOME/results/qwen3.8-gb10/frontier-speed-72e4ef7.jsonl",
       "git_revision": "72e4ef7c3f1765aa9f9295b95428e7b7b9801400",
       "git_tracked_dirty": false
     },
     {
       "kind": "capabilities",
-      "path": "/home/lidaiqing/results/qwen3.8-gb10/capabilities-1a6bbac.json",
+      "path": "$HOME/results/qwen3.8-gb10/capabilities-1a6bbac.json",
       "git_revision": "1a6bbaca178ddf6091e79edc4b7d41c5a42073b6",
       "git_tracked_dirty": false
     },
     {
       "kind": "context_recall",
-      "path": "/home/lidaiqing/results/qwen3.8-gb10/context-65536-d40270d.json",
+      "path": "$HOME/results/qwen3.8-gb10/context-65536-d40270d.json",
       "git_revision": "d40270da70547ccd70f0e20f6051691985e5cb68",
       "git_tracked_dirty": false,
       "physical_disk_bytes": 550827560960
     },
     {
       "kind": "correctness_and_endurance",
-      "path": "/home/lidaiqing/results/qwen3.8-gb10/aime-endurance-5-096af67.jsonl",
+      "path": "$HOME/results/qwen3.8-gb10/aime-endurance-5-096af67.jsonl",
       "git_revision": "096af67d3cfb8bfaf239563a130c2e88db17084f",
       "git_tracked_dirty": false,
       "physical_disk_bytes": 65520963584

--- a/benchmarks/gb10/results/GB10-QWEN38-NVFP4-001.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-NVFP4-001.json
@@ -119,7 +119,7 @@
   },
   "source": {
     "summary": "exps/exp_qwen3_8_nvfp4_gb10.md",
-    "raw_artifact": "/home/lidaiqing/results/qwen3.8-gb10/inferact-nvfp4-decode64-d979d99.jsonl"
+    "raw_artifact": "$HOME/results/qwen3.8-gb10/inferact-nvfp4-decode64-d979d99.jsonl"
   },
   "limitations": [
     "This result establishes complete-checkpoint performance only; it is not a Frontier certification.",

--- a/exps/exp_dsv4.md
+++ b/exps/exp_dsv4.md
@@ -448,7 +448,7 @@ SPARKLAB_DISK_READ_WORKERS=16 \
 SPARKLAB_DISK_CACHE_POLICY=layer_lru \
 .venv/bin/python benchmarks/bench_aime_suite.py \
   --model /mnt/ssd/freetoken/ftw/DeepSeek-V4-Flash-0731 \
-  --aime /home/lidaiqing/.cache/huggingface/hub/datasets--math-ai--aime25/snapshots/563bb8404243c5f09de6ec262f2db674fe5bce9b/test.jsonl \
+  --aime $HOME/.cache/huggingface/hub/datasets--math-ai--aime25/snapshots/563bb8404243c5f09de6ec262f2db674fe5bce9b/test.jsonl \
   --problems all --decode 1024 \
   --backend hybrid --storage disk --host-cache-gb 40 \
   --hybrid-fetch 3 --cpu-threads 8 --mem-ratio 0.90 \

--- a/exps/exp_dsv4_gb10.md
+++ b/exps/exp_dsv4_gb10.md
@@ -35,8 +35,8 @@ path rather than forcing route-first GEMV at an inefficient density.
 | FlashInfer / SGLang kernel | 0.6.15.post1 / 0.4.5 |
 | FreeToken revision | `ddc3b34` plus the benchmark-metadata change in this experiment |
 | Model | `deepseek-ai/DeepSeek-V4-Flash-0731` |
-| Source checkpoint | `/home/lidaiqing/models/DeepSeek-V4-Flash-0731` |
-| FTW checkpoint | `/home/lidaiqing/ftw/DeepSeek-V4-Flash-0731` |
+| Source checkpoint | `$HOME/models/DeepSeek-V4-Flash-0731` |
+| FTW checkpoint | `$HOME/ftw/DeepSeek-V4-Flash-0731` |
 
 The environment was created with `uv` and the checkout installed editable with
 the development dependencies. CUDA allocation and a real GB10 tensor operation
@@ -60,7 +60,7 @@ FlashInfer dependency.
 | Recommended backend | `offload` |
 
 The profile is saved at
-`/home/lidaiqing/results/dsv4-gb10/benchbw-dsfp4.json`. The large gap between
+`$HOME/results/dsv4-gb10/benchbw-dsfp4.json`. The large gap between
 CPU MoE and GPU expert gather is why Stage A uses `offload`, not `hybrid`.
 
 ## Checkpoint preparation
@@ -76,8 +76,8 @@ CUDA_HOME=/usr/local/cuda \
 PATH=/usr/local/cuda/bin:$PATH \
 SPARKLAB_CONVERT_PROGRESS=1 \
 .venv/bin/sparklab checkpoint \
-  --model /home/lidaiqing/models/DeepSeek-V4-Flash-0731 \
-  --out /home/lidaiqing/ftw/DeepSeek-V4-Flash-0731 \
+  --model $HOME/models/DeepSeek-V4-Flash-0731 \
+  --out $HOME/ftw/DeepSeek-V4-Flash-0731 \
   --dtype bfloat16 \
   --moe-backend offload \
   --shard-gib 8 \
@@ -97,7 +97,7 @@ SPARKLAB_CONVERT_PROGRESS=1 \
 All 23 on-disk shard sizes and their sum match the FTW index. All 1,693 tensor
 ranges are in bounds, the reader sees the indexed 1,521 weights and 172 expert
 banks, and the fingerprint matches. The conversion log is
-`/home/lidaiqing/results/dsv4-gb10/conversion.log`.
+`$HOME/results/dsv4-gb10/conversion.log`.
 
 ## Stage A tuning
 
@@ -162,9 +162,9 @@ reports as free even when Linux still reports ample `MemAvailable`; targeted
 CUDA_HOME=/usr/local/cuda \
 PATH=/usr/local/cuda/bin:$PATH \
 SPARKLAB_DISK_READ_WORKERS=20 \
-SPARKLAB_AIME25_JSONL=/home/lidaiqing/datasets/aime25/test.jsonl \
+SPARKLAB_AIME25_JSONL=$HOME/datasets/aime25/test.jsonl \
 .venv/bin/python benchmarks/bench_decode_moe.py \
-  --model /home/lidaiqing/ftw/DeepSeek-V4-Flash-0731 \
+  --model $HOME/ftw/DeepSeek-V4-Flash-0731 \
   --backend offload \
   --storage disk \
   --host-cache-gb 4 \
@@ -176,7 +176,7 @@ SPARKLAB_AIME25_JSONL=/home/lidaiqing/datasets/aime25/test.jsonl \
   --greedy \
   --no-graph \
   --include-output \
-  --json /home/lidaiqing/results/dsv4-gb10/optimized-sparse-prefill512-auto-confirm-decode64.jsonl
+  --json $HOME/results/dsv4-gb10/optimized-sparse-prefill512-auto-confirm-decode64.jsonl
 ```
 
 The selected JSON records 20 resolved reader workers, two staging buffers, 5,321
@@ -184,7 +184,7 @@ auto-sized expert slots, 16 DSV4 KV pages of 128 tokens, 43 MoE layers, 256 expe
 per layer, and 13,369,344 bytes per cached expert. Its p50/p99 event latencies were
 97.161/101.396 ms and server-reported device allocation was 76.19 GiB.
 
-Result artifacts are under `/home/lidaiqing/results/dsv4-gb10/`. The best measured
+Result artifacts are under `$HOME/results/dsv4-gb10/`. The best measured
 fixed-cache row is `optimized-sparse-prefill512-cache5900-confirm-decode64.jsonl`;
 the selected auto-sized row is
 `optimized-sparse-prefill512-auto-confirm-decode64.jsonl`.

--- a/exps/exp_glm5_2_gb10.md
+++ b/exps/exp_glm5_2_gb10.md
@@ -57,8 +57,8 @@ It is not a substitute for the separate 4K-input/512-output
 | FlashInfer / SGLang kernel | 0.6.15.post1 / 0.4.5 |
 | Model | `nvidia/GLM-5.2-NVFP4` |
 | Pinned model revision | `aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa` |
-| Source checkpoint | `/home/lidaiqing/models/GLM-5.2-NVFP4` |
-| FTW checkpoint | `/home/lidaiqing/ftw/GLM-5.2-NVFP4-b12x` |
+| Source checkpoint | `$HOME/models/GLM-5.2-NVFP4` |
+| FTW checkpoint | `$HOME/ftw/GLM-5.2-NVFP4-b12x` |
 
 The pinned repository advertises 57 files totaling 464,874,323,992 bytes. Its
 weight index contains 47 safetensors shards, 232,385 tensor keys, and
@@ -96,7 +96,7 @@ smaller GLM-4.7 proxy.
 | Recommended backend | `offload` |
 
 The profile is saved at
-`/home/lidaiqing/results/glm5.2-gb10/benchbw-nvfp4.json`.
+`$HOME/results/glm5.2-gb10/benchbw-nvfp4.json`.
 
 The SM12x cache-copy microbenchmark measured a 20.25 MiB b12x expert row. At
 batch size 1, two misses copied at 100.4--100.8 GB/s and eight misses copied at
@@ -114,8 +114,8 @@ CUDA_HOME=/usr/local/cuda \
 PATH=/usr/local/cuda/bin:$PATH \
 SPARKLAB_CONVERT_PROGRESS=1 \
 .venv/bin/sparklab checkpoint \
-  --model /home/lidaiqing/models/GLM-5.2-NVFP4 \
-  --out /home/lidaiqing/ftw/GLM-5.2-NVFP4-b12x \
+  --model $HOME/models/GLM-5.2-NVFP4 \
+  --out $HOME/ftw/GLM-5.2-NVFP4-b12x \
   --dtype bfloat16 \
   --moe-backend offload \
   --nvfp4-backend flashinfer \
@@ -149,11 +149,11 @@ zero-swap result.
 
 Validation artifacts:
 
-- `/home/lidaiqing/results/glm5.2-gb10/source-validation.json`
-- `/home/lidaiqing/results/glm5.2-gb10/native-validation.json`
-- `/home/lidaiqing/results/glm5.2-gb10/b12x-validation.json`
-- `/home/lidaiqing/results/glm5.2-gb10/conversion-native.log`
-- `/home/lidaiqing/results/glm5.2-gb10/conversion-b12x.log`
+- `$HOME/results/glm5.2-gb10/source-validation.json`
+- `$HOME/results/glm5.2-gb10/native-validation.json`
+- `$HOME/results/glm5.2-gb10/b12x-validation.json`
+- `$HOME/results/glm5.2-gb10/conversion-native.log`
+- `$HOME/results/glm5.2-gb10/conversion-b12x.log`
 
 ## Serving benchmark
 
@@ -219,14 +219,14 @@ CUDA_HOME=/usr/local/cuda \
 LD_LIBRARY_PATH=/usr/local/cuda/lib64 \
 SPARKLAB_DISK_READ_WORKERS=20 \
 .venv/bin/python benchmarks/bench_decode_moe.py \
-  --model /home/lidaiqing/ftw/GLM-5.2-NVFP4-b12x \
+  --model $HOME/ftw/GLM-5.2-NVFP4-b12x \
   --backend offload --storage disk --nvfp4-backend flashinfer \
   --host-cache-gb 0 --cache 675 --cache-policy layer_lru \
   --decode 256 --num-tokens 2048 --mem-ratio 0.90 \
   --disable-prefill-overlap --prefill-sparse-max-tokens 256 \
   --shared-expert-overlap --collect-moe-stats \
   --greedy --no-graph --include-output --server-timeout 1200 \
-  --json /home/lidaiqing/results/glm5.2-gb10/selected-b12x-cache675-decode256.jsonl
+  --json $HOME/results/glm5.2-gb10/selected-b12x-cache675-decode256.jsonl
 ```
 
 ### Cold and distinct-prompt evidence
@@ -265,10 +265,10 @@ The compact catalog evidence is checked in as
 It records the measured performance and failed admission separately.
 
 Primary serving results are in
-`/home/lidaiqing/results/glm5.2-gb10/selected-b12x-cache675-decode64.jsonl`,
-`/home/lidaiqing/results/glm5.2-gb10/selected-b12x-cache675-decode256.jsonl`,
+`$HOME/results/glm5.2-gb10/selected-b12x-cache675-decode64.jsonl`,
+`$HOME/results/glm5.2-gb10/selected-b12x-cache675-decode256.jsonl`,
 and
-`/home/lidaiqing/results/glm5.2-gb10/heldout-aime0-2-b12x-cache675-decode64.jsonl`.
+`$HOME/results/glm5.2-gb10/heldout-aime0-2-b12x-cache675-decode64.jsonl`.
 G1--G6 used clean revision `83b0758547ee396d6e7ccdbd9706d644a5ad0612`;
 G7 and the primary selected/stability runs used clean pushed revision
 `b5db743d4d5103c452835fc25af9e178a8c1c523`. The cache-600 stability retry ran

--- a/exps/exp_kimik3_gb10.md
+++ b/exps/exp_kimik3_gb10.md
@@ -70,8 +70,8 @@ physical bytes are present, with no partial files. The strict metadata/header au
 passed with complete 2,946/2,946 model-state mapping, 992,508 indexed tensors,
 741,888 indexed expert entries, no cross-shard resident scales, and no errors.
 The final acquisition records are
-`/home/lidaiqing/results/kimi-k3-gb10/acquisition-final.json` and
-`/home/lidaiqing/results/kimi-k3-gb10/source-audit-final.json`.
+`$HOME/results/kimi-k3-gb10/acquisition-final.json` and
+`$HOME/results/kimi-k3-gb10/source-audit-final.json`.
 
 Acquisition recorded zero new OOM kills and one isolated swap-out page (4 KiB)
 over the full 8.49-hour window; the counter did not continue increasing. This is
@@ -141,11 +141,11 @@ Pre-conversion index audits passed:
 
 The reproducible metadata-only auditor is
 `benchmarks/audit_kimi_k3_checkpoint.py`. During acquisition it writes
-`/home/lidaiqing/results/kimi-k3-gb10/source-audit-partial.json` with
+`$HOME/results/kimi-k3-gb10/source-audit-partial.json` with
 `--allow-partial`; the final evidence audit reruns it without that flag after all
 96 indexed shards are present. The real-layer payload probe is
 `benchmarks/probe_kimi_k3_expert_layer.py`; its payload and supervisor records are
-`/home/lidaiqing/results/kimi-k3-gb10/expert-layer1.json` and
+`$HOME/results/kimi-k3-gb10/expert-layer1.json` and
 `expert-layer1-supervision.json`.
 The conversion-seam round trip is `benchmarks/probe_kimi_k3_ftw_layer.py`; its
 payload and supervisor records are `ftw-layer1.json` and
@@ -191,7 +191,7 @@ projection, not proof of the eventual prepared size; the live disk guard remains
 authoritative. Runtime admission remains correctly closed because no full Kimi
 runtime-memory budget has been measured and the machine has pre-existing swap
 occupancy. The record is
-`/home/lidaiqing/results/kimi-k3-gb10/plan-partial.json`; artifact capacity is not
+`$HOME/results/kimi-k3-gb10/plan-partial.json`; artifact capacity is not
 being misreported as runtime certification.
 
 Conversion is guarded by:
@@ -208,7 +208,7 @@ Conversion is guarded by:
 conversion and serving. In addition to successful exit and intact memory/disk
 telemetry, it requires zero `oom_kill`, zero `pswpout`, and zero swap-occupancy
 growth; missing counters fail the gate. Its record is
-`/home/lidaiqing/results/kimi-k3-gb10/conversion-gate.json`. The supervisor/gate
+`$HOME/results/kimi-k3-gb10/conversion-gate.json`. The supervisor/gate
 schema was exercised end to end with a short child process before queuing the full
 conversion.
 
@@ -230,12 +230,12 @@ The conversion command is:
 CUDA_HOME=/usr/local/cuda PATH=/usr/local/cuda/bin:$PATH \
 SPARKLAB_CONVERT_PROGRESS=1 PYTHONPATH=python \
 .venv/bin/python benchmarks/supervise_process.py \
-  --output /home/lidaiqing/results/kimi-k3-gb10/conversion.json \
-  --log /home/lidaiqing/results/kimi-k3-gb10/conversion.log \
-  --disk-path /home/lidaiqing --min-memory-gib 12 --min-disk-gib 140 \
+  --output $HOME/results/kimi-k3-gb10/conversion.json \
+  --log $HOME/results/kimi-k3-gb10/conversion.log \
+  --disk-path $HOME --min-memory-gib 12 --min-disk-gib 140 \
   -- .venv/bin/sparklab checkpoint \
-  --model /home/lidaiqing/.sparklab/models/kimi-k3/source/f8c5234a0a88 \
-  --out /home/lidaiqing/.sparklab/models/kimi-k3/prepared/0.2.0 \
+  --model $HOME/.sparklab/models/kimi-k3/source/f8c5234a0a88 \
+  --out $HOME/.sparklab/models/kimi-k3/prepared/0.2.0 \
   --dtype bfloat16 --moe-backend offload --nvfp4-backend triton \
   --shard-gib 8 --device cuda:0
 ```
@@ -247,13 +247,13 @@ The first complete-checkpoint probe uses the minimum expert cache and a fail-clo
 
 ```bash
 PYTHONPATH=python .venv/bin/python benchmarks/bench_decode_moe.py \
-  --model /home/lidaiqing/.sparklab/models/kimi-k3/prepared/0.2.0 \
+  --model $HOME/.sparklab/models/kimi-k3/prepared/0.2.0 \
   --recipe kimi-k3 --backend offload --storage disk --nvfp4-backend triton \
   --host-cache-gb 0 --cache 896 --cache-policy lru --mem-ratio 0.85 \
   --num-tokens 2048 --disable-prefill-overlap \
   --prefill-sparse-max-tokens 256 --decode 1 --no-graph \
   --collect-moe-stats --greedy --include-output --min-memory-gib 12 \
-  --json /home/lidaiqing/results/kimi-k3-gb10/probe-1.jsonl
+  --json $HOME/results/kimi-k3-gb10/probe-1.jsonl
 ```
 
 Promotion is strictly one token, then 16, 64, and finally 256 tokens. A stage is
@@ -267,7 +267,7 @@ benchmark results.
 JSONL row before the next server launch. It also requires an identified FTW
 checkpoint, complete token/event accounting, a nonempty output hash and payload,
 and both lifecycle-wide and measured-request safety telemetry. Gate records are
-saved as `/home/lidaiqing/results/kimi-k3-gb10/gate-{1,16,64,256}.json`; a missing
+saved as `$HOME/results/kimi-k3-gb10/gate-{1,16,64,256}.json`; a missing
 counter is a failure rather than an assumed zero.
 
 `benchmarks/finalize_kimi_k3_result.py` performs the publication handoff. It
@@ -945,10 +945,10 @@ the refactor pause, no usable FTW conversion, runtime probe, or benchmark result
 was produced. A pre-queued conversion watcher raced the final source audit and ran
 for 16.5 seconds before it was caught and stopped. Its two incomplete FTW shards
 (16,621,034,424 bytes) were moved out of the active prepared path to
-`/home/lidaiqing/.sparklab/models/kimi-k3/prepared-interrupted-20260829T020606Z`;
+`$HOME/.sparklab/models/kimi-k3/prepared-interrupted-20260829T020606Z`;
 the canonical prepared path and `conversion.json` are absent. The interruption is
 recorded in
-`/home/lidaiqing/results/kimi-k3-gb10/conversion-interrupted-20260829T020606Z.json`.
+`$HOME/results/kimi-k3-gb10/conversion-interrupted-20260829T020606Z.json`.
 
 1. After the refactor, run the supervised FTW conversion; stop on the disk or
    memory floor, any OOM or


### PR DESCRIPTION
## Outcome

Prepare SparkLab for a later private-to-public visibility cutover without changing repository visibility.

- anonymize machine-specific home paths in checked-in benchmark evidence and experiment notes
- reject personal `/home/<user>/...` paths and tracked checkpoint/binary weights in hosted PR checks
- add weekly Dependabot coverage for GitHub Actions and Python dependencies
- document the visibility cutover, security enablement, ruleset restoration, and self-hosted runner boundary

Existing private Actions history and artifacts are intentionally retained pending an explicit deletion decision.

## Validation

- `gitleaks 8.30.1 git . --log-opts=--all` — 118 commits, no leaks
- parsed all checked-in benchmark result JSON and GitHub workflow/config YAML
- exercised the public-tree hygiene shell checks
- `PYTHONPATH=python .venv/bin/python -m pytest -q tests/sparklab/test_project_identity.py` — 6 passed
- `git diff --check`

## Checklist

- [x] The change is focused and contains no unrelated generated files or credentials.
- [x] Behavior changes include tests and relevant documentation.
- [x] No model or performance claims are changed.
- [x] Every commit includes a DCO Signed-off-by line.
- [x] I have the right to submit all code, data, and documentation in this pull request.
