### PR TITLE
perf: graph Qwen3.8 dense QSA decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ a SparkLab support claim.
       <td>125B LM + 55B auxiliary / 6B active</td>
       <td>NVFP4 · FTW</td>
       <td>Experimental</td>
-      <td align="right">16.06</td>
-      <td align="right">0.434</td>
+      <td align="right">16.61</td>
+      <td align="right">0.403</td>
       <td><a href="docs/models/qwen3.8-flash-next.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-002.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-002.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-NVFP4-OPT-002",
+  "status": "measured",
+  "recipe": {
+    "slug": "qwen3.8-flash-next",
+    "recipe_version": "0.7.0",
+    "revision": "103a7608316173ca6edd49929544244de7ffda70"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "12cfbbe66b84ef743cc819cd8e42484e6105445e",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "os": "Linux 6.17.0-1014-nvidia",
+    "driver": "580.126.09",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "repository": "Inferact/Qwen3.8-Flash-Next-NVFP4",
+    "revision": "103a7608316173ca6edd49929544244de7ffda70",
+    "full_model": true,
+    "format": "ftw-nvfp4",
+    "quantization": "nvfp4",
+    "fingerprint": "47e11ddb878adf4c",
+    "bytes": 180433108992,
+    "ftw_bytes": 78032617472,
+    "external_ngram_bytes": 102400491520
+  },
+  "workload": {
+    "name": "AIME-25 problem 0 fixed decode probe",
+    "batch_size": 1,
+    "sampling": "greedy",
+    "prompt_tokens": 96,
+    "requested_completion_tokens": 64,
+    "returned_completion_tokens": 64,
+    "timed_decode_steps": 63,
+    "warmup_requests": 1,
+    "measured_requests": 1,
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "expert_storage": "disk",
+    "expert_cache_slots": 24576,
+    "expert_preload": "immutable-full",
+    "expert_preload_seconds": 35.26,
+    "host_cache_gib": 0.0,
+    "disk_read_workers": 16,
+    "nvfp4_backend": "triton",
+    "attention_backend": "qsa",
+    "qsa_fused_selection": true,
+    "cuda_graph": true,
+    "cuda_graph_batch_size": 1,
+    "dense_qsa_visible_token_limit": 2051,
+    "sparse_qsa_fallback": "eager",
+    "kv_tokens": 131072,
+    "page_size": 16,
+    "cache_type": "naive"
+  },
+  "metrics": {
+    "decode_tokens_per_second": 16.607355237469154,
+    "decode_milliseconds_per_token": 60.21428371350917,
+    "warm_ttft_seconds": 0.40297515969723463,
+    "latency_p50_milliseconds": 59.59520395845175,
+    "latency_p99_milliseconds": 64.51890338212252,
+    "device_allocation_gib": 76.427734375,
+    "minimum_mem_available_gib": 23.436580657958984,
+    "power_watts_average": 40.85,
+    "power_watts_peak": 47.63,
+    "gpu_temperature_celsius_peak": 50.0,
+    "dense_ab_graph_tokens_per_second": 16.169252871711507,
+    "dense_ab_eager_tokens_per_second": 15.515170953714739,
+    "dense_ab_improvement_percent": 4.2157570802670685,
+    "expert_cache_miss_rate_percent": 0.0,
+    "expert_disk_read_operations": 0,
+    "swap_in_pages": 0,
+    "swap_out_pages": 0
+  },
+  "validation": {
+    "checkpoint_checksum_verified": true,
+    "complete_checkpoint_loaded": true,
+    "api_stream_completed": true,
+    "output_hash_algorithm": "sha1-prefix",
+    "output_hash": "c1c0854490c6",
+    "output_hash_matches_eager_fixed_probe": true,
+    "output_correctness": true,
+    "reasoning_parser": true,
+    "tool_parser": true,
+    "coding_agent_task": true,
+    "memory_bounded": true,
+    "nvme_behavior": "bounded",
+    "context_tokens": 65536,
+    "context_gate_run": true,
+    "dense_sparse_transition_context_tokens": 2048,
+    "dense_sparse_transition_recall": "SPARK-7319",
+    "dense_sparse_transition_gate_run": true,
+    "capability_gate_run": true,
+    "quality_gate_run": true,
+    "endurance_gate_run": false
+  },
+  "stability": {
+    "duration_minutes": 9.60445735817775,
+    "oom_count": 0,
+    "service_restarts": 0,
+    "swap_growth_bytes": 0,
+    "parser_failures": 0,
+    "uninterrupted": true
+  },
+  "admission": {
+    "tier": "frontier",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "The graph-enabled fixed probe measured 16.607 tok/s and 0.403 s warm TTFT, passing the Frontier performance thresholds with the established exact output hash.",
+      "An exact 2,048-token probe crossed from captured dense QSA to eager sparse QSA and returned the planted key with zero expert disk reads, swap growth, or OOMs.",
+      "The 64K context, parser, coding-agent, and five-problem quality gates are inherited regression evidence from recipe 0.6.0; a clean-revision 60-minute endurance run remains outstanding."
+    ]
+  },
+  "source": {
+    "summary": "exps/exp_qwen3_8_nvfp4_gb10.md",
+    "raw_artifact": "$HOME/results/qwen3.8-gb10/qwen38-cudagraph-fixed-decode64-20260830.jsonl",
+    "dense_control_artifact": "$HOME/results/qwen3.8-gb10/qwen38-cudagraph-control-eager-decode512-20260830.jsonl",
+    "dense_graph_artifact": "$HOME/results/qwen3.8-gb10/qwen38-cudagraph-optimized-decode512-20260830.jsonl",
+    "transition_artifact": "$HOME/results/qwen3.8-gb10/qwen38-cudagraph-transition-context2048-fixed-20260830.json",
+    "prior_evidence": "GB10-QWEN38-NVFP4-OPT-001"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "CUDA-graph replay is limited to batch-one exact dense QSA through 2,051 visible tokens; sparse QSA remains eager.",
+    "The 512-token graph and eager runs selected different but semantically equivalent wording at generated token 342; the fixed 64-token acceptance probe retained the established exact hash.",
+    "Broader 64K context, capability, and quality evidence comes from recipe 0.6.0 and was not rerun after the graph-only decode change.",
+    "The host had about 3.38 GiB of pre-existing swap resident, although measured requests grew neither swap nor routed-expert disk I/O.",
+    "Certification must be repeated from a clean revision after host swap usage returns to zero."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -33,7 +33,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
-| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW | `qwen3.8-flash-next` | Experimental | 16.06 | 0.434 |
+| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW | `qwen3.8-flash-next` | Experimental | 16.61 | 0.403 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 | `deepseek-v4` | Preview | 10.28 | 0.604 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 6.27 | 5.681 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
@@ -54,14 +54,15 @@ means no accepted complete-checkpoint GB10 performance evidence is attached.
 
 The primary lineup is Qwen3.6 NVFP4 for Fast; Qwen3.8 Flash Next, GLM-5.3 Flash,
 and DeepSeek V4 Flash for Frontier; and Kimi K3 for Research. The Beta Qwen3.8 recipe
-preserves Inferact's publisher-quantized ModelOpt NVFP4 precision. Recipe 0.6.0 preloads
+preserves Inferact's publisher-quantized ModelOpt NVFP4 precision. Recipe 0.7.0 preloads
 all routed experts into immutable unified-memory slots, caps KV capacity at 128K tokens,
-and measured 16.06 decode tok/s with 0.434 s warm TTFT, passing the Frontier performance
-thresholds. Exact 64K sparse-QSA recall, reasoning/tool parsing, the coding-agent probe,
-and a five-problem quality sample also passed; the clean-revision 60-minute endurance
-gate remains outstanding. Its historical FP8 and earlier
-NVFP4 results do not transfer across checkpoint and recipe-version boundaries. See the
-[optimization evidence](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-001.json).
+and uses CUDA-graph replay for batch-one dense QSA before automatically falling back to
+eager sparse QSA. It measured 16.61 decode tok/s with 0.403 s warm TTFT, passing the
+Frontier performance thresholds. Exact 64K sparse-QSA recall, reasoning/tool parsing,
+the coding-agent probe, and a five-problem quality sample also passed; the clean-revision
+60-minute endurance gate remains outstanding. Its historical FP8 and earlier NVFP4
+results do not transfer across checkpoint and recipe-version boundaries. See the
+[optimization evidence](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-002.json).
 Qwen3.6 recipe 0.3.0 passed the Fast gate on its pinned FTW artifact: 67.79 decode
 tok/s, 0.329 s warm TTFT, exact 32K recall, capability probes, and an uninterrupted
 60.28-minute zero-swap run. The fixed five-problem AIME sample hit the 2,048-token cap

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -47,6 +47,9 @@ Startup includes a one-time full-expert preload (about 35 seconds in the measure
 Steady-state decode then performs no routed-expert disk staging or LRU bookkeeping. On
 GB10, SparkLab first advises Linux to release clean download page cache so a freshly
 pulled artifact does not hide reclaimable unified memory from the cache planner.
+Batch-one QSA decode replays a CUDA graph while attention remains inside its exact dense
+budget (up to 2,051 visible tokens). SparkLab automatically returns to eager sparse QSA
+for longer contexts; no command-line switch is required.
 The recipe caps KV capacity at 131,072 tokens, enough for the validated 64K context gate
 while retaining substantially more operating-system headroom than the unconstrained
 auto-allocation.

--- a/exps/exp_qwen3_8_nvfp4_gb10.md
+++ b/exps/exp_qwen3_8_nvfp4_gb10.md
@@ -5,12 +5,14 @@ Last updated: 2026-08-30
 ## Result
 
 The complete pinned `Inferact/Qwen3.8-Flash-Next-NVFP4` checkpoint was prepared into
-SparkLab's FTW layout and ran through the OpenAI-compatible streaming API at **16.06
-decode tok/s** with **0.434 s warm TTFT** on one NVIDIA GB10. Recipe 0.6.0 preloads all
+SparkLab's FTW layout and ran through the OpenAI-compatible streaming API at **16.61
+decode tok/s** with **0.403 s warm TTFT** on one NVIDIA GB10. Recipe 0.7.0 preloads all
 24,576 routed experts into deterministic immutable slots, removing steady-state expert
-disk staging, the pageable host LRU, and decode-time cache ownership updates. A 128K-token
-KV cap retains operating-system headroom. Relative to the previous 12.58 tok/s result,
-throughput improved by 27.6% and warm TTFT fell by 44.7%.
+disk staging, the pageable host LRU, and decode-time cache ownership updates. Batch-one
+dense QSA now uses CUDA-graph replay and automatically returns to eager execution when
+the sparse budget is crossed. A 128K-token KV cap retains operating-system headroom.
+Relative to the previous 12.58 tok/s result, throughput improved by 32.0% and warm TTFT
+fell by 48.9%.
 
 Both numbers pass the Frontier performance thresholds. Exact 64K recall, reasoning and
 tool parsing, a coding-agent task, and the fixed five-problem quality sample also passed.
@@ -18,7 +20,7 @@ The recipe remains Experimental because the optimization result came from a dirt
 worktree and the clean-revision 60-minute endurance gate was not run.
 
 Compact evidence:
-[`GB10-QWEN38-NVFP4-OPT-001`](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-001.json).
+[`GB10-QWEN38-NVFP4-OPT-002`](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-002.json).
 
 ## Artifact and system
 
@@ -42,8 +44,9 @@ conversion-time requantization. Other served tensors retain their published prec
 The selected run used AIME-25 problem 0, batch size one, greedy sampling, 64 requested
 completion tokens, one warm request, and one measured request. Timing spans the streaming
 HTTP API. The runtime used QSA attention, a complete immutable 24,576-slot expert cache,
-no pageable host expert cache, a 131,072-token KV capacity, and no CUDA graph. The
-one-time expert preload took 35.78 seconds.
+no pageable host expert cache, a 131,072-token KV capacity, and a batch-one CUDA graph
+for the exact dense-QSA domain. The one-time expert preload took 35.26 seconds and graph
+capture took 1.15 seconds.
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 SPARKLAB_DISK_READ_WORKERS=16 PYTHONPATH=python:. \
@@ -53,7 +56,7 @@ CUDA_VISIBLE_DEVICES=0 SPARKLAB_DISK_READ_WORKERS=16 PYTHONPATH=python:. \
   --backend offload --storage disk --attention-backend qsa \
   --nvfp4-backend triton --host-cache-gb 0 --preload-all \
   --num-tokens 131072 \
-  --page-size 16 --cache-type naive --no-graph \
+  --page-size 16 --cache-type naive \
   --include-output --greedy --decode 64
 ```
 
@@ -64,6 +67,11 @@ The optimized path combines several changes:
   isolated GB10 router probe);
 - full expert preload gives every `(layer, expert)` a fixed physical slot, so decode and
   prefill bypass cache lookup, eviction, ownership updates, host-LRU work, and expert I/O;
+- the engine asks each attention backend whether a live batch fits its captured execution
+  domain, allowing a model to mix graph replay and eager decode safely;
+- QSA stages exact dense row metadata into fixed-address buffers and maintains pooled index
+  keys inside the graph, while disk-backed PLE rows are resolved before replay into stable
+  device buffers;
 - dense QSA metadata is built once per batch, completed four-token index-key pools are
   materialized once in the existing cache, and dense attention skips the unused query
   projection;
@@ -84,23 +92,30 @@ The optimized path combines several changes:
 
 | Metric | Value |
 |---|---:|
-| Decode throughput | 16.061 tok/s |
-| Warm TTFT | 0.434 s |
-| Inter-token p50 / p99 | 61.82 / 71.43 ms |
+| Decode throughput | 16.607 tok/s |
+| Warm TTFT | 0.403 s |
+| Inter-token p50 / p99 | 59.60 / 64.52 ms |
 | Device allocation | 76.43 GiB |
-| Minimum host memory available | 32.46 GiB |
+| Minimum host memory available | 23.44 GiB |
 | Expert cache miss rate | 0% by immutable mapping |
 | Routed-expert disk reads | 0 during steady-state decode |
 | Output hash | `c1c0854490c6` |
 
 The API returned 64 completion tokens and produced 63 timed decode steps. The measured
 request grew neither swap nor expert disk I/O and completed without an OOM or service
-restart. Its hash exactly matched the immediate pre-optimization control. The 64-token cap
+restart. Its hash exactly matched the established eager result. The 64-token cap
 stopped before a final mathematical answer, so this run is performance and serving
 evidence rather than task-accuracy evidence.
 
 Longer diagnostics exercised correctness, quality, and the sparse path:
 
+- A controlled 512-token dense-decode A/B measured 16.169 tok/s with graph replay versus
+  15.515 tok/s eager, a 4.2% gain. Both produced the same correct reasoning through token
+  341; a near-tied greedy decision then changed wording while preserving the correct
+  solution. The fixed 64-token acceptance hash remained exact.
+- An exact 2,048-token transition probe used graph replay for the last dense steps,
+  automatically crossed into eager sparse QSA, and returned `SPARK-7319` with zero routed-
+  expert disk reads, zero swap growth, and no OOM.
 - A controlled 4,193-token prompt plus 512-token decode measured 14.303 tok/s with fused
   QSA selection versus 13.888 tok/s with the eager selector, a 3.0% gain. The greedy
   hashes diverged after accumulated selector floating-point differences, so exact recall
@@ -124,9 +139,10 @@ Longer diagnostics exercised correctness, quality, and the sparse path:
 The immediate pre-optimization control at engine revision `8544aa5` measured 12.92 tok/s
 and 0.771 s warm TTFT with the same artifact, prompt, sampling, and host. The optimized
 dynamic-cache path measured 13.89 tok/s with the same output hash; immutable preload then
-raised the fixed probe to 15.54 tok/s, while reference-exact Hyper-Connection fusion
-raised the final result to 16.06 tok/s and cut TTFT to 0.434 s. Capping KV at 128K
-reduced device allocation from 97.62 to 76.43 GiB while retaining the same output hash;
+raised the fixed probe to 15.54 tok/s, reference-exact Hyper-Connection fusion raised it
+to 16.06 tok/s, and dense-QSA graph replay reached 16.61 tok/s with 0.403 s warm TTFT.
+Capping KV at 128K reduced device allocation from 97.62 to 76.43 GiB while retaining
+the same output hash;
 the 0.7% throughput difference from the unconstrained sample is within short-run noise.
 
 Against the earlier recipe's exact-64K recall run, request time fell from 689.37 to 208.58

--- a/python/sparklab/attention/base.py
+++ b/python/sparklab/attention/base.py
@@ -73,6 +73,10 @@ class BaseAttnBackend(ABC):
     @abstractmethod
     def prepare_for_replay(self, batch: Batch) -> None: ...
 
+    def supports_cuda_graph(self, batch: Batch) -> bool:
+        """Whether this decode batch fits the backend's captured execution domain."""
+        return True
+
     def reset_capture(self) -> None:
         """Drop CUDA-graph capture scratch so ``init_capture_graph`` can re-run after a
         runtime cache rebuild. The default clears the common capture state (guarded by
@@ -119,6 +123,9 @@ class HybridBackend(BaseAttnBackend):
 
     def prepare_for_replay(self, batch: Batch) -> None:
         self.decode_backend.prepare_for_replay(batch)
+
+    def supports_cuda_graph(self, batch: Batch) -> bool:
+        return self.decode_backend.supports_cuda_graph(batch)
 
     def reset_capture(self) -> None:
         # Only the decode backend is ever captured (see init_capture_graph above).

--- a/python/sparklab/attention/qsa.py
+++ b/python/sparklab/attention/qsa.py
@@ -28,9 +28,33 @@ class QSAMetadata(BaseAttnMetadata):
     dense_indptr: torch.Tensor | None = None
     dense_indices: torch.Tensor | None = None
     dense_q_positions: torch.Tensor | None = None
+    capture_decode: bool = False
 
     def get_last_indices(self, bs: int) -> torch.Tensor:
         return self.last_indices[:bs]
+
+
+@dataclass
+class QSACaptureData:
+    """Fixed-address inputs for the batch-one dense-QSA decode graph."""
+
+    dense_indptr: torch.Tensor
+    dense_indices: torch.Tensor
+    dense_q_positions: torch.Tensor
+    q_to_req: torch.Tensor
+    last_indices: torch.Tensor
+
+    @classmethod
+    def create(cls, dense_limit: int, device: torch.device) -> QSACaptureData:
+        return cls(
+            dense_indptr=torch.zeros(2, dtype=torch.int32, device=device),
+            # Unused suffix rows must still be valid because the captured pooling
+            # update speculatively gathers a four-row group on incomplete steps.
+            dense_indices=torch.zeros(dense_limit, dtype=torch.int32, device=device),
+            dense_q_positions=torch.zeros(1, dtype=torch.int64, device=device),
+            q_to_req=torch.zeros(1, dtype=torch.int32, device=device),
+            last_indices=torch.zeros(1, dtype=torch.int32, device=device),
+        )
 
 
 def _plus_one_rms(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
@@ -56,6 +80,20 @@ class QSAAttnBackend(BaseAttnBackend):
         self._fused_selection = os.getenv(
             "SPARKLAB_DISABLE_QSA_FUSED_SELECTION", "0"
         ).lower() not in {"1", "true", "yes"}
+        self.capture: QSACaptureData | None = None
+        self.capture_bs: List[int] = []
+        self.max_graph_bs = 0
+
+    def supports_cuda_graph(self, batch: Batch) -> bool:
+        """Capture the common batch-one dense-QSA domain; sparse QSA stays eager."""
+        if not batch.is_decode or batch.size != 1:
+            return False
+        ratio = self.args.index_compress_ratio
+        return all(
+            (req.cached_len + req.extend_len) // ratio
+            <= self.args.index_block_topk
+            for req in batch.reqs
+        )
 
     def prepare_metadata(self, batch: Batch) -> None:
         reqs = batch.padded_reqs if hasattr(batch, "padded_reqs") else batch.reqs
@@ -221,6 +259,51 @@ class QSAAttnBackend(BaseAttnBackend):
             _, pooled = rotary.forward(starts, pooled.clone(), pooled)
             cache[rows[:, -1]] = pooled
 
+    def _pool_completed_keys_capture(
+        self,
+        slot: int,
+        raw_index_k: torch.Tensor,
+        out_loc: torch.Tensor,
+        metadata: QSAMetadata,
+        k_norm_weight: torch.Tensor,
+        rotary,
+    ) -> None:
+        """Graph-safe batch-one form of the once-per-four-token pool update.
+
+        A graph cannot branch on the live position. It therefore computes the
+        candidate pool every step and selects it only when the current group is
+        complete; incomplete steps retain the raw key written at ``out_loc``.
+        """
+        assert metadata.dense_indices is not None
+        assert metadata.dense_q_positions is not None
+        ratio = self.args.index_compress_ratio
+        offsets = getattr(self, "_pool_offsets", None)
+        if offsets is None or offsets.device != self.device:
+            offsets = torch.arange(ratio, dtype=torch.long, device=self.device)
+            self._pool_offsets = offsets
+
+        positions = metadata.dense_q_positions
+        starts = positions.div(ratio, rounding_mode="floor") * ratio
+        logical = starts[:, None] + offsets[None, :]
+        # The final dense-QSA positions can begin an incomplete group whose next
+        # row lies just beyond the captured dense buffer. That candidate is
+        # discarded by ``complete`` below, but index_select still requires a
+        # valid speculative address.
+        logical = logical.clamp_max(metadata.dense_indices.numel() - 1)
+        rows = metadata.dense_indices.index_select(0, logical.flatten()).to(torch.long)
+        cache = self.kvcache.index_k_cache(slot)
+        pooled = cache.index_select(0, rows).view(1, ratio, -1).float().mean(1)
+        pooled = _plus_one_rms(
+            pooled.to(cache.dtype), k_norm_weight, self.config.rms_norm_eps
+        )
+        _, pooled = rotary.forward(starts, pooled.clone(), pooled)
+        complete = (positions + 1).remainder(ratio).eq(0).view(-1, 1)
+        cache.index_copy_(
+            0,
+            out_loc.to(torch.long),
+            torch.where(complete, pooled, raw_index_k),
+        )
+
     def qsa_forward(
         self, q, k, v, index_q, raw_index_k, k_norm_weight, rotary,
         layer_id: int, batch: Batch,
@@ -234,7 +317,12 @@ class QSAAttnBackend(BaseAttnBackend):
 
         ctx = get_global_ctx()
         reqs = batch.padded_reqs if hasattr(batch, "padded_reqs") else batch.reqs
-        self._pool_completed_keys(slot, reqs, k_norm_weight, rotary)
+        if md.capture_decode:
+            self._pool_completed_keys_capture(
+                slot, raw_index_k, batch.out_loc, md, k_norm_weight, rotary
+            )
+        else:
+            self._pool_completed_keys(slot, reqs, k_norm_weight, rotary)
 
         from sparklab.kernels.triton.attention import paged_attention
 
@@ -295,16 +383,59 @@ class QSAAttnBackend(BaseAttnBackend):
         )
 
     def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
-        if bs_list:
-            raise RuntimeError(
-                "Qwen4 QSA decode is currently eager; serve with --cuda-graph-max-bs 0"
-            )
+        assert self.capture is None, "Capture already initialized."
+        if any(bs != 1 for bs in bs_list):
+            raise ValueError("Qwen4 QSA CUDA graphs currently support only batch size 1")
+        ratio = self.args.index_compress_ratio
+        dense_limit = min(
+            max_seq_len,
+            self.args.index_block_topk * ratio + ratio - 1,
+        )
+        self.capture = QSACaptureData.create(dense_limit, self.device)
+        self.capture_bs = sorted(bs_list)
+        self.max_graph_bs = max(bs_list)
 
     def prepare_for_capture(self, batch: Batch) -> None:
-        raise RuntimeError("Qwen4 QSA CUDA graph capture is not implemented")
+        self.prepare_metadata(batch)
+        self._point_to_capture(batch)
 
     def prepare_for_replay(self, batch: Batch) -> None:
-        raise RuntimeError("Qwen4 QSA CUDA graph replay is not implemented")
+        self._point_to_capture(batch)
+
+    def _point_to_capture(self, batch: Batch) -> None:
+        """Stage dense-QSA addressing into persistent graph input buffers."""
+        assert self.capture is not None and batch.padded_size == 1
+        metadata = batch.attn_metadata
+        if not isinstance(metadata, QSAMetadata):
+            raise TypeError(f"QSA metadata expected, got {type(metadata).__name__}")
+        if (
+            metadata.dense_indptr is None
+            or metadata.dense_indices is None
+            or metadata.dense_q_positions is None
+        ):
+            raise RuntimeError("Sparse QSA batches are not CUDA-graph eligible")
+
+        cap = self.capture
+        total = metadata.dense_indices.numel()
+        if total > cap.dense_indices.numel():
+            raise RuntimeError(
+                f"Dense QSA capture capacity {cap.dense_indices.numel()} < {total} rows"
+            )
+        cap.dense_indptr.copy_(metadata.dense_indptr)
+        cap.dense_indices[:total].copy_(metadata.dense_indices)
+        cap.dense_q_positions.copy_(metadata.dense_q_positions)
+        cap.last_indices.copy_(metadata.last_indices)
+        batch.attn_metadata = QSAMetadata(
+            qo_indptr=(0, 1),
+            last_indices=cap.last_indices,
+            q_to_req=cap.q_to_req,
+            dense_indptr=cap.dense_indptr,
+            # Keep the full fixed-size view: the graph must see the same tensor
+            # address and shape at capture and every replay. indptr bounds reads.
+            dense_indices=cap.dense_indices,
+            dense_q_positions=cap.dense_q_positions,
+            capture_decode=True,
+        )
 
 
-__all__ = ["QSAAttnBackend", "QSAMetadata"]
+__all__ = ["QSAAttnBackend", "QSACaptureData", "QSAMetadata"]

--- a/python/sparklab/models/blocks.py
+++ b/python/sparklab/models/blocks.py
@@ -23,6 +23,10 @@ class BaseLLMModel(ABC, BaseOP):
     @abstractmethod
     def forward(self) -> torch.Tensor: ...
 
+    def prepare_cuda_graph_inputs(self, batch) -> None:
+        """Stage model-specific inputs that must remain outside graph capture/replay."""
+        return None
+
 
 class GatedMLP(BaseOP):
     def __init__(self, config: ModelConfig):

--- a/python/sparklab/models/qwen4_exp/model.py
+++ b/python/sparklab/models/qwen4_exp/model.py
@@ -100,6 +100,11 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
             if layer.ple is not None:
                 layer.ple.bind(model_path, dummy=dummy)
 
+    def prepare_cuda_graph_inputs(self, batch) -> None:
+        for layer in self.model.layers.op_list:
+            if layer.ple is not None:
+                layer.ple.prepare_cuda_graph_inputs(batch)
+
     def forward(self) -> torch.Tensor:
         hidden = self.model.forward(get_global_ctx().batch.input_ids)
         return self.lm_head.forward(hidden)

--- a/python/sparklab/models/qwen4_exp/ple.py
+++ b/python/sparklab/models/qwen4_exp/ple.py
@@ -436,9 +436,25 @@ class Qwen4PLE(BaseOP):
         self.conv1d = _DepthwiseDilatedConv(self.width, args.ple_conv_kernel_size)
         self.dilation = args.ngram_size
         self.state_len = (args.ple_conv_kernel_size - 1) * self.dilation
+        self._capture_embed: torch.Tensor | None = None
 
     def bind(self, model_path: str, *, dummy: bool = False) -> None:
         self.embedding.bind(model_path, dummy=dummy)
+
+    def prepare_cuda_graph_inputs(self, batch) -> None:
+        """Resolve disk-backed PLE rows before graph replay into a stable GPU buffer."""
+        embed = self.embedding.forward(batch)
+        weight = self.key_proj.weight
+        if self._capture_embed is None:
+            self._capture_embed = torch.empty(
+                (1, embed.shape[-1]), dtype=weight.dtype, device=weight.device
+            )
+        if embed.shape != self._capture_embed.shape:
+            raise RuntimeError(
+                "Qwen4 PLE CUDA graphs require batch-one decode rows, got "
+                f"{tuple(embed.shape)}"
+            )
+        self._capture_embed.copy_(embed)
 
     def _conv(self, x: torch.Tensor, batch) -> torch.Tensor:
         pool = get_global_ctx().linear_state_pool
@@ -473,7 +489,12 @@ class Qwen4PLE(BaseOP):
 
     def forward(self, hidden: torch.Tensor) -> torch.Tensor:
         batch = get_global_ctx().batch
-        embed = self.embedding.forward(batch).to(hidden.device, dtype=hidden.dtype)
+        if getattr(batch.attn_metadata, "capture_decode", False):
+            if self._capture_embed is None:
+                raise RuntimeError("Qwen4 PLE graph input was not staged before replay")
+            embed = self._capture_embed
+        else:
+            embed = self.embedding.forward(batch).to(hidden.device, dtype=hidden.dtype)
         key = self.norm_key.forward(self.key_proj.forward(embed)).view(
             -1, self.hc_count, self.hidden_size
         )

--- a/python/sparklab/recipes/qwen3.8-flash-next.json
+++ b/python/sparklab/recipes/qwen3.8-flash-next.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.6.0",
+  "recipe_version": "0.7.0",
   "slug": "qwen3.8-flash-next",
   "name": "Qwen3.8 Flash Next",
   "model": "Inferact/Qwen3.8-Flash-Next-NVFP4",
@@ -34,7 +34,7 @@
       "moe_cache_auto": true,
       "moe_preload_all": true,
       "nvfp4_backend": "triton",
-      "cuda_graph_max_bs": 0,
+      "cuda_graph_max_bs": 1,
       "cache_type": "naive",
       "page_size": 16,
       "max_running_req": 1,
@@ -47,23 +47,24 @@
   "profile": "quality",
   "description": "Precision-preserving text-only recipe for Inferact's ModelOpt NVFP4 Qwen3.8 checkpoint on one NVIDIA GB10.",
   "performance": {
-    "decode_tokens_per_second": 16.061408803195647,
-    "warm_ttft_seconds": 0.4342626500874758,
+    "decode_tokens_per_second": 16.607355237469154,
+    "warm_ttft_seconds": 0.40297515969723463,
     "context_tokens": 65536,
-    "evidence": "GB10-QWEN38-NVFP4-OPT-001",
-    "note": "The complete pinned publisher-NVFP4 checkpoint passed a 64-token GB10 performance probe with immutable full-expert preload, exact 64K sparse-QSA recall, capability probes, and a fixed five-problem quality sample. The clean-revision 60-minute endurance gate remains outstanding."
+    "evidence": "GB10-QWEN38-NVFP4-OPT-002",
+    "note": "The complete pinned publisher-NVFP4 checkpoint passed a graph-enabled 64-token GB10 performance probe with the established exact output hash. Dense batch-one QSA replays a CUDA graph and automatically falls back to eager sparse QSA; an exact 2K boundary-transition recall probe passed. The clean-revision 60-minute endurance gate remains outstanding."
   },
   "evidence": [
+    "GB10-QWEN38-NVFP4-OPT-002",
     "GB10-QWEN38-NVFP4-OPT-001",
     "GB10-QWEN38-NVFP4-001"
   ],
   "limitations": [
     "Beta 0.1 FTW preparation preserves Inferact's native ModelOpt NVFP4 routed experts without conversion-time requantization; all served non-expert tensors retain their published precision.",
     "The published BF16 n-gram table is extracted into an approximately 102.4 GB random-read artifact during preparation.",
-    "The complete pinned checkpoint and 180,433,108,992-byte FTW artifact were validated; immutable full-expert preload with a 128K KV cap and reference-exact Hyper-Connection fusion measured 16.061 tok/s and 0.434 s warm TTFT on GB10.",
+    "The complete pinned checkpoint and 180,433,108,992-byte FTW artifact were validated; immutable full-expert preload, a 128K KV cap, and batch-one dense-QSA CUDA-graph replay measured 16.607 tok/s and 0.403 s warm TTFT on GB10.",
     "Full expert preload takes about 35 seconds at startup, eliminates steady-state routed-expert disk I/O and the pageable host LRU, and requires all 24,576 routed experts to fit in unified memory.",
     "GB10-QWEN38-FRONTIER-001 and GB10-QWEN38-FP8-001 describe superseded recipe/checkpoint tuples and do not transfer to this 0.5.0 release.",
-    "QSA selection currently runs eagerly, so CUDA graph capture is disabled.",
+    "Batch-one QSA decode uses CUDA-graph replay while the complete-group count remains within the exact dense budget (up to 2,051 visible tokens); longer sparse-QSA decode automatically runs eagerly.",
     "The published checkpoint is multimodal; initial SparkLab certification is text-only.",
     "An exact 65,536-token sparse-QSA recall probe returned the planted key in 208.58 seconds with zero routed-expert disk reads and no swap growth; reasoning, tool, coding-agent, and five-problem quality gates passed, while the 60-minute endurance gate remains outstanding.",
     "The performance host had 3.71 GiB of unrelated swap resident before launch, although the measured request swapped no pages out."

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -606,8 +606,14 @@ class Engine:
                         "--moe-storage disk supports --moe-backend offload or hybrid, "
                         "but not full CPU decode"
                     )
-                if config.cuda_graph_max_bs not in (None, 0):
-                    raise ValueError("--moe-storage disk requires --cuda-graph-max-bs 0")
+                if (
+                    config.cuda_graph_max_bs not in (None, 0)
+                    and not config.moe_preload_all
+                ):
+                    raise ValueError(
+                        "--moe-storage disk requires --cuda-graph-max-bs 0 unless "
+                        "--moe-preload-all makes expert ownership immutable"
+                    )
                 banks, disk_source = open_ftw_disk_banks(
                     config.model_path,
                     num_layers=config.model_config.num_moe_layers,

--- a/python/sparklab/runtime/engine/graph.py
+++ b/python/sparklab/runtime/engine/graph.py
@@ -112,6 +112,7 @@ class GraphRunner:
             free_memory=free_memory,
         )
         self.attn_backend = attn_backend
+        self.model = model
         self.max_graph_bs = max(cuda_graph_bs) if cuda_graph_bs else 0
         self.graph_bs_list = sorted(cuda_graph_bs)
         self.dummy_req = dummy_req
@@ -172,6 +173,7 @@ class GraphRunner:
                           else self.dummy_req.table_idx)
             self.buffer.table_idx[:bs].fill_(dummy_slot)
             with get_global_ctx().forward_batch(batch):
+                self.model.prepare_cuda_graph_inputs(batch)
                 self.buffer.logits[:bs] = model.forward()
                 # Keep the offload cache warmed for capture. Resetting here forces
                 # CUDA graph capture to replay cold-cache expert copies.
@@ -187,13 +189,18 @@ class GraphRunner:
         logger.info_rank0(f"Free GPU memory after capturing CUDA graphs: {mem_GB(free_memory)}")
 
     def can_use_cuda_graph(self, batch: Batch) -> bool:
-        return batch.is_decode and batch.size <= self.max_graph_bs
+        return (
+            batch.is_decode
+            and batch.size <= self.max_graph_bs
+            and self.attn_backend.supports_cuda_graph(batch)
+        )
 
     def replay(self, batch: Batch) -> torch.Tensor:
         assert self.can_use_cuda_graph(batch)
         self.buffer.copy_from(batch)
         g = self.graph_map[batch.padded_size]
         self.attn_backend.prepare_for_replay(batch)
+        self.model.prepare_cuda_graph_inputs(batch)
         g.replay()
         return self.buffer.logits[: batch.size]
 

--- a/tests/models/test_qwen4_exp.py
+++ b/tests/models/test_qwen4_exp.py
@@ -9,10 +9,10 @@ import torch
 from safetensors.torch import save_file
 
 from sparklab.attention import AttnType
-from sparklab.attention.qsa import QSAAttnBackend
+from sparklab.attention.qsa import QSAAttnBackend, QSACaptureData, QSAMetadata
 from sparklab.models.qwen4_exp.config import parse_config
 from sparklab.models.qwen4_exp.hyper import GroupedPlusOneRMSNorm, Qwen4GatedResidual
-from sparklab.models.qwen4_exp.ple import DiskNGramEmbedding, RawNGramStore
+from sparklab.models.qwen4_exp.ple import DiskNGramEmbedding, Qwen4PLE, RawNGramStore
 from sparklab.models.qwen4_exp.weight import copy_external_artifacts
 from sparklab.models.qwen4_exp.weight import _iter_experts_layer_order
 from sparklab.models.qwen4_exp.weight import iter_weights
@@ -618,6 +618,24 @@ def test_ple_span_hash_matches_full_history_reference_across_eos_boundaries():
         )
 
 
+def test_ple_stages_disk_row_into_stable_graph_input():
+    ple = Qwen4PLE.__new__(Qwen4PLE)
+    rows = torch.arange(8, dtype=torch.bfloat16).view(1, 8)
+    ple.embedding = SimpleNamespace(forward=lambda _batch: rows)
+    ple.key_proj = SimpleNamespace(weight=torch.empty(4, 8, dtype=torch.bfloat16))
+    ple._capture_embed = None
+
+    ple.prepare_cuda_graph_inputs(SimpleNamespace())
+    pointer = ple._capture_embed.data_ptr()
+    torch.testing.assert_close(ple._capture_embed, rows)
+
+    replacement = rows + 1
+    ple.embedding = SimpleNamespace(forward=lambda _batch: replacement)
+    ple.prepare_cuda_graph_inputs(SimpleNamespace())
+    assert ple._capture_embed.data_ptr() == pointer
+    torch.testing.assert_close(ple._capture_embed, replacement)
+
+
 def test_qsa_selects_complete_blocks_and_always_keeps_tail():
     backend = QSAAttnBackend.__new__(QSAAttnBackend)
     backend.args = SimpleNamespace(
@@ -759,6 +777,122 @@ def test_qsa_dense_metadata_is_built_once_and_supports_missing_index_query(monke
     assert result.unique().item() == 9
     assert captured["indices"].data_ptr() == md.dense_indices.data_ptr()
     assert captured["q_to_req"].tolist() == [0, 1, 2]
+
+
+def test_qsa_cuda_graph_domain_is_batch_one_and_dense():
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.args = SimpleNamespace(index_compress_ratio=4, index_block_topk=512)
+    dense = SimpleNamespace(cached_len=2050, extend_len=1)
+    sparse = SimpleNamespace(cached_len=2051, extend_len=1)
+
+    assert backend.supports_cuda_graph(
+        SimpleNamespace(is_decode=True, size=1, reqs=[dense])
+    )
+    assert not backend.supports_cuda_graph(
+        SimpleNamespace(is_decode=True, size=1, reqs=[sparse])
+    )
+    assert not backend.supports_cuda_graph(
+        SimpleNamespace(is_decode=True, size=2, reqs=[dense, dense])
+    )
+
+
+def test_qsa_capture_stages_dense_rows_into_fixed_buffers():
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.capture = QSACaptureData.create(7, torch.device("cpu"))
+    source = QSAMetadata(
+        qo_indptr=(0, 1),
+        last_indices=torch.tensor([0], dtype=torch.int32),
+        q_to_req=torch.tensor([0], dtype=torch.int32),
+        dense_indptr=torch.tensor([0, 4], dtype=torch.int32),
+        dense_indices=torch.tensor([9, 3, 12, 1], dtype=torch.int32),
+        dense_q_positions=torch.tensor([3], dtype=torch.int64),
+    )
+    batch = SimpleNamespace(padded_size=1, attn_metadata=source)
+
+    backend._point_to_capture(batch)
+
+    md = batch.attn_metadata
+    assert md.capture_decode
+    assert md.dense_indices.data_ptr() == backend.capture.dense_indices.data_ptr()
+    assert md.dense_indices.tolist() == [9, 3, 12, 1, 0, 0, 0]
+    assert md.dense_indptr.tolist() == [0, 4]
+    assert md.dense_q_positions.tolist() == [3]
+
+
+def test_qsa_capture_pool_update_matches_completed_group():
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.args = SimpleNamespace(index_compress_ratio=4)
+    backend.config = SimpleNamespace(rms_norm_eps=1e-6)
+    backend.device = torch.device("cpu")
+    raw = torch.arange(15 * 4, dtype=torch.float32).view(15, 4) / 10
+
+    class FakeKVCache:
+        @staticmethod
+        def index_k_cache(_slot):
+            return raw
+
+    class IdentityRotary:
+        @staticmethod
+        def forward(positions, query, key):
+            assert positions.tolist() == [0]
+            return query, key
+
+    backend.kvcache = FakeKVCache()
+    physical = torch.tensor([9, 3, 12, 1], dtype=torch.int32)
+    md = QSAMetadata(
+        qo_indptr=(0, 1),
+        last_indices=torch.tensor([0], dtype=torch.int32),
+        q_to_req=torch.tensor([0], dtype=torch.int32),
+        dense_indptr=torch.tensor([0, 4], dtype=torch.int32),
+        dense_indices=physical,
+        dense_q_positions=torch.tensor([3], dtype=torch.int64),
+        capture_decode=True,
+    )
+    expected = raw.index_select(0, physical.long()).mean(0, keepdim=True)
+    expected = expected * torch.rsqrt(
+        expected.square().mean(-1, keepdim=True) + 1e-6
+    )
+
+    backend._pool_completed_keys_capture(
+        0,
+        raw_index_k=raw[1].clone().view(1, -1),
+        out_loc=torch.tensor([1], dtype=torch.int32),
+        metadata=md,
+        k_norm_weight=torch.zeros(4),
+        rotary=IdentityRotary(),
+    )
+
+    torch.testing.assert_close(raw[1].view(1, -1), expected)
+
+
+def test_qsa_capture_pool_update_clamps_incomplete_dense_boundary():
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.args = SimpleNamespace(index_compress_ratio=4)
+    backend.config = SimpleNamespace(rms_norm_eps=1e-6)
+    backend.device = torch.device("cpu")
+    cache = torch.arange(24, dtype=torch.float32).view(6, 4)
+    backend.kvcache = SimpleNamespace(index_k_cache=lambda _slot: cache)
+    md = QSAMetadata(
+        qo_indptr=(0, 1),
+        last_indices=torch.tensor([0], dtype=torch.int32),
+        q_to_req=torch.tensor([0], dtype=torch.int32),
+        dense_indptr=torch.tensor([0, 3], dtype=torch.int32),
+        dense_indices=torch.tensor([1, 2, 3], dtype=torch.int32),
+        dense_q_positions=torch.tensor([2], dtype=torch.int64),
+        capture_decode=True,
+    )
+    raw = torch.tensor([[91.0, 92.0, 93.0, 94.0]])
+
+    backend._pool_completed_keys_capture(
+        0,
+        raw_index_k=raw,
+        out_loc=torch.tensor([3], dtype=torch.int32),
+        metadata=md,
+        k_norm_weight=torch.zeros(4),
+        rotary=SimpleNamespace(forward=lambda positions, query, key: (query, key)),
+    )
+
+    torch.testing.assert_close(cache[3].view(1, -1), raw)
 
 
 def test_registry_has_qwen_wrapper_and_text_architectures():

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -844,6 +844,9 @@ def test_graph_capture_reuses_warm_offload_cache_before_capture(monkeypatch):
             pass
 
     class FakeModel:
+        def prepare_cuda_graph_inputs(self, batch):
+            events.append("prepare_graph_inputs")
+
         def forward(self):
             events.append("forward")
             batch = get_global_ctx().batch
@@ -885,6 +888,7 @@ def test_graph_capture_reuses_warm_offload_cache_before_capture(monkeypatch):
 
     assert events == [
         "reset",
+        "prepare_graph_inputs",
         "forward",
         "graph_enter",
         "forward",

--- a/tests/runtime/engine/test_graph.py
+++ b/tests/runtime/engine/test_graph.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from sparklab.runtime.engine.graph import GraphRunner
+
+
+def test_cuda_graph_eligibility_delegates_to_attention_backend():
+    runner = GraphRunner.__new__(GraphRunner)
+    runner.max_graph_bs = 1
+    batch = SimpleNamespace(is_decode=True, size=1)
+
+    runner.attn_backend = SimpleNamespace(supports_cuda_graph=lambda _batch: True)
+    assert runner.can_use_cuda_graph(batch)
+
+    runner.attn_backend = SimpleNamespace(supports_cuda_graph=lambda _batch: False)
+    assert not runner.can_use_cuda_graph(batch)
+
+
+def test_cuda_graph_eligibility_keeps_phase_and_batch_guards():
+    runner = GraphRunner.__new__(GraphRunner)
+    runner.max_graph_bs = 1
+    runner.attn_backend = SimpleNamespace(supports_cuda_graph=lambda _batch: True)
+
+    assert not runner.can_use_cuda_graph(SimpleNamespace(is_decode=False, size=1))
+    assert not runner.can_use_cuda_graph(SimpleNamespace(is_decode=True, size=2))

--- a/tests/sparklab/test_backends.py
+++ b/tests/sparklab/test_backends.py
@@ -104,7 +104,7 @@ def test_native_backend_compiles_qwen_recipe_options_in_stable_order(tmp_path):
         "--nvfp4-backend",
         "triton",
         "--cuda-graph-max-bs",
-        "0",
+        "1",
         "--cache-type",
         "naive",
         "--page-size",

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -54,10 +54,11 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
         "qwen3.6-35b-a3b",
     }
     qwen = get_recipe("qwen3.8-flash-next")
-    assert qwen.recipe_version == "0.6.0"
+    assert qwen.recipe_version == "0.7.0"
     assert qwen.intended_tier == "frontier"
     assert qwen.status == "experimental"
     assert qwen.evidence == (
+        "GB10-QWEN38-NVFP4-OPT-002",
         "GB10-QWEN38-NVFP4-OPT-001",
         "GB10-QWEN38-NVFP4-001",
     )
@@ -68,8 +69,8 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert qwen.deployment.quantization == "nvfp4"
     assert "convert_expert_quantization" not in qwen.deployment.backend_options
     assert qwen.deployment.backend_options["nvfp4_backend"] == "triton"
-    assert qwen.performance.decode_tokens_per_second == pytest.approx(16.061408803195647)
-    assert qwen.performance.warm_ttft_seconds == pytest.approx(0.4342626500874758)
+    assert qwen.performance.decode_tokens_per_second == pytest.approx(16.607355237469154)
+    assert qwen.performance.warm_ttft_seconds == pytest.approx(0.40297515969723463)
     assert qwen.deployment.backend_options["moe_host_cache_gb"] == 0
     assert qwen.deployment.backend_options["moe_preload_all"] is True
     assert qwen.deployment.backend_options["num_tokens"] == 131_072
@@ -345,15 +346,15 @@ def test_current_qwen_nvfp4_evidence_passes_all_non_endurance_frontier_gates():
     recipe = get_recipe("qwen3.8-flash-next")
     root = Path(__file__).resolve().parents[2]
     result = json.loads(
-        (root / "benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-001.json").read_text()
+        (root / "benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-002.json").read_text()
     )
     assert result["result_id"] == recipe.evidence[0]
     assert result["admission"]["performance_gate_passed"] is True
     assert result["metrics"]["decode_tokens_per_second"] == pytest.approx(
-        16.061408803195647
+        16.607355237469154
     )
     assert result["metrics"]["warm_ttft_seconds"] == pytest.approx(
-        0.4342626500874758
+        0.40297515969723463
     )
     assert result["validation"]["context_tokens"] == 65_536
     assert result["validation"]["context_gate_run"] is True

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -60,7 +60,7 @@ def test_models_human_table_groups_tiers_and_shows_performance_metrics(capsys):
     assert "CERTIFIED" in qwen36_row
     assert qwen36_row.split()[-2:] == ["67.79", "0.329"]
     qwen38_row = next(line for line in output.splitlines() if line.startswith("Qwen3.8"))
-    assert qwen38_row.split()[-2:] == ["16.06", "0.434"]
+    assert qwen38_row.split()[-2:] == ["16.61", "0.403"]
     assert "No recipe is certified yet" not in output
 
 


### PR DESCRIPTION
## Summary

- add backend-scoped CUDA graph eligibility and model input staging hooks
- capture batch-one dense QSA while preserving eager sparse-QSA fallback
- stage disk-backed PLE rows into stable device buffers and permit immutable preloaded MoE graphs
- promote the Qwen3.8 recipe to 0.7.0 with updated GB10 evidence and documentation

## Results

- fixed probe: 16.607 tok/s and 0.403 s warm TTFT
- controlled 512-token A/B: 16.169 tok/s graph vs 15.515 tok/s eager (+4.2%)
- exact 2,048-token dense-to-sparse transition recall passed

## Validation

- full suite: 1,584 passed, 8 skipped
- final focused suite: 44 passed
- diff and evidence JSON validation passed