### PR TITLE
fix: detect mismatched kernel cache in doctor

### DIFF
--- a/python/sparklab/platform.py
+++ b/python/sparklab/platform.py
@@ -126,6 +126,11 @@ def collect_gb10_snapshot(storage_path: str = ".") -> GB10Snapshot:
 
     swap_total = mem.get("SwapTotal", 0)
     swap_free = mem.get("SwapFree", 0)
+    try:
+        from sparklab.version import __version__ as runtime_version
+    except ImportError:
+        runtime_version = None
+
     return GB10Snapshot(
         os_name=host_platform.system(),
         machine=host_platform.machine(),
@@ -147,6 +152,11 @@ def collect_gb10_snapshot(storage_path: str = ".") -> GB10Snapshot:
         block_device=block_device,
         nvme=("nvme" in block_device.lower()) if block_device else None,
         dependencies={
+            # Use the imported code version for SparkLab, not distribution metadata. An
+            # editable checkout can move to a new release while its installed companion
+            # cache remains on the previous one -- the exact drift doctor must detect.
+            "sparklab": runtime_version,
+            "sparklab-kernel-cache": _package_version("sparklab-kernel-cache"),
             "torch": _package_version("torch"),
             "triton": _package_version("triton"),
             "flashinfer-python": _package_version("flashinfer-python"),
@@ -279,6 +289,28 @@ def assess_gb10(snapshot: GB10Snapshot) -> dict[str, Any]:
         )
     )
 
+    runtime_version = snapshot.dependencies.get("sparklab")
+    kernel_cache_version = snapshot.dependencies.get("sparklab-kernel-cache")
+    if runtime_version is not None and kernel_cache_version is not None:
+        from sparklab.kernels.utils import _kernel_cache_version_ok
+
+        cache_matches = _kernel_cache_version_ok(kernel_cache_version, runtime_version)
+        checks.append(
+            _check(
+                "kernel_cache_version",
+                "pass" if cache_matches else "fail",
+                {
+                    "sparklab": runtime_version,
+                    "sparklab-kernel-cache": kernel_cache_version,
+                },
+                "same release and build stamp",
+                (
+                    "The prebuilt CUDA kernels must come from the same SparkLab release "
+                    "and, when stamped, the same source build."
+                ),
+            )
+        )
+
     failures = [item["name"] for item in checks if item["status"] == "fail"]
     warnings = [item["name"] for item in checks if item["status"] == "warn"]
     identity_checks = {
@@ -310,6 +342,11 @@ def assess_gb10(snapshot: GB10Snapshot) -> dict[str, Any]:
         recommendations.append("Confirm the selected model directory is backed by local NVMe.")
     if "storage_capacity" in warnings:
         recommendations.append("Choose a storage path with at least 512 GiB free for frontier recipes.")
+    if "kernel_cache_version" in failures:
+        recommendations.append(
+            "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before "
+            "loading a model."
+        )
     if not recommendations:
         recommendations.append("Platform identity is ready for recipe-level model validation.")
 

--- a/tests/sparklab/test_doctor.py
+++ b/tests/sparklab/test_doctor.py
@@ -28,7 +28,12 @@ def _snapshot() -> GB10Snapshot:
         filesystem="ext4",
         block_device="/dev/nvme0n1p2",
         nvme=True,
-        dependencies={"torch": "2.11.0", "triton": "3.6.0"},
+        dependencies={
+            "sparklab": "0.1.0+gabc1234",
+            "sparklab-kernel-cache": "0.1.0+cu130.gabc1234",
+            "torch": "2.11.0",
+            "triton": "3.6.0",
+        },
     )
 
 
@@ -69,3 +74,40 @@ def test_non_nvme_or_low_capacity_is_an_explicit_warning():
     assert report["status"] == "supported_with_warnings"
     assert report["ready"] is True
     assert report["warnings"] == ["nvme_storage", "storage_capacity"]
+
+
+def test_mismatched_kernel_cache_blocks_readiness_before_model_load():
+    snapshot = _snapshot()
+    report = assess_gb10(
+        replace(
+            snapshot,
+            dependencies={
+                **snapshot.dependencies,
+                "sparklab-kernel-cache": "0.1.0b1+cu130.g07097cb30",
+            },
+        )
+    )
+
+    assert report["status"] == "supported_not_ready"
+    assert report["ready"] is False
+    assert report["failures"] == ["kernel_cache_version"]
+    check = next(item for item in report["checks"] if item["name"] == "kernel_cache_version")
+    assert check["observed"] == {
+        "sparklab": "0.1.0+gabc1234",
+        "sparklab-kernel-cache": "0.1.0b1+cu130.g07097cb30",
+    }
+    assert any("matched wheel pair" in item for item in report["recommendations"])
+
+
+def test_missing_optional_kernel_cache_does_not_block_jit_fallback():
+    snapshot = _snapshot()
+    report = assess_gb10(
+        replace(
+            snapshot,
+            dependencies={**snapshot.dependencies, "sparklab-kernel-cache": None},
+        )
+    )
+
+    assert report["status"] == "supported"
+    assert report["ready"] is True
+    assert all(item["name"] != "kernel_cache_version" for item in report["checks"])


### PR DESCRIPTION
## Summary
- report the imported SparkLab runtime version and installed kernel-cache version in doctor snapshots
- fail readiness when the companion cache belongs to a different release or stamped build
- recommend reinstalling the runtime and cache as a matched wheel pair
- preserve the supported JIT fallback when no cache package is installed

## Why
A checkout running SparkLab 0.1.0 with an older 0.1.0b1 kernel cache passed initial platform inspection, allocated the Qwen model, and failed only during CUDA graph capture. Doctor now catches that environment drift before model loading.

## Verification
- PYTHONPATH=python .venv/bin/python -m pytest -q tests/sparklab/test_doctor.py tests/kernels/test_kernel_cache_version.py tests/sparklab/test_planner.py tests/sparklab/test_runtime.py
- PYTHONPATH=python .venv/bin/python -m pytest -q tests/sparklab
- 71 SparkLab product tests passed