### PR TITLE
Publish Kimi K3 NVFP4 FTW runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ a SparkLab support claim.
       <td><a href="docs/models/glm-5.2.md">Instructions</a></td>
     </tr>
     <tr>
-      <td><a href="https://huggingface.co/nvidia/Kimi-K3-NVFP4">Kimi K3</a></td>
+      <td><a href="https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW">Kimi K3</a></td>
       <td>2.8T total / 16 of 896 experts</td>
-      <td>NVFP4 · FTW pending</td>
+      <td>ModelOpt NVFP4/FP8 · FTW</td>
       <td>Experimental</td>
-      <td align="right">—</td>
-      <td align="right">—</td>
+      <td align="right">0.16</td>
+      <td align="right">395.405</td>
       <td><a href="docs/models/kimi-k3.md">Instructions</a></td>
     </tr>
   </tbody>
@@ -149,6 +149,7 @@ Displayed values are fixed, batch-one probes—not certification or capacity pro
 - [DeepSeek V4 evidence](benchmarks/gb10/results/GB10-DSV4-SPARSE-001.json)
 - [GLM-5.3 evidence](benchmarks/gb10/results/GB10-GLM53-KDA-FP8-002.json)
 - [GLM-5.2 experiment](exps/exp_glm5_2_gb10.md)
