### PR TITLE
feat: publish GLM-5.3 FTW artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ a SparkLab support claim.
       <td><a href="docs/models/glm-5.2.md">Instructions</a></td>
     </tr>
     <tr>
-      <td><a href="https://huggingface.co/Inferact/GLM-5.3-NVFP4">GLM-5.3</a></td>
+      <td><a href="https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW">GLM-5.3</a></td>
       <td>753B total / 40B active</td>
-      <td>NVFP4</td>
+      <td>NVFP4 + resident FP8 · FTW</td>
       <td>Experimental</td>
       <td align="right">0.81</td>
       <td align="right">2.530</td>

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,12 +38,12 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 6.27 | 5.681 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.2](https://huggingface.co/nvidia/GLM-5.2-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.2` | Experimental fallback | 0.80 | 2.570 |
-| [GLM-5.3](https://huggingface.co/Inferact/GLM-5.3-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
+| [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
-Model links point to the selected source or published FTW checkpoints. Qwen3.6 and Kimi K3
-use pinned prebuilt FTW artifacts; their source-conversion paths remain available for
-reproducibility.
+Model links point to the selected source or published FTW checkpoints. Qwen3.6, GLM-5.3,
+and Kimi K3 use pinned prebuilt FTW artifacts; their source-conversion paths remain
+available for reproducibility.
 
 Parameter values use publisher-reported architecture counts. Qwen3.8's auxiliary total is
 the 51B n-gram embedding plus its 4B MTP module. NVIDIA reports Kimi K3 activation as 16 of

--- a/docs/models/glm-5.3.md
+++ b/docs/models/glm-5.3.md
@@ -22,9 +22,10 @@ sparklab --version
 
 ## Prepare
 
-Use fast local NVMe storage. The recipe downloads the immutable source revision
-and prepares FTW locally. Budget about 1.03 TB of free space; the measured b12x
-artifact is 428,713,099,264 bytes.
+Use fast local NVMe storage. By default, the recipe downloads the pinned, validated
+FTW artifact directly, so no local conversion is required. The FTW payload is
+428,713,099,264 bytes (about 399.3 GiB). Source conversion remains available for
+reproducibility; budget about 1.03 TB when keeping both source and prepared artifacts.
 
 ```bash
 sparklab doctor --storage-path /path/to/models

--- a/python/sparklab/recipes/glm-5.3.json
+++ b/python/sparklab/recipes/glm-5.3.json
@@ -9,6 +9,12 @@
   "source_bytes": 464867183339,
   "prepared_bytes": 428713099264,
   "minimum_free_bytes": 1031019236075,
+  "runtime_artifact": {
+    "repo_id": "oakmindai/GLM-5.3-NVFP4-FTW",
+    "revision": "024b437e3f31f9cf9b8a936dffaf1302fbda1d30",
+    "bytes": 428713099264,
+    "fingerprint": "a0e799b03bceb4bf"
+  },
   "intended_tier": "research",
   "status": "experimental",
   "implementation": "available",

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -285,6 +285,13 @@ def test_glm53_full_recipe_points_to_measured_failed_research_evidence():
     from sparklab.certification import evaluate_tier
 
     recipe = get_recipe("glm-5.3")
+    assert recipe.runtime_artifact is not None
+    assert recipe.runtime_artifact.repo_id == "oakmindai/GLM-5.3-NVFP4-FTW"
+    assert recipe.runtime_artifact.revision == (
+        "024b437e3f31f9cf9b8a936dffaf1302fbda1d30"
+    )
+    assert recipe.runtime_artifact.bytes == 428713099264
+    assert recipe.runtime_artifact.fingerprint == "a0e799b03bceb4bf"
     assert recipe.performance.evidence == "GB10-GLM53-RESEARCH-001"
     assert recipe.performance.evidence in recipe.evidence
     root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- pin the verified GLM-5.3 FTW artifact at its immutable Hugging Face revision
- point the model catalog and README to the hosted checkpoint
- document direct FTW acquisition, payload size, and the source-conversion fallback
- assert the artifact revision, size, and fingerprint in catalog tests

## Validation
- 32 focused catalog/acquisition/CLI tests pass
- full suite: 1,558 passed, 11 skipped, 1 environment-only failure because optional FlashInfer is not installed while CUDA is available
- verified all 86 remote filenames and all material file sizes against the local artifact; Hugging Face only expanded generated .gitattributes patterns

Hugging Face: https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW/tree/024b437e3f31f9cf9b8a936dffaf1302fbda1d30