### PR TITLE
docs: complete public repository follow-up

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible SparkLab problem
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve SparkLab. For security vulnerabilities, use the private reporting link in SECURITY.md instead of this form.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and pull requests for this problem.
+          required: true
+        - label: This report does not contain credentials, private prompts, model weights, or undisclosed security details.
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: SparkLab version or commit
+      placeholder: 0.1.0b1 or a commit SHA
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include operating system, Python version, GPU, driver, and CUDA version where relevant.
+      placeholder: DGX OS, Python 3.11, NVIDIA GB10, driver r580, CUDA 13
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Explain what happened and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest commands or code that reproduce the problem.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Remove credentials, private prompts, local usernames, and unrelated model output before pasting logs.
+      render: text
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other information that may help diagnose the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/sixteen-miles-labs/sparklab/security/advisories/new
+    about: Report vulnerabilities privately to the SparkLab maintainers.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,7 +133,8 @@ parsers all resolve automatically from the checkpoint and the GPU.
 
 ### MoE offload
 
-See [models.md](models.md#moe-backends) for what each backend does.
+See the [FTW and NVMe execution notes](models.md#ftw-and-nvme-execution) for
+the model-portfolio context behind offloaded execution.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -213,8 +214,9 @@ sparklab checkpoint --model <hf_dir> --out <ftw_dir> [--dtype bfloat16] [--moe-b
 Converts an HF safetensors checkpoint to FTW, the engine's self-contained
 fast-load format; point `sparklab serve --model` at the output dir. `--moe-backend
 offload` (default) packs experts into offload banks; `--moe-backend triton`
-keeps them dense for resident serving. See the FTW caveats in
-[models.md](models.md#notes). NVFP4 layouts are backend-owned, so choose the
+keeps them dense for resident serving. See the
+[FTW and NVMe execution notes](models.md#ftw-and-nvme-execution). NVFP4 layouts
+are backend-owned, so choose the
 same `--nvfp4-backend` at conversion and serve time; `auto` selects by GPU,
 while `flashinfer` forces the SM12x b12x layout.
 


### PR DESCRIPTION
## Summary\n\n- repair two stale CLI links to the FTW and NVMe execution notes\n- add a structured public bug-report form\n- route vulnerability reports to GitHub private reporting\n\n## Validation\n\n- parsed both issue-template files as YAML\n- confirmed the target documentation anchor exists\n- ran `git diff --check`