### PR TITLE
Add and benchmark GLM-5.3 NVFP4 on GB10

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ a SparkLab support claim.
       <td>753B total / 40B active</td>
       <td>NVFP4</td>
       <td>Experimental</td>
-      <td align="right">—</td>
-      <td align="right">—</td>
+      <td align="right">0.81</td>
+      <td align="right">2.530</td>
       <td><a href="docs/models/glm-5.3.md">Instructions</a></td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ a SparkLab support claim.
       <td><a href="docs/models/glm-5.2.md">Instructions</a></td>
     </tr>
     <tr>
+      <td><a href="https://huggingface.co/Inferact/GLM-5.3-NVFP4">GLM-5.3</a></td>
+      <td>753B total / 40B active</td>
+      <td>NVFP4</td>
+      <td>Experimental</td>
+      <td align="right">—</td>
+      <td align="right">—</td>
+      <td><a href="docs/models/glm-5.3.md">Instructions</a></td>
+    </tr>
+    <tr>
       <td><a href="https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW">Kimi K3</a></td>
       <td>2.8T total / 16 of 896 experts</td>
       <td>ModelOpt NVFP4/FP8 · FTW</td>

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-GLM53-RESEARCH-001",
+  "status": "measured",
+  "recipe": {
+    "slug": "glm-5.3",
+    "recipe_version": "0.1.0",
+    "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8"
+  },
+  "engine": {
+    "git_revision": "039bc348f30608b08103d877c6d2a225617db136"
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "os": "Ubuntu NVIDIA kernel 6.17.0-1014-nvidia",
+    "cuda": "13.0"
+  },
+  "checkpoint": {
+    "full_model": true,
+    "format": "ftw-nvfp4-b12x",
+    "fingerprint": "a0e799b03bceb4bf",
+    "bytes": 428713099264,
+    "source_bytes": 464867183339
+  },
+  "metrics": {
+    "decode_tokens_per_second": 0.8126153861203544,
+    "decode_milliseconds_per_token": 1230.594469511918,
+    "warm_ttft_seconds": 2.530337787233293,
+    "latency_p50_milliseconds": 1233.3040283992887,
+    "latency_p99_milliseconds": 1447.3086688667536,
+    "expert_cache_miss_rate_percent": 75.49281045751634,
+    "physical_io_gib": 2294.9736328125,
+    "minimum_mem_available_gib": 71.84626007080078,
+    "swap_growth_bytes": 0
+  },
+  "stability": {
+    "requested_completion_tokens": 256,
+    "returned_completion_tokens": 256,
+    "timed_decode_steps": 255,
+    "swap_in_pages": 7882,
+    "swap_out_pages": 0,
+    "swap_growth_bytes": 0,
+    "oom_count": 0
+  },
+  "validation": {
+    "output_correctness": false,
+    "output_correctness_evaluated": false,
+    "output_hash_algorithm": "sha1-prefix",
+    "output_hash": "bdbf1a17f134",
+    "output_hash_probe_tokens": 256,
+    "matched_native_control": false,
+    "memory_bounded": true,
+    "nvme_behavior": "bounded",
+    "reasoning_parser": false,
+    "tool_parser": false,
+    "coding_agent_task": false
+  },
+  "admission": {
+    "tier": "research",
+    "passed": false,
+    "reasons": [
+      "The 256-token output hit the length cap before stating the expected answer, so output correctness is not established.",
+      "The host had pre-existing swap use and read 7,882 swap-in pages during the measured request, although it wrote no pages out.",
+      "Reasoning parser, tool parser, and coding-agent gates were not run."
+    ]
+  },
+  "source_report": "exps/exp_glm5_3_full_gb10.md",
+  "limitations": [
+    "This is a 54-input-token AIME tuning and stability probe, not the separate GB10-INTERACTIVE-001 benchmark.",
+    "The prepared artifact preserves routed experts as NVFP4 but converts large resident BF16 projections to per-row W8A16 FP8.",
+    "No context, endurance, API, reasoning-parser, tool-parser, coding-agent, or quality certification is claimed."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,7 +38,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 4.98 | 5.379 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.2](https://huggingface.co/nvidia/GLM-5.2-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.2` | Experimental fallback | 0.80 | 2.570 |
-| [GLM-5.3](https://huggingface.co/Inferact/GLM-5.3-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.3` | Experimental fallback | — | — |
+| [GLM-5.3](https://huggingface.co/Inferact/GLM-5.3-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
 Model links point to the selected source or published FTW checkpoints. Qwen3.6 and Kimi K3
@@ -85,9 +85,12 @@ rungs, so correctness and cross-rung determinism are not established. See the
 [full experiment](../exps/exp_kimik3_gb10.md).
 
 GLM-5.3 uses the GLM-5.2 runtime recipe because the pinned checkpoint declares the same
-`glm_moe_dsa` architecture and execution dimensions. It remains unmeasured: the GLM-5.2
-performance result does not transfer to a different checkpoint, and no complete-checkpoint
-GB10 result is attached yet. See the [run instructions](models/glm-5.3.md).
+`glm_moe_dsa` architecture and execution dimensions. Its own complete-checkpoint probe
+measured 0.813 tok/s and 2.530 s warm TTFT with no OOM or swap-out growth. The 256-token
+output hit its length cap before stating the expected answer, so correctness is not
+established and the recipe remains Experimental. See the
+[versioned evidence](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json) and
+[full experiment](../exps/exp_glm5_3_full_gb10.md).
 
 GLM-5.2 is listed in Research because its selected GB10 experiment sustained 0.802 tok/s,
 below the 5 tok/s Frontier threshold. The displayed 2.57 s TTFT and throughput are measured,

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,6 +38,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 4.98 | 5.379 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.2](https://huggingface.co/nvidia/GLM-5.2-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.2` | Experimental fallback | 0.80 | 2.570 |
+| [GLM-5.3](https://huggingface.co/Inferact/GLM-5.3-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.3` | Experimental fallback | — | — |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
 Model links point to the selected source or published FTW checkpoints. Qwen3.6 and Kimi K3
@@ -82,6 +83,11 @@ OOM or swap-out. It stopped before a final AIME answer and diverged from shorter
 rungs, so correctness and cross-rung determinism are not established. See the
 [versioned evidence](../benchmarks/gb10/results/GB10-KIMI-001.json) and
 [full experiment](../exps/exp_kimik3_gb10.md).
+
+GLM-5.3 uses the GLM-5.2 runtime recipe because the pinned checkpoint declares the same
+`glm_moe_dsa` architecture and execution dimensions. It remains unmeasured: the GLM-5.2
+performance result does not transfer to a different checkpoint, and no complete-checkpoint
+GB10 result is attached yet. See the [run instructions](models/glm-5.3.md).
 
 GLM-5.2 is listed in Research because its selected GB10 experiment sustained 0.802 tok/s,
 below the 5 tok/s Frontier threshold. The displayed 2.57 s TTFT and throughput are measured,

--- a/docs/models/glm-5.3.md
+++ b/docs/models/glm-5.3.md
@@ -5,9 +5,10 @@ NVMe-backed inference. The pinned Inferact checkpoint declares the same
 `glm_moe_dsa` architecture and runtime dimensions as GLM-5.2, so SparkLab uses
 the existing GLM-5.2 execution path.
 
-This is an architecture-compatibility recipe, not a performance result. GLM-5.2
-benchmark evidence does not transfer to the GLM-5.3 checkpoint, and GLM-5.3 has
-not yet completed a full GB10 load or generation probe.
+The complete checkpoint has been measured on one NVIDIA GB10 at 0.813 decode
+tok/s and 2.530 seconds warm TTFT. The selected output reached its 256-token cap
+before stating the expected final answer, so this remains a bounded performance
+result rather than a correctness or certification claim.
 
 ## Install SparkLab
 
@@ -22,8 +23,8 @@ sparklab --version
 ## Prepare
 
 Use fast local NVMe storage. The recipe downloads the immutable source revision
-and prepares FTW locally. Budget about 1.03 TB of free space; the prepared size
-is currently estimated from the same-shape GLM-5.2 conversion.
+and prepares FTW locally. Budget about 1.03 TB of free space; the measured b12x
+artifact is 428,713,099,264 bytes.
 
 ```bash
 sparklab doctor --storage-path /path/to/models
@@ -46,6 +47,6 @@ curl http://127.0.0.1:1919/health
 curl http://127.0.0.1:1919/v1/models
 ```
 
-Treat the first run as validation and capture a versioned benchmark result before
-making performance or reliability claims. See the [quick start](../quickstart.md)
-for more detail.
+Expect Research-tier throughput. See the
+[GLM-5.3 experiment](../../exps/exp_glm5_3_full_gb10.md) and the
+[quick start](../quickstart.md) for more detail.

--- a/docs/models/glm-5.3.md
+++ b/docs/models/glm-5.3.md
@@ -1,0 +1,51 @@
+# Run GLM-5.3
+
+GLM-5.3 is an Experimental Research-tier NVFP4 recipe for complete-model,
+NVMe-backed inference. The pinned Inferact checkpoint declares the same
+`glm_moe_dsa` architecture and runtime dimensions as GLM-5.2, so SparkLab uses
+the existing GLM-5.2 execution path.
+
+This is an architecture-compatibility recipe, not a performance result. GLM-5.2
+benchmark evidence does not transfer to the GLM-5.3 checkpoint, and GLM-5.3 has
+not yet completed a full GB10 load or generation probe.
+
+## Install SparkLab
+
+Follow the [full installation guide](../install.md). On NVIDIA DGX Spark:
+
+```bash
+uv venv && source .venv/bin/activate
+uv pip install "sparklab[accel]"
+sparklab --version
+```
+
+## Prepare
+
+Use fast local NVMe storage. The recipe downloads the immutable source revision
+and prepares FTW locally. Budget about 1.03 TB of free space; the prepared size
+is currently estimated from the same-shape GLM-5.2 conversion.
+
+```bash
+sparklab doctor --storage-path /path/to/models
+sparklab plan glm-5.3 --root /path/to/models --prepare
+sparklab pull glm-5.3 --root /path/to/models --prepare
+```
+
+Review the exact storage and runtime admission output from `plan` before continuing.
+
+## Run
+
+```bash
+sparklab run glm-5.3 --root /path/to/models
+```
+
+Wait for the API to listen on `127.0.0.1:1919`, then verify it:
+
+```bash
+curl http://127.0.0.1:1919/health
+curl http://127.0.0.1:1919/v1/models
+```
+
+Treat the first run as validation and capture a versioned benchmark result before
+making performance or reliability claims. See the [quick start](../quickstart.md)
+for more detail.

--- a/exps/exp_glm5_3_full_gb10.md
+++ b/exps/exp_glm5_3_full_gb10.md
@@ -1,0 +1,117 @@
+# GLM-5.3 NVFP4 on NVIDIA GB10
+
+Last updated: 2026-08-29
+
+## Result
+
+The complete pinned `Inferact/GLM-5.3-NVFP4` checkpoint was downloaded,
+converted to SparkLab's FlashInfer b12x FTW layout, and served through the
+OpenAI-compatible API on one NVIDIA GB10. The selected 256-token request decoded
+at **0.813 tok/s** with **2.530 s warm TTFT**. It completed without an OOM or
+swap-out growth.
+
+This is successful complete-checkpoint loading and a bounded performance result,
+not a correctness or certification result. The output hit its 256-token limit
+after deriving the correct divisibility reduction and first valid base, but
+before stating the expected final answer `70`. Compact evidence:
+[`GB10-GLM53-RESEARCH-001`](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json).
+
+## Artifact and system
+
+| Component | Value |
+|---|---|
+| Source | `Inferact/GLM-5.3-NVFP4` |
+| Revision | `ce67b36f3669192b5bb233819f0fda6c8a9837f8` |
+| Source size | 464,867,183,339 bytes |
+| Prepared artifact | FTW NVFP4 b12x, 428,713,099,264 bytes |
+| FTW layout | 77 shards, 2,043 tensor entries, fingerprint `a0e799b03bceb4bf` |
+| Engine revision | `039bc348f30608b08103d877c6d2a225617db136`, clean tracked worktree |
+| Hardware | NVIDIA GB10, SM121, 128 GB unified memory, NVMe |
+| Software | Linux 6.17.0-1014-nvidia; CUDA 13.0; PyTorch 2.11.0+cu130; Triton 3.6.0 |
+
+The checkpoint declares `GlmMoeDsaForCausalLM` with the same execution geometry
+as GLM-5.2: 78 transformer layers, 75 MoE layers, 256 routed experts, top-8
+routing, hidden size 6,144, expert intermediate size 2,048, MLA latent KV, and
+DSA sparse attention. SparkLab therefore reused the established GLM-5.2 runtime
+path while keeping checkpoint-specific evidence separate.
+
+## Conversion
+
+The pinned snapshot finished downloading at 16:50 local time. Conversion used
+one-layer bounded expert staging and completed in about 16 minutes:
+
+```bash
+CUDA_HOME=/usr/local/cuda \
+SPARKLAB_CONVERT_PROGRESS=1 \
+sparklab checkpoint \
+  --model /path/to/glm-5.3/source/ce67b36f3669 \
+  --out /path/to/glm-5.3/prepared/0.1.0-b12x \
+  --dtype bfloat16 \
+  --moe-backend offload \
+  --nvfp4-backend flashinfer \
+  --shard-gib 8 \
+  --device cuda:0
+```
+
+Routed experts remain in the checkpoint's NVFP4 precision and are repacked for
+the SM12x FlashInfer b12x backend. The GLM resident-weight policy converts large
+BF16 attention, dense-MLP, and output projections to per-row W8A16 FP8.
+
+## Method
+
+Both runs used AIME-25 problem 0, batch size one, greedy sampling, one warm
+request, and one measured request. The configuration exactly follows the
+selected GLM-5.2 b12x recipe: 675 layer-LRU expert slots, 20 disk readers, no
+pageable host expert LRU, one staging layer, sparse prefill through 256 tokens,
+shared-expert overlap, a 2,048-token KV allocation, and eager decode.
+
+```bash
+SPARKLAB_DISK_READ_WORKERS=20 \
+python benchmarks/bench_decode_moe.py \
+  --model /path/to/glm-5.3/prepared/0.1.0-b12x \
+  --recipe glm-5.3 \
+  --backend offload --storage disk --nvfp4-backend flashinfer \
+  --host-cache-gb 0 --cache 675 --cache-policy layer_lru \
+  --decode 256 --num-tokens 2048 --mem-ratio 0.90 \
+  --disable-prefill-overlap --prefill-sparse-max-tokens 256 \
+  --shared-expert-overlap --collect-moe-stats \
+  --greedy --no-graph --include-output --server-timeout 1200
+```
+
+## Measurements
+
+| Requested decode | tok/s | ms/token | Warm TTFT | p50 / p99 | Miss rate | Physical I/O | Output hash |
+|---:|---:|---:|---:|---:|---:|---:|---|
+| 64 | 0.832 | 1,202.5 | 2.962 s | 1,223.8 / 1,420.7 ms | 74.47% | 568.03 GiB | `e19ef21a678b` |
+| 256 | 0.813 | 1,230.6 | 2.530 s | 1,233.3 / 1,447.3 ms | 75.49% | 2,294.97 GiB | `bdbf1a17f134` |
+
+The selected request returned 256 completion tokens and 255 timed decode steps.
+Minimum `MemAvailable` was 71.85 GiB; board power averaged 16.64 W and peaked at
+17.77 W; GPU and NVMe temperature peaks were 47 C and 52.85 C. The measured
+request read 7,882 pages from pre-existing swap but wrote zero pages out, had
+zero scoped cgroup OOM kills, and contained no OOM markers.
+
+## Output validation
+
+The 64-token output ended after converting the two base-`b` numbers. The
+256-token output correctly reduced the condition to `(b + 7) | 56`, selected
+divisors 28 and 56, and derived `b = 21`; it ended while beginning the second
+case. Because it did not state both bases or the requested sum `70`, SparkLab
+records correctness as not evaluated rather than inferring a pass from the
+partial reasoning. No native GLM-5.3 control hash was produced.
+
+## Verdict
+
+- Complete source acquisition, FTW conversion, model loading, DSA execution,
+  sparse prefill, and 256-token decoding succeeded.
+- The measured 0.813 tok/s clears the experiment's 0.5 tok/s usability floor
+  but remains far below the 5 tok/s Frontier threshold.
+- The request had no swap-out growth, but the machine began with roughly
+  3.8 GiB of swap in use and performed swap-in reads, so this is not a clean
+  zero-swap certification environment.
+- Correctness, context, endurance, API/parser, quality, and coding-agent gates
+  remain outstanding. The recipe remains Experimental Research fallback.
+
+Raw local results are
+`$HOME/results/glm5.3-gb10/selected-b12x-cache675-decode64.jsonl` and
+`$HOME/results/glm5.3-gb10/selected-b12x-cache675-decode256.jsonl`.

--- a/python/sparklab/kernels/aot_models.py
+++ b/python/sparklab/kernels/aot_models.py
@@ -252,6 +252,7 @@ SUPPORTED_MODELS: tuple[AotModel, ...] = (
         top_k=8,
         moe_intermediate_size=2048,
         expert_formats=_NVFP4_FORMATS,
+        aliases=("Inferact/GLM-5.3-NVFP4",),
     ),
     AotModel(
         # MiniMaxAI/MiniMax-M2.5 ships block-fp8, which has no expert-bank

--- a/python/sparklab/models/glm_moe_dsa/weight.py
+++ b/python/sparklab/models/glm_moe_dsa/weight.py
@@ -1,4 +1,4 @@
-"""Weight loading for GLM-5.2 (``glm_moe_dsa``).
+"""Weight loading for GLM-5.x DSA models (``glm_moe_dsa``).
 
 Resident (non routed-expert) weights are bf16 in the checkpoint. What this loader
 yields follows the quant modes RESOLVED IN ``parse_config`` (``ModelConfig.attn_quant``
@@ -87,7 +87,7 @@ def iter_weights(
     include_non_moe: bool,
 ) -> Iterator[tuple[str, torch.Tensor]]:
     assert not include_moe_experts, (
-        "GLM-5.2 stores routed experts as NVFP4 and only supports the offload backend; "
+        "GLM MoE DSA checkpoints store routed experts as NVFP4 and only support the offload backend; "
         "experts are loaded into the offload cache via load_nvfp4_expert_sources()."
     )
     assert include_non_moe
@@ -105,14 +105,14 @@ def iter_weights(
         from sparklab.utils import init_logger
 
         init_logger(__name__).info(
-            f"GLM-5.2 resident quant: attn={config.attn_quant} dense={config.dense_quant} "
+            f"GLM MoE DSA resident quant: attn={config.attn_quant} dense={config.dense_quant} "
             f"lm_head={config.lm_head_quant} (SPARKLAB_GLM_ATTN_FP8/SPARKLAB_GLM_MLP_FP8; "
             "an FTW conversion records these choices implicitly -- serve with the same flags)"
         )
     try:
         for layer in tqdm(
             range(config.num_layers),
-            desc="Loading GLM-5.2 dense weights",
+            desc="Loading GLM MoE DSA dense weights",
             disable=not primary,
         ):
             a = f"model.layers.{layer}.self_attn"

--- a/python/sparklab/recipes/glm-5.3.json
+++ b/python/sparklab/recipes/glm-5.3.json
@@ -15,11 +15,18 @@
   "portfolio_role": "fallback",
   "deployment": {"backend": "native", "backend_api": "1.0", "source_format": "safetensors", "runtime_format": "ftw-nvfp4", "quantization": "nvfp4", "execution_policy": "nvme-moe", "backend_options": {}},
   "profile": "research",
-  "description": "Unmeasured GLM-5.2-compatible Research fallback for complete-model NVMe inference.",
-  "evidence": [],
+  "description": "Measured GLM-5.2-compatible Research fallback for complete-model NVMe inference.",
+  "performance": {
+    "decode_tokens_per_second": 0.8126153861203544,
+    "warm_ttft_seconds": 2.530337787233293,
+    "evidence": "GB10-GLM53-RESEARCH-001",
+    "note": "Selected 256-token b12x trial; no OOM or swap-out growth, but the length-capped output did not establish correctness."
+  },
+  "evidence": ["GB10-GLM53-RESEARCH-001"],
   "limitations": [
-    "The pinned checkpoint matches GLM-5.2's glm_moe_dsa architecture and runtime geometry, but complete-checkpoint loading and generation have not yet been validated on GB10.",
-    "The prepared size is a planning estimate inherited from the same-shape GLM-5.2 recipe; verify the plan before conversion.",
-    "GLM-5.2 performance evidence does not transfer to this checkpoint; no GLM-5.3 latency, throughput, correctness, context, endurance, API, parser, or coding-agent result is claimed."
+    "The 256-token output hit the length cap before stating the expected final answer, so output correctness is not established.",
+    "The measured request had zero swap-out growth but began with pre-existing swap use and read 7,882 swap-in pages.",
+    "The prepared artifact preserves routed experts as NVFP4 but converts large resident BF16 projections to per-row W8A16 FP8.",
+    "No context, endurance, API, reasoning-parser, tool-parser, coding-agent, or quality certification is claimed."
   ]
 }

--- a/python/sparklab/recipes/glm-5.3.json
+++ b/python/sparklab/recipes/glm-5.3.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "2.0",
+  "recipe_version": "0.1.0",
+  "slug": "glm-5.3",
+  "name": "GLM-5.3",
+  "model": "Inferact/GLM-5.3-NVFP4",
+  "parameters": "753B total / 40B active",
+  "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+  "source_bytes": 464867183339,
+  "prepared_bytes": 428713099264,
+  "minimum_free_bytes": 1031019236075,
+  "intended_tier": "research",
+  "status": "experimental",
+  "implementation": "available",
+  "portfolio_role": "fallback",
+  "deployment": {"backend": "native", "backend_api": "1.0", "source_format": "safetensors", "runtime_format": "ftw-nvfp4", "quantization": "nvfp4", "execution_policy": "nvme-moe", "backend_options": {}},
+  "profile": "research",
+  "description": "Unmeasured GLM-5.2-compatible Research fallback for complete-model NVMe inference.",
+  "evidence": [],
+  "limitations": [
+    "The pinned checkpoint matches GLM-5.2's glm_moe_dsa architecture and runtime geometry, but complete-checkpoint loading and generation have not yet been validated on GB10.",
+    "The prepared size is a planning estimate inherited from the same-shape GLM-5.2 recipe; verify the plan before conversion.",
+    "GLM-5.2 performance evidence does not transfer to this checkpoint; no GLM-5.3 latency, throughput, correctness, context, endurance, API, parser, or coding-agent result is claimed."
+  ]
+}

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -36,6 +36,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert get_recipe("qwen3.6-35b-a3b").name == "Qwen3.6 35B A3B"
     assert get_recipe("glm-5.2").name == "GLM-5.2"
     assert get_recipe("glm-5.2").intended_tier == "research"
+    assert get_recipe("glm-5.3").model == "Inferact/GLM-5.3-NVFP4"
     assert {
         recipe.slug: recipe.parameters for recipe in load_catalog()
     } == {
@@ -44,6 +45,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
         "glm-5.3-flash": "320B total / 18B active",
         "qwen3.8-flash-next": "125B LM + 55B aux / 6B active",
         "glm-5.2": "753B total / 40B active",
+        "glm-5.3": "753B total / 40B active",
         "kimi-k3": "2.8T total / 16 of 896 experts",
     }
     assert get_recipe("deepseek-v4").status == "preview"
@@ -124,7 +126,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     }
     assert {
         item.slug for item in select_recipes(load_catalog(), portfolio_role="fallback")
-    } == {"glm-5.2"}
+    } == {"glm-5.2", "glm-5.3"}
 
 
 def test_next_model_recipes_are_immutable_and_capacity_plannable():
@@ -132,12 +134,14 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     glm = get_recipe("glm-5.3-flash")
     kimi = get_recipe("kimi-k3")
     glm52 = get_recipe("glm-5.2")
+    glm53 = get_recipe("glm-5.3")
     deepseek = get_recipe("deepseek-v4")
     assert qwen.revision == "103a7608316173ca6edd49929544244de7ffda70"
     assert glm.recipe_version == "0.3.2"
     assert glm.revision == "9eaeadaf026871a90640e32c0604f6ab0b2d641d"
     assert kimi.revision == "f8c5234a0a880bcc6cbf779a315e7ee2f405b812"
     assert glm52.revision == "aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa"
+    assert glm53.revision == "ce67b36f3669192b5bb233819f0fda6c8a9837f8"
     assert deepseek.revision == "7872f01b1d1fe23eabc4c98b48bffcef5a386062"
     assert qwen.source_bytes == 182838060595
     assert qwen.expert_quantization == "nvfp4"
@@ -158,6 +162,11 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert kimi.source_bytes == 1610038482254
     assert kimi.prepared_bytes == 1610936311808
     assert glm52.source_bytes == 464874323992
+    assert glm53.source_bytes == 464867183339
+    assert glm53.deployment.quantization == "nvfp4"
+    assert glm53.deployment.runtime_format == "ftw-nvfp4"
+    assert glm53.performance is None
+    assert glm53.evidence == ()
     assert deepseek.source_bytes == 166878536440
     assert deepseek.prepared_bytes == 157460918272
     assert qwen.execution_policy == glm.execution_policy == "nvme-moe"
@@ -165,6 +174,7 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert glm.minimum_free_bytes > glm.source_bytes + glm.prepared_bytes
     assert kimi.minimum_free_bytes > kimi.source_bytes + kimi.prepared_bytes
     assert glm52.minimum_free_bytes > glm52.source_bytes + glm52.prepared_bytes
+    assert glm53.minimum_free_bytes > glm53.source_bytes + glm53.prepared_bytes
     assert deepseek.minimum_free_bytes > deepseek.source_bytes + deepseek.prepared_bytes
 
 

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -165,8 +165,11 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert glm53.source_bytes == 464867183339
     assert glm53.deployment.quantization == "nvfp4"
     assert glm53.deployment.runtime_format == "ftw-nvfp4"
-    assert glm53.performance is None
-    assert glm53.evidence == ()
+    assert glm53.performance.decode_tokens_per_second == pytest.approx(
+        0.8126153861203544
+    )
+    assert glm53.performance.warm_ttft_seconds == pytest.approx(2.530337787233293)
+    assert glm53.evidence == ("GB10-GLM53-RESEARCH-001",)
     assert deepseek.source_bytes == 166878536440
     assert deepseek.prepared_bytes == 157460918272
     assert qwen.execution_policy == glm.execution_policy == "nvme-moe"
@@ -265,6 +268,35 @@ def test_glm52_recipe_points_to_measured_failed_research_evidence():
     evaluation = evaluate_tier(recipe, result, "research")
     assert not evaluation.passed
     assert any("reasoning_parser" in reason for reason in evaluation.reasons)
+
+
+def test_glm53_full_recipe_points_to_measured_failed_research_evidence():
+    from sparklab.certification import evaluate_tier
+
+    recipe = get_recipe("glm-5.3")
+    assert recipe.performance.evidence == "GB10-GLM53-RESEARCH-001"
+    assert recipe.performance.evidence in recipe.evidence
+    root = Path(__file__).resolve().parents[2]
+    result = json.loads(
+        (root / "benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json").read_text()
+    )
+    assert result["result_id"] == recipe.performance.evidence
+    assert result["status"] == "measured"
+    assert result["recipe"]["recipe_version"] == recipe.recipe_version
+    assert result["recipe"]["revision"] == recipe.revision
+    assert result["checkpoint"]["fingerprint"] == "a0e799b03bceb4bf"
+    assert result["checkpoint"]["bytes"] == recipe.prepared_bytes
+    assert result["metrics"]["decode_tokens_per_second"] == pytest.approx(
+        recipe.performance.decode_tokens_per_second
+    )
+    assert result["metrics"]["warm_ttft_seconds"] == pytest.approx(
+        recipe.performance.warm_ttft_seconds
+    )
+    assert result["stability"]["oom_count"] == 0
+    assert result["stability"]["swap_out_pages"] == 0
+    assert result["validation"]["output_correctness_evaluated"] is False
+    evaluation = evaluate_tier(recipe, result, "research")
+    assert not evaluation.passed
 
 
 def test_historical_qwen_nvfp4_evidence_does_not_transfer_to_new_checkpoint():

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -22,7 +22,11 @@ def test_models_json_exposes_tier_and_admission_status(capsys):
     assert cli.main(["models", "--tier", "research", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["product"] == "SparkLab" and payload["platform"] == "gb10"
-    assert [recipe["slug"] for recipe in payload["recipes"]] == ["glm-5.2", "kimi-k3"]
+    assert [recipe["slug"] for recipe in payload["recipes"]] == [
+        "glm-5.2",
+        "glm-5.3",
+        "kimi-k3",
+    ]
     assert all(recipe["status"] == "experimental" for recipe in payload["recipes"])
     assert payload["recipes"][0]["parameters"] == "753B total / 40B active"
 
@@ -66,6 +70,9 @@ def test_models_research_table_includes_measured_glm52_fallback(capsys):
     glm52_row = next(line for line in output.splitlines() if line.startswith("GLM-5.2"))
     assert "NVFP4" in glm52_row and "EXPERIMENTAL" in glm52_row
     assert glm52_row.split()[-2:] == ["0.80", "2.570"]
+    glm53_row = next(line for line in output.splitlines() if line.startswith("GLM-5.3"))
+    assert "NVFP4" in glm53_row and "EXPERIMENTAL" in glm53_row
+    assert glm53_row.split()[-2:] == ["—", "—"]
     assert "Kimi K3" in output
 
 

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -72,7 +72,7 @@ def test_models_research_table_includes_measured_glm52_fallback(capsys):
     assert glm52_row.split()[-2:] == ["0.80", "2.570"]
     glm53_row = next(line for line in output.splitlines() if line.startswith("GLM-5.3"))
     assert "NVFP4" in glm53_row and "EXPERIMENTAL" in glm53_row
-    assert glm53_row.split()[-2:] == ["—", "—"]
+    assert glm53_row.split()[-2:] == ["0.81", "2.530"]
     assert "Kimi K3" in output
 
 


### PR DESCRIPTION
## Summary
- add the pinned `Inferact/GLM-5.3-NVFP4` Research recipe immediately after GLM-5.2
- reuse the matching GLM MoE DSA runtime and FlashInfer b12x geometry
- report the clean full-checkpoint GB10 probe at 0.813 tok/s and 2.530 s warm TTFT
- add compact evidence and a full experiment report without overclaiming correctness or certification

## Result
- full source: 464,867,183,339 bytes
- FTW b12x: 428,713,099,264 bytes; fingerprint `a0e799b03bceb4bf`
- selected 256-token probe: 0.812615 tok/s; 2.530338 s warm TTFT
- zero OOM; zero swap-out pages; 75.49% expert-cache miss rate
- correctness remains unestablished because output reached the length cap before stating answer `70`

## Validation
- `uv run pytest -q tests/sparklab tests/models/test_glm_dsa.py tests/models/test_muse_glimmer.py` (87 passed)
- catalog evidence evaluator rejects Research admission for the documented correctness/parser gates
- changed Markdown relative links resolve
- `git diff --check`
