### PR TITLE
security: sanitize public API errors

### DIFF
--- a/python/sparklab/daemon/app.py
+++ b/python/sparklab/daemon/app.py
@@ -12,6 +12,7 @@ import asyncio
 import collections
 import functools
 import json
+import logging
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -24,6 +25,8 @@ from pydantic import BaseModel
 from .accounting import AccountingOutboxError, AccountingPrepareError
 from .serve_manager import Conflict
 from .version import DAEMON_VERSION
+
+logger = logging.getLogger(__name__)
 
 
 class StartBody(BaseModel):
@@ -142,10 +145,11 @@ def build_app(
             if isinstance(exc, AccountingOutboxError)
             else "accounting_prepare_failed"
         )
+        logger.warning("daemon accounting operation failed", exc_info=exc)
         return JSONResponse(
             status_code=503,
             content={
-                "error": str(exc),
+                "error": "accounting operation failed",
                 "code": code,
                 "enginePreserved": True,
             },
@@ -171,18 +175,20 @@ def build_app(
         try:
             return await run(lifecycle_pool, manager.start, body.model, port, list(body.args))
         except Conflict as exc:
+            logger.info("engine start conflict", exc_info=exc)
             st = manager.status()
             return JSONResponse(
                 status_code=409,
                 content={
-                    "error": str(exc),
+                    "error": "engine is already running with another configuration",
                     "code": "serve_conflict",
                     "currentModel": st.get("model"),
                     "currentPort": st.get("port"),
                 },
             )
         except Exception as exc:  # noqa: BLE001 — never propagate a 500-as-crash
-            raise HTTPException(status_code=500, detail=f"start failed: {exc}")
+            logger.exception("engine start failed")
+            raise HTTPException(status_code=500, detail="engine start failed") from exc
 
     @app.post("/engine/stop", dependencies=auth)
     async def engine_stop(body: StopBody | None = None):
@@ -224,7 +230,8 @@ def build_app(
         except (AccountingPrepareError, AccountingOutboxError) as exc:
             return accounting_error(exc)
         except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=500, detail=f"switch failed: {exc}")
+            logger.exception("engine switch failed")
+            raise HTTPException(status_code=500, detail="engine switch failed") from exc
 
     # ---- durable accounting outbox ----
 
@@ -241,7 +248,8 @@ def build_app(
         try:
             return await run(lifecycle_pool, manager.ack_accounting, body.receiptId)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            logger.info("invalid accounting acknowledgement", exc_info=exc)
+            raise HTTPException(status_code=400, detail="invalid accounting receipt") from exc
         except AccountingOutboxError as exc:
             return accounting_error(exc)
 
@@ -296,9 +304,11 @@ def build_app(
             try:
                 return await run(lifecycle_pool, checkpoints.start, body.id, list(body.args))
             except Conflict as exc:
-                raise HTTPException(status_code=409, detail=str(exc))
+                logger.info("checkpoint start conflict", exc_info=exc)
+                raise HTTPException(status_code=409, detail="checkpoint is already running") from exc
             except Exception as exc:  # noqa: BLE001
-                raise HTTPException(status_code=500, detail=f"checkpoint start failed: {exc}")
+                logger.exception("checkpoint start failed")
+                raise HTTPException(status_code=500, detail="checkpoint start failed") from exc
 
         @app.post("/checkpoint/cancel", dependencies=auth)
         async def checkpoint_cancel(body: CancelBody):
@@ -328,7 +338,8 @@ def build_app(
                     *argv, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, env=env
                 )
             except Exception as exc:  # noqa: BLE001
-                yield _bench_sse("error", {"message": f"failed to spawn bench: {exc}"})
+                logger.exception("failed to spawn bandwidth benchmark")
+                yield _bench_sse("error", {"message": "failed to start bandwidth benchmark"})
                 return
             tail: collections.deque = collections.deque(maxlen=8)  # last non-progress lines (errors)
             assert proc.stdout is not None

--- a/python/sparklab/serving/accounting.py
+++ b/python/sparklab/serving/accounting.py
@@ -10,6 +10,7 @@ longer race the last sampled-token reply.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from ipaddress import IPv6Address, ip_address
 from typing import Any, Callable
@@ -17,6 +18,8 @@ from typing import Any, Callable
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 
 class AdmissionClosedError(RuntimeError):
@@ -132,7 +135,8 @@ def _is_loopback(host: str | None) -> bool:
 
 def register_accounting_routes(app: FastAPI, get_state: Callable[[], Any]) -> None:
     async def _admission_closed(_: Request, exc: AdmissionClosedError) -> JSONResponse:
-        return JSONResponse(status_code=503, content={"error": str(exc)})
+        logger.info("request rejected while admission is closed", exc_info=exc)
+        return JSONResponse(status_code=503, content={"error": "request admission is closed"})
 
     app.add_exception_handler(AdmissionClosedError, _admission_closed)
 
@@ -151,7 +155,12 @@ def register_accounting_routes(app: FastAPI, get_state: Callable[[], Any]) -> No
                 abort_timeout_s=body.abort_timeout_s,
             )
         except AccountingDrainError as exc:
+            logger.warning("prepare-stop accounting drain failed", exc_info=exc)
             return JSONResponse(
                 status_code=503,
-                content={"error": str(exc), "drain_complete": False, "engine_preserved": True},
+                content={
+                    "error": "engine could not complete accounting drain",
+                    "drain_complete": False,
+                    "engine_preserved": True,
+                },
             )

--- a/python/sparklab/serving/anthropic_api.py
+++ b/python/sparklab/serving/anthropic_api.py
@@ -11,6 +11,7 @@ It consumes typed events, not a re-parsed OpenAI stream.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -46,6 +47,7 @@ from .generation import (
     count_prompt_tokens,
     generate_events,
     generate_full,
+    public_generation_error,
     render_messages,
     resolve_sampling,
     split_tool_lists,
@@ -53,6 +55,8 @@ from .generation import (
     with_keepalive,
 )
 from .request_logger import log_request
+
+logger = logging.getLogger(__name__)
 
 # Emit a protocol-native `ping` event after this many seconds of stream silence,
 # bridging long queue/prefill/decode gaps for clients with stream-idle timeouts.
@@ -118,8 +122,8 @@ async def handle_anthropic_messages(
             reasoning_parser=getattr(state.config, "reasoning_parser", None),
         )
         uid = await submit_generation(spec, state)
-    except ValueError as exc:
-        return _anthropic_error_response(400, "invalid_request_error", str(exc))
+    except ValueError:
+        return _anthropic_error_response(400, "invalid_request_error", "invalid message parameters")
 
     cache_report = getattr(state.config, "enable_cache_report", False)
     if req.stream:
@@ -134,7 +138,9 @@ async def handle_anthropic_messages(
     try:
         result = await generate_full(uid, spec, state, source="/v1/messages")
     except GenerationError as exc:
-        return _anthropic_error_response(400, "invalid_request_error", str(exc))
+        return _anthropic_error_response(
+            400, "invalid_request_error", public_generation_error(exc)
+        )
     response = anthropic_full_response(result, req.model, uid, cache_report=cache_report)
     return JSONResponse(content=response.model_dump(exclude_none=True))
 
@@ -151,8 +157,8 @@ async def handle_anthropic_count_tokens(req: AnthropicCountTokensRequest, state:
         messages, template_tools, _, ctk = convert_anthropic_prompt(
             req, reasoning_parser=getattr(state.config, "reasoning_parser", None)
         )
-    except ValueError as exc:
-        return _anthropic_error_response(400, "invalid_request_error", str(exc))
+    except ValueError:
+        return _anthropic_error_response(400, "invalid_request_error", "invalid message content")
     if not messages:
         # Non-empty on the wire but nothing survived conversion (e.g. image-only blocks on
         # this text-only server) — a client error, not a tokenizer fault.
@@ -164,9 +170,12 @@ async def handle_anthropic_count_tokens(req: AnthropicCountTokensRequest, state:
     except GenerationError as exc:
         # The chat template could not render this conversation (bad role ordering, an unmatched
         # tool_result, ...) — a client error, exactly as /v1/messages classifies the same failure.
-        return _anthropic_error_response(400, "invalid_request_error", str(exc))
+        return _anthropic_error_response(
+            400, "invalid_request_error", public_generation_error(exc)
+        )
     except Exception as exc:  # noqa: BLE001 — tokenizer init / other failure -> server error
-        return _anthropic_error_response(500, "api_error", f"token counting failed: {exc}")
+        logger.exception("Anthropic token counting failed")
+        return _anthropic_error_response(500, "api_error", "token counting failed")
     response = AnthropicCountTokensResponse(input_tokens=n_tokens)
     return JSONResponse(content=response.model_dump())
 
@@ -564,14 +573,19 @@ async def anthropic_event_stream(
             for f in _stop_block():
                 yield f
         yield _event(AnthropicStreamEvent(
-            type="error", error=AnthropicError(type="invalid_request_error", message=str(exc)),
+            type="error",
+            error=AnthropicError(
+                type="invalid_request_error", message=public_generation_error(exc)
+            ),
         ))
     except Exception as exc:  # noqa: BLE001 — surface as an Anthropic error event
+        logger.exception("Anthropic message stream failed")
         if block_open:
             for f in _stop_block():
                 yield f
         yield _event(AnthropicStreamEvent(
-            type="error", error=AnthropicError(type="internal_error", message=str(exc)),
+            type="error",
+            error=AnthropicError(type="internal_error", message="the message stream failed"),
         ))
 
 

--- a/python/sparklab/serving/generation.py
+++ b/python/sparklab/serving/generation.py
@@ -54,6 +54,13 @@ class GenerationError(Exception):
         self.code = code
 
 
+def public_generation_error(exc: GenerationError) -> str:
+    """Return a stable client-safe message without exposing backend exception text."""
+    if exc.code == "context_length_exceeded":
+        return "the request exceeds the available model context"
+    return "the generation request failed"
+
+
 # --------------------------------------------------------------------------- #
 # Protocol-neutral generation events.
 #

--- a/python/sparklab/serving/openai_api.py
+++ b/python/sparklab/serving/openai_api.py
@@ -34,6 +34,7 @@ from .generation import (
     generate_events,
     generate_full,
     prerender_error,
+    public_generation_error,
     render_messages,
     resolve_sampling,
     submit_generation,
@@ -180,15 +181,15 @@ async def handle_chat_completion(
 
     try:
         spec = chat_request_to_genspec(req, model_sampling)
-    except ValueError as exc:
-        return create_error_response(str(exc))
+    except ValueError:
+        return create_error_response("invalid generation parameters")
 
     if req.stream:
         # Non-stream requests already surface render failures as a clean 400
         # through GenerationError; only the stream path needs the pre-check.
         err = await prerender_error(spec, state)
         if err is not None:
-            return create_error_response(str(err), code=err.code)
+            return create_error_response(public_generation_error(err), code=err.code)
 
     uid = await submit_generation(spec, state)
 
@@ -201,7 +202,7 @@ async def handle_chat_completion(
     try:
         result = await generate_full(uid, spec, state, source="/v1/chat/completions")
     except GenerationError as exc:
-        return create_error_response(str(exc), code=exc.code)
+        return create_error_response(public_generation_error(exc), code=exc.code)
     message: dict[str, Any] = {"role": "assistant", "content": result.content}
     if result.reasoning:
         message["reasoning_content"] = result.reasoning
@@ -260,7 +261,13 @@ async def stream_chat_completion_chunks(
             # Request failed before producing output — emit an error chunk + [DONE] so the
             # client gets a terminal signal instead of a stalled stream.
             yield _sse(
-                {"error": {"message": str(exc), "type": "invalid_request_error", "code": exc.code}}
+                {
+                    "error": {
+                        "message": public_generation_error(exc),
+                        "type": "invalid_request_error",
+                        "code": exc.code,
+                    }
+                }
             )
             break
         if isinstance(ev, ReasoningDelta):
@@ -387,8 +394,8 @@ async def handle_completion(
         return create_error_response(unsupported)
     try:  # surfaces an out-of-range max_tokens as a 400 rather than a 500 from the worker
         _resolve_sampling(req, model_sampling)
-    except ValueError as exc:
-        return create_error_response(str(exc), param="max_tokens")
+    except ValueError:
+        return create_error_response("invalid max_tokens", param="max_tokens")
 
     prompts = [req.prompt] if isinstance(req.prompt, str) else req.prompt
     assert isinstance(prompts, list)
@@ -415,7 +422,7 @@ async def handle_completion(
         finish_reason = "stop"
         async for ack in state.wait_for_ack(uid):
             if getattr(ack, "error", None):
-                return create_error_response(ack.error)
+                return create_error_response("the generation request failed")
             prompt_tokens += ack.prompt_tokens_delta
             completion_tokens += ack.completion_tokens_delta
             cached_tokens += ack.cached_tokens
@@ -442,7 +449,13 @@ async def stream_completion_chunks(uid: int, req: CompletionRequest, state: Any)
     finish_reason = "stop"
     async for ack in state.wait_for_ack(uid):
         if getattr(ack, "error", None):
-            yield _sse({"error": {"message": ack.error, "type": "invalid_request_error", "code": None}})
+            yield _sse({
+                "error": {
+                    "message": "the generation request failed",
+                    "type": "invalid_request_error",
+                    "code": None,
+                }
+            })
             yield b"data: [DONE]\n\n"
             return
         prompt_tokens += ack.prompt_tokens_delta

--- a/python/sparklab/serving/responses_api.py
+++ b/python/sparklab/serving/responses_api.py
@@ -18,6 +18,7 @@ back into their assistant turn as ``reasoning_content``.
 from __future__ import annotations
 
 import json
+import logging
 import time
 import uuid
 from collections.abc import AsyncIterator, Callable
@@ -71,6 +72,7 @@ from .generation import (
     ToolCallStart,
     generate_events,
     generate_full,
+    public_generation_error,
     render_messages,
     resolve_sampling,
     split_tool_lists,
@@ -78,6 +80,8 @@ from .generation import (
     with_keepalive,
 )
 from .request_logger import log_request
+
+logger = logging.getLogger(__name__)
 
 # Seconds of event silence before a keep-alive frame is emitted on the stream.
 # codex's stream-idle timeout (default 300s) only resets on a data-bearing SSE
@@ -157,8 +161,8 @@ async def handle_responses(
             reasoning_parser=getattr(state.config, "reasoning_parser", None),
         )
         uid = await submit_generation(spec, state)
-    except ValueError as exc:
-        return _error_response(400, str(exc))
+    except ValueError:
+        return _error_response(400, "invalid response parameters")
 
     cache_report = getattr(state.config, "enable_cache_report", False)
     if req.stream:
@@ -173,7 +177,7 @@ async def handle_responses(
     try:
         result = await generate_full(uid, spec, state, source="/v1/responses")
     except GenerationError as exc:
-        return _error_response(400, str(exc), exc.code)
+        return _error_response(400, public_generation_error(exc), exc.code)
     response = build_responses_response(result, req, response_id, created, cache_report=cache_report)
     return JSONResponse(content=response.model_dump(mode="json"))
 
@@ -714,11 +718,12 @@ async def responses_stream_generator(
                 # codex reads this code to tell a blown context window from a generic failure.
                 # model_construct because ResponseError.code is a closed Literal in the SDK.
                 error=ResponseError.model_construct(
-                    code=exc.code or "server_error", message=str(exc)
+                    code=exc.code or "server_error", message=public_generation_error(exc)
                 ),
             ),
         ))
     except Exception as exc:  # noqa: BLE001 — never leave the client without a terminal event
+        logger.exception("Responses stream failed")
         for f in close_current():
             yield f
         yield _sse(ResponseFailedEvent(
@@ -726,7 +731,7 @@ async def responses_stream_generator(
             response=_response_obj(
                 response_id, created, req.model, output_items, status="failed",
                 usage=_usage(usage_pt, usage_ct, usage_cached),
-                error=ResponseError(code="server_error", message=str(exc)),
+                error=ResponseError(code="server_error", message="the response stream failed"),
             ),
         ))
 

--- a/tests/serving/test_anthropic_api.py
+++ b/tests/serving/test_anthropic_api.py
@@ -545,9 +545,10 @@ def test_stream_request_error_is_invalid_request_not_internal():
     assert types[-1] == "error", types
     err = events[-1][1]["error"]
     assert err["type"] == "invalid_request_error", err
-    assert "7223" in err["message"]
-    # No error `code` on this wire, so the text is the whole signal — must survive verbatim.
-    assert err["message"].startswith("prompt is too long: 8181 tokens > 7223")
+    assert err["message"] == "the request exceeds the available model context"
+    assert "7223" not in err["message"]
+    # Anthropic has no error `code` on this wire, so preserve the context classification in a
+    # stable message without returning backend limits or exception text verbatim.
 
 
 def test_stream_tool_block_closes_before_following_text():

--- a/tests/serving/test_effort_dialect.py
+++ b/tests/serving/test_effort_dialect.py
@@ -190,7 +190,8 @@ def test_stream_returns_400_when_the_template_rejects_the_render():
     assert isinstance(response, JSONResponse)
     assert response.status_code == 400
     message = json.loads(response.body)["error"]["message"]
-    assert message.startswith("could not encode request")
+    assert message == "the generation request failed"
+    assert "Unexpected reasoning effort" not in message
     assert state.sent is None  # rejected before submission
 
 

--- a/tests/serving/test_responses_api.py
+++ b/tests/serving/test_responses_api.py
@@ -635,7 +635,8 @@ def test_stream_surfaces_generation_error_as_failed():
     assert types[-1] == "response.failed"
     failed = events[-1][1]
     assert failed["response"]["status"] == "failed"
-    assert "chat template rejected" in failed["response"]["error"]["message"]
+    assert failed["response"]["error"]["message"] == "the generation request failed"
+    assert "chat template rejected" not in failed["response"]["error"]["message"]
     # No specific class on this failure, so the generic one stands.
     assert failed["response"]["error"]["code"] == "server_error"
 
@@ -673,7 +674,8 @@ def test_route_nonstream_error_returns_400():
     client = _client(_ErrState([]))
     r = client.post("/v1/responses", json={"model": "gpt-x", "input": "hi"})
     assert r.status_code == 400, r.text
-    assert "too long" in r.json()["error"]["message"]
+    assert r.json()["error"]["message"] == "the generation request failed"
+    assert "too long" not in r.json()["error"]["message"]
 
 
 def test_route_stream_error_emits_failed_event():


### PR DESCRIPTION
## Summary\n\n- replace backend exception text in daemon and inference API responses with stable client-safe messages\n- preserve useful context classification through stable error codes/messages\n- retain detailed failures in server-side logs\n- cover non-streaming and streaming OpenAI, Responses, and Anthropic paths\n\n## Validation\n\n- 142 focused daemon/API tests passed\n- 794 broader CPU tests passed (plus 1 skipped)\n- 16 effort-dialect tests passed\n- the local source-only run cannot load the separately built `_pinned_tensor` extension for one model-loader test; hosted PR CI installs its own clean environment