+- [Kimi K3 evidence](benchmarks/gb10/results/GB10-KIMI-001.json)
 
 Status meanings:
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,12 +38,11 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 4.98 | 5.379 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.2](https://huggingface.co/nvidia/GLM-5.2-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.2` | Experimental fallback | 0.80 | 2.570 |
-| [Kimi K3](https://huggingface.co/nvidia/Kimi-K3-NVFP4) | 2.8T total / 16 of 896 experts | NVFP4 · FTW upload pending | `kimi-k3` | Experimental | — | — |
+| [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
-Model links point to the selected source or published FTW checkpoints. Qwen3.6 uses a
-pinned prebuilt FTW artifact; its source-conversion path remains available for
-reproducibility. The Kimi K3 NVFP4 FTW link remains marked pending until its Hugging Face
-upload exists.
+Model links point to the selected source or published FTW checkpoints. Qwen3.6 and Kimi K3
+use pinned prebuilt FTW artifacts; their source-conversion paths remain available for
+reproducibility.
 
 Parameter values use publisher-reported architecture counts. Qwen3.8's auxiliary total is
 the 51B n-gram embedding plus its 4B MTP module. NVIDIA reports Kimi K3 activation as 16 of
@@ -68,9 +67,15 @@ warm TTFT with an auto-sized 5,321-slot expert cache. The repeated fixed probe r
 no physical expert reads during the measured request and preserved the established greedy
 output hash. Longer prompts fall back to bounded full-layer streaming. See the
 [full experiment](../exps/exp_dsv4_gb10.md).
-The Kimi K3 recipe similarly preserves NVIDIA's mixed checkpoint: routed experts remain
-NVFP4, supported attention projections remain block FP8, and other tensors retain their
-source precision.
+The Kimi K3 FTW artifact preserves NVIDIA's mixed checkpoint: routed experts remain NVFP4,
+supported attention projections remain block FP8, and other tensors retain their source
+precision on disk. Its validated GB10 resident profile converts 188 dense/shared/embedding/
+head matrices to per-row FP8 while loading so the minimum 896-slot expert cache fits. The
+exact 256-token probe measured 0.1613 tok/s and 395.405 s warm TTFT with zero scoped runtime
+OOM or swap-out. It stopped before a final AIME answer and diverged from shorter greedy
+rungs, so correctness and cross-rung determinism are not established. See the
+[versioned evidence](../benchmarks/gb10/results/GB10-KIMI-001.json) and
+[full experiment](../exps/exp_kimik3_gb10.md).
 
 GLM-5.2 is listed in Research because its selected GB10 experiment sustained 0.802 tok/s,
 below the 5 tok/s Frontier threshold. The displayed 2.57 s TTFT and throughput are measured,

--- a/docs/models/kimi-k3.md
+++ b/docs/models/kimi-k3.md
@@ -1,7 +1,8 @@
 # Run Kimi K3
 
 Kimi K3 is SparkLab's 2.8T-parameter Research recipe for inference beyond physical memory.
-It is Experimental, and its prebuilt FTW artifact is not yet published.
+It is Experimental. The validated text-only FTW artifact is published at
+[`oakmindai/Kimi-K3-NVFP4-FTW`](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW).
 
 ## Install SparkLab
 
@@ -21,9 +22,10 @@ checkout.
 ## Prepare
 
 Use fast local NVMe storage. `pull --prepare` automatically selects a pinned Hugging Face
-FTW artifact when the recipe publishes one. Kimi K3 does not have one yet, so the same
-command downloads the source checkpoint and builds FTW locally. The catalog currently
-requires about 3.36 TB of free space, making this a long, storage-intensive operation.
+FTW artifact. The Kimi repository contains 1,610,936,311,808 bytes across 194 FTW shards,
+so allow approximately 1.5 TiB for the artifact plus the planner's operational reserve.
+Use `--from-source` only when you deliberately want to download NVIDIA's original
+checkpoint and reproduce the conversion; that path requires roughly 3.36 TB.
 
 ```bash
 sparklab doctor --storage-path /path/to/models
@@ -32,13 +34,19 @@ sparklab pull kimi-k3 --root /path/to/models --prepare
 ```
 
 Do not continue unless `doctor` and `plan` pass. Preserve the generated FTW directory so
-an interrupted model download or preparation does not need to restart from zero.
+an interrupted download does not need to restart from zero. `pull` pins the public artifact
+revision and validates its byte count and FTW fingerprint before recording it for launch.
 
 ## Run
 
 ```bash
 sparklab run kimi-k3 --root /path/to/models
 ```
+
+The recipe applies the measured bounded configuration automatically: disk-backed ModelOpt
+NVFP4 experts, an 896-slot layer-aware cache, per-row FP8 resident weights, disabled startup
+prefill warmup, eager execution, and one active request. The server can take several minutes
+to become ready; the first request pays the prefill/JIT cost.
 
 Wait for the API to listen on `127.0.0.1:1919`, then verify it:
 
@@ -47,5 +55,11 @@ curl http://127.0.0.1:1919/health
 curl http://127.0.0.1:1919/v1/models
 ```
 
-No accepted GB10 performance result is attached yet. See the
+The promoted 256-token probe measured **0.1613 tok/s** and **395.405 s** warm TTFT with
+17.68 GiB minimum `MemAvailable`, zero scoped runtime OOM kills, and zero runtime swap-out.
+This is a bounded-capacity result, not an interactivity or correctness claim: the response
+ended before stating the expected AIME answer, and the 256-token greedy text diverged from
+the shorter promotion ladder. See
+[`GB10-KIMI-001`](../../benchmarks/gb10/results/GB10-KIMI-001.json), the
+[full experiment](../../exps/exp_kimik3_gb10.md), and the
 [quick start](../quickstart.md) for API examples.

--- a/hf/models/kimi-k3-NVFP4-FTW/MODEL_CARD.md
+++ b/hf/models/kimi-k3-NVFP4-FTW/MODEL_CARD.md
@@ -1,0 +1,200 @@
+---
+pipeline_tag: text-generation
+base_model:
+- nvidia/Kimi-K3-NVFP4
+- moonshotai/Kimi-K3
+license: other
+license_name: nvidia-open-model-license
+license_link: https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-agreement/
+library_name: sparklab
+tags:
+- kimi-k3
+- nvidia
+- modelopt
+- nvfp4
+- quantized
+- sparklab
+- ftw
+- dgx-spark
+---
+
+# Kimi K3 NVFP4 — SparkLab FTW
+
+This is a ready-to-run **SparkLab FTW** checkpoint for
+[`nvidia/Kimi-K3-NVFP4`](https://huggingface.co/nvidia/Kimi-K3-NVFP4), optimized
+for text inference on one **NVIDIA DGX Spark** with the Grace Blackwell GB10
+Superchip.
+
+> **SparkLab source:** https://github.com/sixteen-miles-labs/sparklab
+
+The artifact is large: its FTW payload occupies **1,610,936,311,808 bytes**
+(approximately 1.465 TiB) across 194 shards. Store it on fast local NVMe.
+
+## What this repository contains
+
+This repository does not introduce a new model, fine-tune, or quantization. It
+repackages NVIDIA's published checkpoint into SparkLab's self-contained, aligned FTW
+format so individual routed-expert rows can be read from NVMe:
+
+1. [Moonshot AI](https://huggingface.co/moonshotai) developed
+   [Kimi K3](https://huggingface.co/moonshotai/Kimi-K3).
+2. [NVIDIA](https://huggingface.co/nvidia) produced
+   [Kimi-K3-NVFP4](https://huggingface.co/nvidia/Kimi-K3-NVFP4) with
+   [NVIDIA Model Optimizer](https://github.com/NVIDIA/Model-Optimizer).
+3. [SparkLab](https://github.com/sixteen-miles-labs/sparklab) provides the native
+   inference runtime, FTW conversion, GB10 kernels, NVMe-backed MoE execution, model
+   recipes, readiness checks, capacity planning, and serving workflow.
+4. [OakMind AI](https://huggingface.co/oakmindai) performed, validated, documented,
+   and published this FTW conversion.
+
+The exact source revision is
+`f8c5234a0a880bcc6cbf779a315e7ee2f405b812`. The FTW fingerprint is
+`534cbc4565d4279d`. Routed experts retain NVIDIA's ModelOpt NVFP4 representation,
+supported attention/KDA projections retain block FP8, and the other text tensors retain
+their source precision. The current artifact is text-only; SparkLab's vision path is not
+included or validated.
+
+## Why FTW is required here
+
+Kimi K3 has 2.8T total parameters and activates 16 of 896 routed experts per token. The
+whole model cannot reside in the GB10's 128 GB coherent memory. FTW makes expert rows
+independently addressable, allowing SparkLab to retain a bounded GPU expert cache while
+streaming misses from NVMe.
+
+FTW improves artifact loading and enables this bounded execution policy; it does not make
+the model interactive. The measured configuration remains storage-bound.
+
+## Run with SparkLab on NVIDIA DGX Spark
+
+Install SparkLab:
+
+```bash
+git clone https://github.com/sixteen-miles-labs/sparklab.git
+cd sparklab
+./install.sh
+```
+
+SparkLab can download this pinned runtime artifact automatically:
+
+```bash
+sparklab doctor --storage-path ~/models
+sparklab plan kimi-k3 --root ~/models --prepare
+sparklab pull kimi-k3 --root ~/models --prepare
+```
+
+Or download the repository directly:
+
+```bash
+hf download oakmindai/Kimi-K3-NVFP4-FTW \
+  --local-dir ~/models/Kimi-K3-NVFP4-FTW
+```
+
+The validated one-GB10 server configuration is:
+
+```bash
+sparklab serve \
+  --model ~/models/Kimi-K3-NVFP4-FTW \
+  --kimi-mlp-fp8 \
+  --disable-startup-prefill-warmup \
+  --moe-backend offload \
+  --moe-storage disk \
+  --moe-host-cache-gb 0 \
+  --moe-cache-size 896 \
+  --moe-cache-policy layer_lru \
+  --memory-ratio 0.85 \
+  --num-tokens 1024 \
+  --disable-moe-prefill-overlap \
+  --moe-prefill-sparse-max-tokens 256 \
+  --nvfp4-backend triton \
+  --cuda-graph-max-bs 0 \
+  --max-running-requests 1 \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+The resident-profile flag quantizes 188 BF16 dense/shared/embedding/head
+matrices to per-output-row FP8 while loading. This saves 14.176 GiB of resident memory;
+it does not alter the routed NVFP4 expert banks stored in this repository. Disabling the
+flag does not fit the validated 128 GB configuration.
+
+Send a request after `/health` reports that the server is ready:
+
+```bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "nvidia/Kimi-K3-NVFP4",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 16,
+    "stream": false
+  }'
+```
+
+## GB10 validation
+
+SparkLab promoted the complete artifact through exact 1-, 16-, 64-, and 256-token
+single-request probes under no-swap service cgroups.
+
+| Measurement | Result |
+|---|---:|
+| Decode throughput | 0.1613 tok/s |
+| Warm TTFT | 395.405 s |
+| Completion | 256 / 256 tokens |
+| Minimum `MemAvailable` | 17.68 GiB |
+| Device allocation | 74.86 GiB |
+| Runtime OOM kills | 0 |
+| Runtime swap-out | 0 |
+
+This is a bounded-capacity result, not a quality or interactivity claim. The 256-token
+response stopped while reasoning before emitting the expected AIME answer, and its greedy
+text diverged from the shorter ladder after a shared prefix. The experiment report and
+machine-readable evidence are in
+[`exps/exp_kimik3_gb10.md`](https://github.com/sixteen-miles-labs/sparklab/blob/main/exps/exp_kimik3_gb10.md)
+and
+[`GB10-KIMI-001.json`](https://github.com/sixteen-miles-labs/sparklab/blob/main/benchmarks/gb10/results/GB10-KIMI-001.json).
+
+## Limitations
+
+- This FTW artifact and the published SparkLab path are text-only.
+- The validated configuration is batch one on a single 128 GB GB10.
+- TTFT is approximately 6.5 minutes because the current 129-token prefill fallback scans
+  all 896 experts across 92 MoE layers.
+- Decode is NVMe-bound at an 80.23% expert-cache miss rate in the 256-token probe.
+- Cross-rung greedy determinism, answer correctness, long-context behavior, concurrency,
+  agent capability, and endurance are not established.
+- The checkpoint is Experimental and is not a SparkLab certification claim.
+
+## Credits and license
+
+- Architecture and base weights: [Moonshot AI / Kimi K3](https://huggingface.co/moonshotai/Kimi-K3)
+- NVFP4/FP8 checkpoint: [NVIDIA](https://huggingface.co/nvidia/Kimi-K3-NVFP4), using
+  [NVIDIA Model Optimizer](https://github.com/NVIDIA/Model-Optimizer)
+- Native runtime, FTW format, conversion, kernels, workflow, and deployment:
+  [SparkLab](https://github.com/sixteen-miles-labs/sparklab)
+- Research ancestry: [FreeToken](https://github.com/FlashML-org/FreeToken)
+- FTW conversion and publishing: [OakMind AI](https://huggingface.co/oakmindai)
+
+Use is governed by the
+[NVIDIA Open Model Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-agreement/)
+and the additional upstream Kimi K3 terms included in `LICENSE`. Review the
+[base model card](https://huggingface.co/moonshotai/Kimi-K3) and
+[quantized source card](https://huggingface.co/nvidia/Kimi-K3-NVFP4/tree/f8c5234a0a880bcc6cbf779a315e7ee2f405b812)
+for the complete intended-use, evaluation, safety, and license information.
+
+## Citation
+
+```bibtex
+@software{sparklab2026,
+  title  = {SparkLab: Frontier Inference on NVIDIA DGX Spark},
+  author = {Sixteen Miles Labs},
+  year   = {2026},
+  url    = {https://github.com/sixteen-miles-labs/sparklab}
+}
+
+@software{freetoken2025,
+  title = {FreeToken},
+  author = {FlashML.org},
+  year = {2025},
+  url = {https://github.com/FlashML-org/FreeToken}
+}
+```

--- a/hf/models/kimi-k3-NVFP4-FTW/README.md
+++ b/hf/models/kimi-k3-NVFP4-FTW/README.md
@@ -1,0 +1,29 @@
+# Kimi K3 NVFP4 FTW upload
+
+This helper publishes SparkLab's validated Kimi K3 artifact to
+[`oakmindai/Kimi-K3-NVFP4-FTW`](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW).
+
+The default source is the validated local artifact:
+
+```text
+~/.sparklab/models/kimi-k3/prepared/0.2.0
+```
+
+Authenticate, validate without uploading, then start or resume the upload:
+
+```bash
+hf auth login
+python hf/models/kimi-k3-NVFP4-FTW/push_weights.py --validate-only
+
+HF_XET_HIGH_PERFORMANCE=1 \
+  python hf/models/kimi-k3-NVFP4-FTW/push_weights.py --create --workers 8
+```
+
+The uploader checks the FTW identity, fingerprint, total byte count, all 194 indexed
+shards, and the absence of stale shard files before publishing. It excludes the local
+source model card and index from the bulk transfer, then commits this directory's public
+model card together with an index whose machine-local source path has been redacted.
+
+Hugging Face's large-folder state is stored under the artifact's `.cache/huggingface`
+directory, so rerunning the same command resumes completed hashing, pre-upload, and commit
+work. The model repository is public; do not use `--private` for the production upload.

--- a/hf/models/kimi-k3-NVFP4-FTW/push_weights.py
+++ b/hf/models/kimi-k3-NVFP4-FTW/push_weights.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Upload the validated Kimi K3 NVFP4 FTW artifact to Hugging Face."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from huggingface_hub import CommitOperationAdd, HfApi
+from huggingface_hub.errors import HfHubHTTPError
+
+
+DEFAULT_REPO_ID = "oakmindai/Kimi-K3-NVFP4-FTW"
+DEFAULT_WEIGHTS_DIR = Path(
+    "~/.sparklab/models/kimi-k3/prepared/0.2.0"
+).expanduser()
+PUBLIC_CARD = Path(__file__).with_name("MODEL_CARD.md")
+SOURCE_REPOSITORY = "nvidia/Kimi-K3-NVFP4"
+SOURCE_REVISION = "f8c5234a0a880bcc6cbf779a315e7ee2f405b812"
+EXPECTED_FINGERPRINT = "534cbc4565d4279d"
+EXPECTED_TOTAL_BYTES = 1_610_936_311_808
+EXPECTED_SHARDS = 194
+REQUIRED_FILES = (
+    "config.json",
+    "freetoken_weight.json",
+    "tokenizer_config.json",
+    "tiktoken.model",
+    "LICENSE",
+)
+DEFAULT_IGNORE_PATTERNS = [
+    ".git/**",
+    ".cache/**",
+    "__pycache__/**",
+    "*.pyc",
+    "*.tmp",
+    # These are committed after the large transfer so the public card replaces the
+    # upstream card and the published index contains no workstation-local path.
+    "README.md",
+    "freetoken_weight.json",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Upload SparkLab's validated Kimi K3 NVFP4 FTW artifact with "
+            "Hugging Face's resumable large-folder uploader."
+        )
+    )
+    parser.add_argument(
+        "weights_dir",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_WEIGHTS_DIR,
+        help=f"FTW artifact directory (default: {DEFAULT_WEIGHTS_DIR})",
+    )
+    parser.add_argument(
+        "--repo-id",
+        default=DEFAULT_REPO_ID,
+        help=f"Destination model repository (default: {DEFAULT_REPO_ID})",
+    )
+    parser.add_argument("--revision", help="Destination branch")
+    parser.add_argument("--workers", type=int, help="Number of upload workers")
+    parser.add_argument(
+        "--create", action="store_true", help="Create the public repository if needed"
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="validate the local artifact without contacting Hugging Face",
+    )
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> tuple[Path, dict]:
+    weights_dir = args.weights_dir.expanduser().resolve()
+    if not weights_dir.is_dir():
+        raise ValueError(f"weights directory does not exist: {weights_dir}")
+    missing = [name for name in REQUIRED_FILES if not (weights_dir / name).is_file()]
+    if missing:
+        raise ValueError(f"FTW artifact is missing: {', '.join(missing)}")
+    if not PUBLIC_CARD.is_file():
+        raise ValueError(f"public model card is missing: {PUBLIC_CARD}")
+
+    try:
+        index = json.loads((weights_dir / "freetoken_weight.json").read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read FTW index: {error}") from error
+
+    if index.get("format") != "freetoken_weight" or index.get("version") != 1:
+        raise ValueError("unsupported FTW identity")
+    if index.get("fingerprint") != EXPECTED_FINGERPRINT:
+        raise ValueError(
+            "unexpected FTW fingerprint: "
+            f"{index.get('fingerprint')!r} (expected {EXPECTED_FINGERPRINT!r})"
+        )
+    if index.get("total_bytes") != EXPECTED_TOTAL_BYTES:
+        raise ValueError(
+            "unexpected FTW byte count: "
+            f"{index.get('total_bytes')!r} (expected {EXPECTED_TOTAL_BYTES})"
+        )
+
+    shards = index.get("shards") or []
+    if len(shards) != EXPECTED_SHARDS:
+        raise ValueError(f"expected {EXPECTED_SHARDS} FTW shards, found {len(shards)}")
+    indexed_names: set[str] = set()
+    for shard in shards:
+        name = shard.get("file")
+        if not isinstance(name, str) or name in indexed_names:
+            raise ValueError(f"invalid or duplicate FTW shard entry: {name!r}")
+        indexed_names.add(name)
+        path = weights_dir / name
+        if not path.is_file():
+            raise ValueError(f"FTW shard is missing: {name}")
+        if path.stat().st_size != shard.get("nbytes"):
+            raise ValueError(
+                f"FTW shard size mismatch for {name}: "
+                f"{path.stat().st_size} != {shard.get('nbytes')}"
+            )
+    actual_names = {path.name for path in weights_dir.glob("freetoken-*.ftw")}
+    if actual_names != indexed_names:
+        raise ValueError(
+            "FTW shard set mismatch: "
+            f"missing={sorted(indexed_names - actual_names)}, "
+            f"stale={sorted(actual_names - indexed_names)}"
+        )
+    if args.workers is not None and args.workers < 1:
+        raise ValueError("--workers must be at least 1")
+    return weights_dir, index
+
+
+def public_index(index: dict) -> dict:
+    value = dict(index)
+    value["source_model_path"] = f"{SOURCE_REPOSITORY}@{SOURCE_REVISION}"
+    return value
+
+
+def verify_remote(api: HfApi, repo_id: str, index: dict, revision: str | None) -> str:
+    info = api.model_info(repo_id, revision=revision, files_metadata=True)
+    siblings = {item.rfilename: item for item in info.siblings or []}
+    required = {"README.md", "freetoken_weight.json", *REQUIRED_FILES}
+    missing = sorted(name for name in required if name not in siblings)
+    if missing:
+        raise ValueError(f"published repository is missing: {', '.join(missing)}")
+    for shard in index["shards"]:
+        remote = siblings.get(shard["file"])
+        if remote is None:
+            raise ValueError(f"published repository is missing {shard['file']}")
+        if remote.size != shard["nbytes"]:
+            raise ValueError(
+                f"published shard size mismatch for {shard['file']}: "
+                f"{remote.size} != {shard['nbytes']}"
+            )
+    remote_shards = [
+        name
+        for name in siblings
+        if name.startswith("freetoken-") and name.endswith(".ftw")
+    ]
+    if len(remote_shards) != EXPECTED_SHARDS:
+        raise ValueError("published repository has an unexpected FTW shard count")
+    return info.sha
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        weights_dir, index = validate_args(args)
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print(
+        f"Validated {EXPECTED_SHARDS} shards, {EXPECTED_TOTAL_BYTES} bytes, "
+        f"fingerprint {EXPECTED_FINGERPRINT}"
+    )
+    if args.validate_only:
+        return 0
+
+    api = HfApi()
+    try:
+        if args.create:
+            api.create_repo(
+                repo_id=args.repo_id,
+                repo_type="model",
+                private=False,
+                exist_ok=True,
+            )
+            api.update_repo_settings(
+                repo_id=args.repo_id, repo_type="model", private=False
+            )
+        print(f"Uploading {weights_dir} to https://huggingface.co/{args.repo_id}")
+        api.upload_large_folder(
+            repo_id=args.repo_id,
+            repo_type="model",
+            folder_path=weights_dir,
+            revision=args.revision,
+            ignore_patterns=DEFAULT_IGNORE_PATTERNS,
+            num_workers=args.workers,
+            print_report=True,
+        )
+        with tempfile.TemporaryDirectory(prefix="kimi-k3-ftw-publish-") as tmp_name:
+            index_path = Path(tmp_name) / "freetoken_weight.json"
+            index_path.write_text(
+                json.dumps(public_index(index), indent=2) + "\n", encoding="utf-8"
+            )
+            api.create_commit(
+                repo_id=args.repo_id,
+                repo_type="model",
+                revision=args.revision,
+                commit_message="Publish validated SparkLab FTW metadata",
+                operations=[
+                    CommitOperationAdd(
+                        path_in_repo="README.md", path_or_fileobj=str(PUBLIC_CARD)
+                    ),
+                    CommitOperationAdd(
+                        path_in_repo="freetoken_weight.json",
+                        path_or_fileobj=str(index_path),
+                    ),
+                ],
+            )
+        sha = verify_remote(api, args.repo_id, index, args.revision)
+    except (HfHubHTTPError, OSError, ValueError) as error:
+        print(f"Hugging Face upload failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Upload complete: https://huggingface.co/{args.repo_id}/tree/{sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/sparklab/backends/native.py
+++ b/python/sparklab/backends/native.py
@@ -22,16 +22,20 @@ _VALUE_OPTIONS: dict[str, tuple[str, type | tuple[type, ...]]] = {
     "moe_storage": ("--moe-storage", str),
     "moe_host_cache_gb": ("--moe-host-cache-gb", (int, float)),
     "memory_ratio": ("--memory-ratio", (int, float)),
+    "moe_cache_size": ("--moe-cache-size", int),
+    "moe_cache_policy": ("--moe-cache-policy", str),
     "moe_cache_rate": ("--moe-cache-rate", (int, float)),
     "nvfp4_backend": ("--nvfp4-backend", str),
     "moe_prefill_sparse_max_tokens": ("--moe-prefill-sparse-max-tokens", int),
     "cuda_graph_max_bs": ("--cuda-graph-max-bs", int),
     "cache_type": ("--cache-type", str),
     "page_size": ("--page-size", int),
-    "max_running_req": ("--max-running-req", int),
+    "max_running_req": ("--max-running-requests", int),
     "num_tokens": ("--num-tokens", int),
 }
 _FLAG_OPTIONS: dict[str, str] = {
+    "disable_startup_prefill_warmup": "--disable-startup-prefill-warmup",
+    "kimi_mlp_fp8": "--kimi-mlp-fp8",
     "moe_cache_auto": "--moe-cache-auto",
     "moe_prefill_hit_d2d": "--moe-prefill-hit-d2d",
 }
@@ -44,6 +48,8 @@ _OPTION_ORDER = (
     "moe_storage",
     "moe_host_cache_gb",
     "memory_ratio",
+    "moe_cache_size",
+    "moe_cache_policy",
     "moe_cache_rate",
     "moe_cache_auto",
     "nvfp4_backend",
@@ -55,6 +61,8 @@ _OPTION_ORDER = (
     "page_size",
     "max_running_req",
     "num_tokens",
+    "kimi_mlp_fp8",
+    "disable_startup_prefill_warmup",
 )
 _SUPPORTED_FORMATS = (
     "safetensors",

--- a/python/sparklab/recipes/kimi-k3.json
+++ b/python/sparklab/recipes/kimi-k3.json
@@ -8,6 +8,12 @@
   "revision": "f8c5234a0a880bcc6cbf779a315e7ee2f405b812",
   "source_bytes": 1610038482254,
   "prepared_bytes": 1610936311808,
+  "runtime_artifact": {
+    "repo_id": "oakmindai/Kimi-K3-NVFP4-FTW",
+    "revision": "793f1f8436cd7de11e7912c41b3d49d4c9e4d11c",
+    "bytes": 1610936311808,
+    "fingerprint": "534cbc4565d4279d"
+  },
   "minimum_free_bytes": 3357515917980,
   "intended_tier": "research",
   "status": "experimental",

--- a/python/sparklab/recipes/kimi-k3.json
+++ b/python/sparklab/recipes/kimi-k3.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.2.0",
+  "recipe_version": "0.3.0",
   "slug": "kimi-k3",
   "name": "Kimi K3",
   "model": "nvidia/Kimi-K3-NVFP4",
   "parameters": "2.8T total / 16 of 896 experts",
   "revision": "f8c5234a0a880bcc6cbf779a315e7ee2f405b812",
   "source_bytes": 1610038482254,
-  "prepared_bytes": 1610038482254,
+  "prepared_bytes": 1610936311808,
   "minimum_free_bytes": 3357515917980,
   "intended_tier": "research",
   "status": "experimental",
@@ -16,18 +16,49 @@
   "deployment": {
     "backend": "native",
     "backend_api": "1.0",
-    "source_format": "safetensors",
+    "source_format": "safetensors-nvfp4",
     "runtime_format": "ftw-nvfp4",
     "quantization": "nvfp4",
     "execution_policy": "nvme-moe",
-    "backend_options": {}
+    "backend_options": {
+      "moe_backend": "offload",
+      "moe_storage": "disk",
+      "moe_host_cache_gb": 0,
+      "memory_ratio": 0.85,
+      "moe_cache_size": 896,
+      "moe_cache_policy": "layer_lru",
+      "nvfp4_backend": "triton",
+      "moe_prefill_sparse_max_tokens": 256,
+      "moe_prefill_overlap": false,
+      "cuda_graph_max_bs": 0,
+      "cache_type": "radix",
+      "page_size": 1,
+      "max_running_req": 1,
+      "num_tokens": 1024,
+      "kimi_mlp_fp8": true,
+      "disable_startup_prefill_warmup": true
+    }
   },
   "profile": "research",
-  "description": "The 2.8T NVIDIA NVFP4 flagship demonstration for inference beyond physical memory.",
+  "runtime_memory": {
+    "total_bytes": 105804767232
+  },
+  "performance": {
+    "decode_tokens_per_second": 0.16130749709147157,
+    "warm_ttft_seconds": 395.4053193805739,
+    "evidence": "GB10-KIMI-001",
+    "note": "The complete FTW checkpoint returned exactly 256 tokens with zero scoped runtime OOM or swap-out. Cross-rung greedy determinism and answer correctness are not established."
+  },
+  "evidence": [
+    "GB10-KIMI-001"
+  ],
+  "description": "Bounded text inference for NVIDIA's 2.8T Kimi K3 ModelOpt NVFP4 checkpoint on one GB10 using a 1.5 TiB FTW expert bank and NVMe streaming.",
   "limitations": [
-    "Beta FTW preparation must preserve the checkpoint's mixed representation: NVFP4 routed experts, 128x128 block-FP8 attention projections, and the original precision of remaining tensors.",
-    "The NVIDIA ModelOpt mixed NVFP4/FP8 mapping is implemented and has exact index-level coverage, but still awaits full-checkpoint conversion and runtime validation.",
-    "Full-checkpoint FTW preparation and GPU parity are not yet validated.",
-    "No latency promise and no vision support."
+    "The validated 1,610,936,311,808-byte FTW artifact contains 194 shards with fingerprint 534cbc4565d4279d; routed experts retain ModelOpt NVFP4 and supported attention/KDA projections retain block FP8.",
+    "The one-GB10 runtime profile quantizes 188 remaining dense/shared/embedding/head matrices to per-row FP8 while loading, saving 14.176 GiB; this resident transform is separate from the FTW expert representation.",
+    "The 256-token probe measured 0.1613 tok/s and 395.405 s warm TTFT with zero scoped runtime OOM or swap-out, below the Research usability target and unsuitable for interactive use.",
+    "The 129-token prefill fallback scans all 896 experts across 92 MoE layers; decode remained storage-bound at an 80.23% expert-cache miss rate.",
+    "The 256-token response ended before emitting the expected AIME answer, and its greedy text diverged from the shorter promotion rungs, so correctness and cross-rung determinism are not established.",
+    "Text-only batch-one serving is validated. Vision, long context, concurrency, capability, agent, quality, and endurance gates remain outstanding."
   ]
 }

--- a/python/sparklab/serving/args.py
+++ b/python/sparklab/serving/args.py
@@ -224,6 +224,23 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--kimi-mlp-fp8",
+        action="store_true",
+        help=(
+            "Kimi K3 only: quantize dense/shared MLP, embedding, and output-head "
+            "weights to per-row FP8 while loading (the validated one-GB10 profile)."
+        ),
+    )
+    parser.add_argument(
+        "--disable-startup-prefill-warmup",
+        action="store_true",
+        help=(
+            "skip synthetic prefill warmup before readiness; the first request pays "
+            "JIT cost (required for multi-terabyte disk-backed expert pools)"
+        ),
+    )
+
+    parser.add_argument(
         "--tensor-parallel-size",
         "--tp-size",
         type=int,
@@ -664,6 +681,14 @@ def parse_args(
 
     # Parse arguments
     kwargs = parser.parse_args(args).__dict__.copy()
+
+    # These settings must be visible before the model configuration is parsed and are
+    # inherited by the engine subprocess. Keep the environment variables as compatibility
+    # aliases for existing benchmark/service invocations.
+    if kwargs.pop("kimi_mlp_fp8"):
+        os.environ["SPARKLAB_KIMI_MLP_FP8"] = "1"
+    if kwargs.pop("disable_startup_prefill_warmup"):
+        os.environ["SPARKLAB_DISABLE_STARTUP_PREFILL_WARMUP"] = "1"
 
     # resolve some arguments
     run_shell |= kwargs.pop("shell_mode")

--- a/tests/serving/test_parser_auto_selection.py
+++ b/tests/serving/test_parser_auto_selection.py
@@ -12,6 +12,7 @@ the moment it is added, and has to be dispositioned here to stay green.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -94,3 +95,26 @@ def test_an_explicit_choice_beats_inference():
         pinned, _ = parse_args(["--model", ANON_PATH, "--reasoning-parser", "qwen3"])
     assert off.reasoning_parser is None
     assert pinned.reasoning_parser == "qwen3"
+
+
+def test_kimi_gb10_flags_publish_compatibility_environment(monkeypatch):
+    monkeypatch.delenv("SPARKLAB_KIMI_MLP_FP8", raising=False)
+    monkeypatch.delenv("SPARKLAB_DISABLE_STARTUP_PREFILL_WARMUP", raising=False)
+
+    with patch(
+        "sparklab.utils.cached_load_hf_config",
+        lambda _path: _Config(
+            {"architectures": ["KimiK3ForConditionalGeneration"], "torch_dtype": "bfloat16"}
+        ),
+    ):
+        parse_args(
+            [
+                "--model",
+                ANON_PATH,
+                "--kimi-mlp-fp8",
+                "--disable-startup-prefill-warmup",
+            ]
+        )
+
+    assert os.environ["SPARKLAB_KIMI_MLP_FP8"] == "1"
+    assert os.environ["SPARKLAB_DISABLE_STARTUP_PREFILL_WARMUP"] == "1"

--- a/tests/sparklab/test_backends.py
+++ b/tests/sparklab/test_backends.py
@@ -111,7 +111,7 @@ def test_native_backend_compiles_qwen_recipe_options_in_stable_order(tmp_path):
         "naive",
         "--page-size",
         "16",
-        "--max-running-req",
+        "--max-running-requests",
         "1",
         "--port",
         "1919",
@@ -140,6 +140,42 @@ def test_native_backend_compiles_glm_residency_options(tmp_path):
     assert "--memory-ratio" in plan.arguments
     assert plan.arguments[plan.arguments.index("--memory-ratio") + 1] == "0.96"
     assert "--disable-moe-prefill-overlap" in plan.arguments
+
+
+def test_native_backend_compiles_kimi_bounded_gb10_options(tmp_path):
+    recipe = get_recipe("kimi-k3")
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text("{}", encoding="utf-8")
+    deployment = replace(
+        recipe.deployment,
+        runtime_format="safetensors",
+        backend_options={
+            "moe_cache_size": 896,
+            "moe_cache_policy": "layer_lru",
+            "kimi_mlp_fp8": True,
+            "disable_startup_prefill_warmup": True,
+        },
+    )
+
+    plan = get_backend("native").build_launch_plan(
+        RuntimeRequest(
+            recipe=recipe.slug,
+            recipe_version=recipe.recipe_version,
+            model=recipe.model,
+            checkpoint=checkpoint,
+            deployment=deployment,
+        )
+    )
+
+    assert plan.arguments[-6:] == (
+        "--moe-cache-size",
+        "896",
+        "--moe-cache-policy",
+        "layer_lru",
+        "--kimi-mlp-fp8",
+        "--disable-startup-prefill-warmup",
+    )
 
 
 def test_native_backend_compiles_deepseek_sparse_prefill_options(tmp_path):
@@ -179,7 +215,7 @@ def test_native_backend_compiles_deepseek_sparse_prefill_options(tmp_path):
         "0",
         "--cache-type",
         "radix",
-        "--max-running-req",
+        "--max-running-requests",
         "1",
     )
 

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -69,10 +69,19 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert qwen.runtime_artifact.revision == "cbbcf69f52b9815b8a987fe839003fae12aa8050"
     assert qwen.runtime_artifact.fingerprint == "47e11ddb878adf4c"
     kimi = get_recipe("kimi-k3")
-    assert kimi.recipe_version == "0.2.0"
+    assert kimi.recipe_version == "0.3.0"
     assert kimi.deployment.runtime_format == "ftw-nvfp4"
     assert kimi.deployment.quantization == "nvfp4"
-    assert kimi.performance is None
+    assert kimi.deployment.backend_options["moe_cache_size"] == 896
+    assert kimi.deployment.backend_options["moe_cache_policy"] == "layer_lru"
+    assert kimi.deployment.backend_options["kimi_mlp_fp8"] is True
+    assert kimi.deployment.backend_options["disable_startup_prefill_warmup"] is True
+    assert kimi.performance.decode_tokens_per_second == pytest.approx(
+        0.16130749709147157
+    )
+    assert kimi.performance.warm_ttft_seconds == pytest.approx(395.4053193805739)
+    assert kimi.evidence == ("GB10-KIMI-001",)
+    assert kimi.runtime_memory == {"total_bytes": 105804767232}
     glm52 = get_recipe("glm-5.2")
     assert glm52.recipe_version == "0.2.0"
     assert glm52.performance.decode_tokens_per_second == pytest.approx(0.802)
@@ -138,6 +147,7 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert glm.runtime_artifact.bytes == 184716947456
     assert glm.runtime_artifact.fingerprint == "4c021651a1e61802"
     assert kimi.source_bytes == 1610038482254
+    assert kimi.prepared_bytes == 1610936311808
     assert glm52.source_bytes == 464874323992
     assert deepseek.source_bytes == 166878536440
     assert deepseek.prepared_bytes == 157460918272
@@ -191,6 +201,32 @@ def test_glm53_recipe_points_to_checked_in_kda_fp8_evidence():
         recipe.performance.warm_ttft_seconds
     )
     assert result["comparison"]["decode_throughput_improvement_percent"] > 18
+
+
+def test_kimi_recipe_points_to_checked_in_bounded_capacity_evidence():
+    recipe = get_recipe("kimi-k3")
+    assert recipe.performance.evidence == "GB10-KIMI-001"
+    assert recipe.performance.evidence in recipe.evidence
+    root = Path(__file__).resolve().parents[2]
+    result = json.loads(
+        (root / "benchmarks/gb10/results/GB10-KIMI-001.json").read_text()
+    )
+    assert result["result_id"] == recipe.performance.evidence
+    assert result["status"] == "measured"
+    assert result["model"]["revision"] == recipe.revision
+    assert result["model"]["fingerprint"] == "534cbc4565d4279d"
+    assert result["model"]["checkpoint_bytes"] == recipe.prepared_bytes
+    assert result["metrics"]["decode_tokens_per_second"] == pytest.approx(
+        recipe.performance.decode_tokens_per_second
+    )
+    assert result["metrics"]["warm_ttft_seconds"] == pytest.approx(
+        recipe.performance.warm_ttft_seconds
+    )
+    assert result["workload"]["completion_tokens"] == 256
+    assert result["validation"]["oom_count"] == 0
+    assert result["validation"]["runtime_swap_growth_bytes"] == 0
+    assert result["validation"]["output_prefix_consistent_across_ladder"] is False
+    assert result["validation"]["output_correctness_evaluated"] is False
 
 
 def test_glm52_recipe_points_to_measured_failed_research_evidence():

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -82,6 +82,11 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert kimi.performance.warm_ttft_seconds == pytest.approx(395.4053193805739)
     assert kimi.evidence == ("GB10-KIMI-001",)
     assert kimi.runtime_memory == {"total_bytes": 105804767232}
+    assert kimi.runtime_artifact is not None
+    assert kimi.runtime_artifact.repo_id == "oakmindai/Kimi-K3-NVFP4-FTW"
+    assert kimi.runtime_artifact.revision == "793f1f8436cd7de11e7912c41b3d49d4c9e4d11c"
+    assert kimi.runtime_artifact.bytes == 1610936311808
+    assert kimi.runtime_artifact.fingerprint == "534cbc4565d4279d"
     glm52 = get_recipe("glm-5.2")
     assert glm52.recipe_version == "0.2.0"
     assert glm52.performance.decode_tokens_per_second == pytest.approx(0.802)


### PR DESCRIPTION
## Summary

- publish the Kimi K3 NVFP4 FTW model card and resumable Hugging Face uploader
- encode the measured bounded GB10 runtime profile and expose its launch flags
- add Kimi performance evidence, caveats, and automatic-download instructions
- pin the validated public artifact at `793f1f8436cd7de11e7912c41b3d49d4c9e4d11c`

## Validation

- `uv run pytest -q` (1561 passed, 8 skipped)
- focused post-pin suite (74 passed)
- local 194-shard FTW validation
- remote 194-shard size, fingerprint, sanitized index, and model-card verification
- `git diff --check`

## Publication

Uploaded and verified at https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW/tree/793f1f8436cd7de11e7912c41b3d49d4c9e4d11c.