### PR TITLE
bench: compare Qwen serving frameworks on GB10

### DIFF
--- a/benchmarks/frameworks/QWEN38_FLASH_NEXT.md
+++ b/benchmarks/frameworks/QWEN38_FLASH_NEXT.md
@@ -1,0 +1,81 @@
+# Qwen3.8-Flash-Next cross-framework benchmark
+
+This report measures batch-one text serving of Qwen3.8-Flash-Next on one NVIDIA
+DGX Spark (GB10, 128 GB coherent memory, ARM64 Linux). It is separate from the
+[Qwen3.6 comparison](README.md) because Qwen3.8-Flash-Next has a substantially
+different QSA/Gated-DeltaNet architecture, 24,576 routed experts, and a 102.4 GB
+external n-gram table.
+
+## Results
+
+| Framework | Version | Artifact | Status | Decode tok/s | Warm TTFT | Detail |
+|---|---:|---|---|---:|---:|---|
+| SparkLab | 0.1.0 | FTW NVFP4, pinned revision `cbbcf69f…` | Measured with startup warning | 16.42 | 0.386 s | QSA, CUDA graph, full immutable expert preload |
+| FreeToken | 0.1.2 (`4b94bdc`) | Same FTW NVFP4 | Unsupported | — | — | Artifact ABI mismatch: expected `model.layers.0.linear_attn.out_proj.weight_scale` |
+| vLLM | 0.28.0 | Publisher ModelOpt NVFP4 | Not run safely | — | — | Published checkpoint is 135 GB before runtime/KV overhead, exceeding GB10 coherent capacity |
+| SGLang | 0.5.18 | Publisher ModelOpt NVFP4 | Not run safely | — | — | Same resident-checkpoint capacity constraint |
+| llama.cpp | `9723942ad` | ggml-org Q8_0 GGUF | Not run safely | — | — | Official GGUF is 163 GB, exceeding coherent capacity |
+| Ollama | 0.33.2 | Official `125b-mlx` | Unavailable | — | — | Published Ollama variants are MLX artifacts, not runnable by the NVIDIA Linux backend |
+| KTransformers | 0.7.0.post1 | — | Unavailable | — | — | `kt-kernel` has no ARM64 wheel; this host cannot install the runtime |
+
+“Not run safely” is not a performance score. The benchmark watchdog deliberately
+does not start a framework when its immutable weight allocation already exceeds
+the machine's 121.7 GiB usable coherent-memory capacity before KV cache, compute
+buffers, and the 12 GiB operating-system reserve.
+
+## Method
+
+- One fixed reasoning prompt, concurrency one, temperature zero.
+- One 32-token warmup followed by three 256-token measured streams.
+- Warm TTFT is request start to the first non-empty content/reasoning SSE delta.
+- Decode throughput is `(completion_tokens - 1) / (last delta - first delta)`.
+- Context/KV capacity is 32,832 tokens with a 32,768-token sequence cap.
+- SparkLab used QSA, page size 16, naive cache, Triton NVFP4 expert kernels,
+  batch-one CUDA-graph replay, zero host expert LRU, and full expert preload.
+- Every server runs alone under a watchdog that terminates it below 12 GiB
+  `MemAvailable` or 2 GiB free swap.
+
+The measured trial decode rates were 16.07, 17.08, and 16.42 tok/s. The median
+TTFT was 0.386 seconds. All three requests returned exactly 256 completion tokens.
+Full preload loaded 24,576 routed experts in 34.58 seconds and disabled decode-time
+disk staging and expert-LRU bookkeeping.
+
+## Operational caveat
+
+The kernel log recorded five recoverable NVIDIA driver allocation warnings
+(`NV_ERR_NO_MEMORY`) at 01:53:36 while resident weights were loading. There was no
+Linux OOM kill (`oom_kill` remained zero), the server did not exit, swap did not grow,
+and it subsequently completed full preload, CUDA-graph capture, and all four requests.
+After graph capture the runtime reported 1.17 GiB of free device allocation headroom.
+The throughput is therefore valid, but this exact full-preload/32K configuration has
+a narrow driver-memory margin and should not be described as OOM-free.
+
+This closely reproduces the earlier certified 64-token probe
+`GB10-QWEN38-NVFP4-OPT-002` (16.61 tok/s, 0.403 s TTFT), while using the common
+cross-framework prompt and three longer measured requests.
+
+## FreeToken baseline limitation
+
+FreeToken's current CLI recognizes the model through its `qsa_sparse` backend, but
+FreeToken 0.1.2 cannot load SparkLab's pinned FTW artifact. The backend exits during
+weight loading because its expected linear-attention scale key is absent from the
+newer artifact ABI. Downloading FreeToken's separately documented 135 GB checkpoint
+would change both the checkpoint tuple and execution policy, so it is not presented
+as a controlled baseline in this report.
+
+## Reproduce
+
+```bash
+python benchmarks/frameworks/run_framework.py sparklab \
+  --model-family qwen38 \
+  --ftw "$HOME/.sparklab/models/qwen3.8-flash-next/prepared/0.5.0" \
+  --output-dir benchmarks/frameworks/results/qwen3.8-flash-next \
+  --startup-timeout 1800
+```
+
+Raw evidence:
+
+- [`results/qwen3.8-flash-next/sparklab.json`](results/qwen3.8-flash-next/sparklab.json)
+- [`results/qwen3.8-flash-next/sparklab.log`](results/qwen3.8-flash-next/sparklab.log)
+- [`results/qwen3.8-flash-next/freetoken.json`](results/qwen3.8-flash-next/freetoken.json)
+- [`results/qwen3.8-flash-next/freetoken.log`](results/qwen3.8-flash-next/freetoken.log)

--- a/benchmarks/frameworks/README.md
+++ b/benchmarks/frameworks/README.md
@@ -1,0 +1,72 @@
+# Qwen3.6 cross-framework benchmark
+
+This benchmark compares batch-one, OpenAI-compatible serving of Qwen3.6-35B-A3B
+on one NVIDIA DGX Spark. FreeToken and SparkLab share the exact FTW NVFP4 artifact;
+vLLM and SGLang share NVIDIA's ModelOpt NVFP4 checkpoint; llama.cpp and Ollama share
+an official Ollama Q4_K_M artifact. Results between groups are operational comparisons,
+while results within each shared-weight group are directly controlled.
+
+## Results
+
+| Framework | Version | Checkpoint format | Status | Decode tok/s | Warm TTFT | Reason when not measured |
+|---|---:|---|---|---:|---:|---|
+| FreeToken | 0.1.2 (`4b94bdc`) | FTW NVFP4 | Measured | 68.72 | 0.286 s | Baseline |
+| SparkLab | 0.1.0 | Same FTW NVFP4 | Measured | 70.11 | 0.279 s | +2.0% decode vs FreeToken |
+| vLLM | 0.28.0 | ModelOpt NVFP4 safetensors | Measured | 69.96 | 0.079 s | — |
+| SGLang | 0.5.18 | ModelOpt NVFP4 safetensors | Measured | 33.48 | 0.087 s | — |
+| llama.cpp | 0.3.0-dev (9723942ad) | Official Ollama Q4_K_M GGUF | Measured | 78.39 | 0.058 s | — |
+| KTransformers | N/A | Official Ollama Q4_K_M GGUF | Unavailable | — | — | `kt-kernel` 0.7.0.post1 publishes no ARM64 wheel |
+| Ollama | 0.33.2 | Official registry Q4_K_M | Measured | 94.02 | 0.060 s | — |
+| Ollama runner, MTP disabled | 0.33.2 | Same official Q4_K_M GGUF | Measured | 69.53 | 0.060 s | Controlled no-speculation run |
+
+## Method
+
+- Hardware: one NVIDIA DGX Spark, GB10, 128 GB coherent memory, ARM64 Linux.
+- Workload: one fixed reasoning prompt, batch/concurrency 1, greedy sampling, a
+  32-token warmup, then three 256-token measured requests.
+- Warm TTFT: request start to the first non-empty streamed content or reasoning delta.
+- Decode tok/s: `(completion_tokens - 1) / (last token time - first token time)`.
+- Token count: the server's final streamed OpenAI usage object. A server that does not
+  return exact usage is not assigned an estimated result.
+- Each framework runs alone. A missing implementation, unsupported architecture or
+  quantization, build failure, and OOM are distinct statuses with logs retained under
+  `results/qwen3.6-35b-a3b/`.
+- Ollama's native row includes its automatically selected Qwen MTP speculative
+  decoding. The `ollama-no-mtp` control invokes Ollama's bundled CUDA runner with
+  otherwise matched settings and deliberately omits `--spec-type draft-mtp`.
+
+FreeToken and SparkLab were freshly run through this harness with identical flags:
+full-resident expert cache, Triton NVFP4 expert kernels, one CUDA-graph batch, 32K
+sequence capacity, and the same immutable FTW bytes. FreeToken is pinned to upstream
+commit `4b94bdc38a46a4dfe534e8793126160d56904c44`.
+
+## Reproduce
+
+For vLLM and SGLang, download the immutable NVFP4 checkpoint:
+
+```bash
+hf download nvidia/Qwen3.6-35B-A3B-NVFP4 \
+  --revision 491c2f1ea524c639598bf8fa787a93fed5a6fbce \
+  --local-dir "$HOME/models/frameworks/qwen3.6-35b-a3b/hf"
+```
+
+Install and run one framework:
+
+```bash
+benchmarks/frameworks/setup_framework.sh vllm
+python benchmarks/frameworks/run_framework.py vllm
+```
+
+Run the controlled FreeToken/SparkLab pair:
+
+```bash
+benchmarks/frameworks/setup_framework.sh freetoken
+python benchmarks/frameworks/run_framework.py freetoken
+python benchmarks/frameworks/run_framework.py sparklab
+```
+
+For Ollama, pull `qwen3.6:35b-a3b`. Its verified GGUF weight layer can be passed to
+llama.cpp and KTransformers with `--gguf`, keeping those native-weight runs on the
+same bytes. Use `--model`, `--ftw`, `--gguf`, `--ollama-model`, `--port`, and `--output-dir`
+to override local paths. KTransformers cannot currently be installed from its
+official wheel release on this ARM64 host.

--- a/benchmarks/frameworks/bench_openai.py
+++ b/benchmarks/frameworks/bench_openai.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Measure warm TTFT and single-stream decode throughput over an OpenAI API.
+
+The server is warmed once, then measured repeatedly. Decode throughput excludes
+the first token: ``(completion_tokens - 1) / (last_token_time - first_token_time)``.
+The final streamed usage chunk supplies the exact completion-token count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import time
+import urllib.request
+from pathlib import Path
+
+
+PROMPT = (
+    "Solve this problem carefully and show your reasoning. Find the smallest positive "
+    "integer n for which 7n is a perfect square and 5n is a perfect cube."
+)
+
+
+def stream_once(base_url: str, model: str, max_tokens: int) -> dict:
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": PROMPT}],
+            "temperature": 0,
+            "max_tokens": max_tokens,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    ).encode()
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    started = time.perf_counter()
+    first = None
+    last = None
+    completion_tokens = None
+    pieces: list[str] = []
+    with urllib.request.urlopen(request, timeout=1800) as response:
+        for raw in response:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[5:].strip()
+            if data == "[DONE]":
+                break
+            event = json.loads(data)
+            usage = event.get("usage")
+            if usage and usage.get("completion_tokens") is not None:
+                completion_tokens = int(usage["completion_tokens"])
+            choices = event.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            # Reasoning deltas are not named consistently across compatible APIs:
+            # SGLang uses reasoning_content, while Ollama releases have used
+            # reasoning or thinking.
+            text = (
+                delta.get("reasoning_content")
+                or delta.get("reasoning")
+                or delta.get("thinking")
+                or delta.get("content")
+                or ""
+            )
+            if text:
+                now = time.perf_counter()
+                first = first or now
+                last = now
+                pieces.append(text)
+    ended = time.perf_counter()
+    if first is None or last is None:
+        raise RuntimeError("stream completed without a content or reasoning token")
+    if completion_tokens is None:
+        raise RuntimeError("server did not return streamed completion-token usage")
+    decode_seconds = last - first
+    return {
+        "ttft_seconds": first - started,
+        "decode_seconds": decode_seconds,
+        "decode_tokens_per_second": (
+            (completion_tokens - 1) / decode_seconds
+            if completion_tokens > 1 and decode_seconds > 0
+            else None
+        ),
+        "completion_tokens": completion_tokens,
+        "request_seconds": ended - started,
+        "output_sha256": hashlib.sha256("".join(pieces).encode()).hexdigest(),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--framework", required=True)
+    parser.add_argument("--version", default="unknown")
+    parser.add_argument("--weight-source", default="unknown")
+    parser.add_argument("--weight-format", default="unknown")
+    parser.add_argument("--warmup-tokens", type=int, default=32)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    warmup = stream_once(args.base_url, args.model, args.warmup_tokens)
+    trials = [
+        stream_once(args.base_url, args.model, args.max_tokens)
+        for _ in range(args.trials)
+    ]
+    result = {
+        "schema_version": "1.0",
+        "framework": args.framework,
+        "framework_version": args.version,
+        "status": "measured",
+        "weights": {"source": args.weight_source, "format": args.weight_format},
+        "method": {
+            "concurrency": 1,
+            "temperature": 0,
+            "warmup_requests": 1,
+            "measured_requests": args.trials,
+            "max_output_tokens": args.max_tokens,
+            "prompt": PROMPT,
+            "ttft": "request start to first non-empty content/reasoning SSE delta",
+            "decode": "(completion_tokens - 1) / (last delta - first delta)",
+        },
+        "warmup": warmup,
+        "trials": trials,
+        "metrics": {
+            "warm_ttft_seconds_median": statistics.median(
+                trial["ttft_seconds"] for trial in trials
+            ),
+            "decode_tokens_per_second_median": statistics.median(
+                trial["decode_tokens_per_second"] for trial in trials
+            ),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result["metrics"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/frameworks/demo.md
+++ b/benchmarks/frameworks/demo.md
@@ -1,0 +1,46 @@
+# DGX Spark model-serving demo
+
+## Test system
+
+| Component | Configuration |
+|---|---|
+| System | NVIDIA DGX Spark |
+| Processor / GPU | NVIDIA GB10 |
+| Memory | 128 GB coherent CPU/GPU memory (121.7 GiB reported usable) |
+| CPU / OS | 20-core ARM64, Ubuntu Linux |
+| CUDA | CUDA 13.0 |
+| Workload | OpenAI-compatible chat completion, batch/concurrency 1 |
+| Context | 32K sequence capacity |
+| Measurement | One 32-token warmup, then three 256-token streamed requests |
+| Decode metric | Median `(completion tokens - 1) / decode time` |
+| Safety | Frameworks run one at a time with a 12 GiB host-memory reserve |
+
+## Results
+
+| Model | Parameters | Quantization used | vLLM | llama.cpp | SparkLab |
+|---|---|---|---|---|---|
+| Qwen3.6-35B-A3B | 35B total / 3B active | vLLM and SparkLab: NVFP4; llama.cpp: Q4_K_M GGUF | **69.96 tok/s** | **78.39 tok/s** | **70.11 tok/s** |
+| Qwen3.8-Flash-Next | 125B language model + approximately 55B auxiliary / 6B active | vLLM: publisher ModelOpt NVFP4; llama.cpp: official Q8_0 GGUF; SparkLab: FTW NVFP4 | **Not run:** 135 GB checkpoint exceeds usable coherent memory before runtime and KV overhead | **Not run:** 163 GB official GGUF exceeds usable coherent memory | **16.42 tok/s** |
+
+## Interpretation
+
+- Qwen3.6 results are not fully quantization-controlled: vLLM and SparkLab use
+  NVFP4, while llama.cpp uses Q4_K_M. They represent practical runtime choices,
+  not a pure kernel comparison.
+- SparkLab's Qwen3.8 result uses QSA, batch-one CUDA-graph replay, and a full
+  immutable preload of all 24,576 routed experts. Decode-time expert disk staging
+  is disabled.
+- “Not run” is not a zero score. The corresponding official artifact could not be
+  loaded while retaining the benchmark's operating-system and runtime memory reserve.
+- The Qwen3.8 SparkLab startup emitted five recoverable NVIDIA
+  `NV_ERR_NO_MEMORY` warnings. There was no Linux OOM kill, the server completed
+  startup and all trials, but the configuration has a narrow device-memory margin.
+
+## Evidence
+
+- [Qwen3.6 cross-framework report](README.md)
+- [Qwen3.6 vLLM result](results/qwen3.6-35b-a3b/vllm.json)
+- [Qwen3.6 llama.cpp result](results/qwen3.6-35b-a3b/llama-cpp.json)
+- [Qwen3.6 SparkLab result](results/qwen3.6-35b-a3b/sparklab.json)
+- [Qwen3.8-Flash-Next report](QWEN38_FLASH_NEXT.md)
+- [Qwen3.8 SparkLab result](results/qwen3.8-flash-next/sparklab.json)

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/freetoken.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/freetoken.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "framework": "freetoken",
+  "framework_version": "freetoken version 0.1.2",
+  "status": "measured",
+  "weights": {
+    "source": "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW@fecab7acfd0590d2b268d8fb9ea1c88431471111",
+    "format": "FTW NVFP4"
+  },
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 52.206643233999785,
+    "decode_seconds": 0.4917687160013884,
+    "decode_tokens_per_second": 61.004287226589874,
+    "completion_tokens": 31,
+    "request_seconds": 52.69882598300319,
+    "output_sha256": "c5049234008141b69a00592fd53c2c81b230b780d079d1c320a0e9f75b576992"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 1.081627417999698,
+      "decode_seconds": 3.7738028000021586,
+      "decode_tokens_per_second": 67.30611361034941,
+      "completion_tokens": 255,
+      "request_seconds": 4.855552090000856,
+      "output_sha256": "e75d3fa18905f58b7956901252a9d5a214af06396397f109eb07fff01f43728e"
+    },
+    {
+      "ttft_seconds": 0.28581412200219347,
+      "decode_seconds": 3.6959219939999457,
+      "decode_tokens_per_second": 68.72439418698504,
+      "completion_tokens": 255,
+      "request_seconds": 3.9821089490033046,
+      "output_sha256": "b7600a171ba8d96ed74831caeb49596467aea9393d7ca47102851aac71676dd7"
+    },
+    {
+      "ttft_seconds": 0.28573375300038606,
+      "decode_seconds": 3.663667913999234,
+      "decode_tokens_per_second": 69.32942776539356,
+      "completion_tokens": 255,
+      "request_seconds": 3.9497819389980577,
+      "output_sha256": "1923058fb4629462072ce985f0d31c69c0746fe5ad739e28e76ec9c4d1e55e89"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.28581412200219347,
+    "decode_tokens_per_second_median": 68.72439418698504
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/ktransformers.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/ktransformers.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1.0",
+  "framework": "ktransformers",
+  "framework_version": "unknown",
+  "status": "unavailable",
+  "reason": "KTransformers runtime is unavailable on this platform: its pinned kt-kernel release has no aarch64 wheel",
+  "server_log": "benchmarks/frameworks/results/qwen3.6-35b-a3b/ktransformers.log"
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/llama-cpp.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/llama-cpp.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "framework": "llama.cpp",
+  "framework_version": "version: 0.3.0-dev (build 10711, commit 9723942ad)\nbuilt with GNU 13.3.0 for Linux aarch64",
+  "status": "measured",
+  "weights": {
+    "source": "ollama.com/library/qwen3.6:35b-a3b (GGUF layer sha256:d372de8e9348...)",
+    "format": "Q4_K_M"
+  },
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 0.2771920779996435,
+    "decode_seconds": 0.4060751329998311,
+    "decode_tokens_per_second": 76.34055247606825,
+    "completion_tokens": 32,
+    "request_seconds": 0.6833605550018547,
+    "output_sha256": "cc8d42bac1dab94ba9b72c590af2da5169360913afc186f5ce60b95c674fbc68"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.04836218000127701,
+      "decode_seconds": 3.2572403869999107,
+      "decode_tokens_per_second": 78.2871295031646,
+      "completion_tokens": 256,
+      "request_seconds": 3.305724519002979,
+      "output_sha256": "71d30a715abb06d6ff414be98eb1b74fc80b3dc6f5a98bd679d3a5ef52ded070"
+    },
+    {
+      "ttft_seconds": 0.10856948899890995,
+      "decode_seconds": 3.2529950969983474,
+      "decode_tokens_per_second": 78.38929736946037,
+      "completion_tokens": 256,
+      "request_seconds": 3.361708201999136,
+      "output_sha256": "71d30a715abb06d6ff414be98eb1b74fc80b3dc6f5a98bd679d3a5ef52ded070"
+    },
+    {
+      "ttft_seconds": 0.05791089099875535,
+      "decode_seconds": 3.2500394550006604,
+      "decode_tokens_per_second": 78.46058595000909,
+      "completion_tokens": 256,
+      "request_seconds": 3.3080221059972246,
+      "output_sha256": "71d30a715abb06d6ff414be98eb1b74fc80b3dc6f5a98bd679d3a5ef52ded070"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.05791089099875535,
+    "decode_tokens_per_second_median": 78.38929736946037
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/ollama-no-mtp.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/ollama-no-mtp.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "framework": "ollama-no-mtp",
+  "framework_version": "0.33.2",
+  "status": "measured",
+  "weights": {
+    "source": "ollama.com/library/qwen3.6:35b-a3b",
+    "format": "Q4_K_M"
+  },
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 0.2786553219993948,
+    "decode_seconds": 0.4383833190004225,
+    "decode_tokens_per_second": 70.71436949445179,
+    "completion_tokens": 32,
+    "request_seconds": 0.7171306409982208,
+    "output_sha256": "31d05e6d16de359253ce105554dae4e471a471aec8d6e75d89b218cd29cbbda9"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.04598626499864622,
+      "decode_seconds": 3.4281276570000045,
+      "decode_tokens_per_second": 74.38462785343108,
+      "completion_tokens": 256,
+      "request_seconds": 3.4742062739969697,
+      "output_sha256": "644ccd18c49fe62bbde950437f78b99258c76af08ce602a48310d0ad89eea0d8"
+    },
+    {
+      "ttft_seconds": 0.09715274600239354,
+      "decode_seconds": 3.667353552998975,
+      "decode_tokens_per_second": 69.53242885226432,
+      "completion_tokens": 256,
+      "request_seconds": 3.764605531003326,
+      "output_sha256": "644ccd18c49fe62bbde950437f78b99258c76af08ce602a48310d0ad89eea0d8"
+    },
+    {
+      "ttft_seconds": 0.06047134400068899,
+      "decode_seconds": 3.717115322997415,
+      "decode_tokens_per_second": 68.60158425065289,
+      "completion_tokens": 256,
+      "request_seconds": 3.777698923000571,
+      "output_sha256": "644ccd18c49fe62bbde950437f78b99258c76af08ce602a48310d0ad89eea0d8"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.06047134400068899,
+    "decode_tokens_per_second_median": 69.53242885226432
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/ollama.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/ollama.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "framework": "ollama",
+  "framework_version": "0.33.2",
+  "status": "measured",
+  "weights": {
+    "source": "ollama.com/library/qwen3.6:35b-a3b",
+    "format": "Q4_K_M"
+  },
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 6.870779919998313,
+    "decode_seconds": 0.3263595240023278,
+    "decode_tokens_per_second": 94.9872693152319,
+    "completion_tokens": 32,
+    "request_seconds": 7.197232195998367,
+    "output_sha256": "cc8d42bac1dab94ba9b72c590af2da5169360913afc186f5ce60b95c674fbc68"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.05046375199890463,
+      "decode_seconds": 2.705840843002079,
+      "decode_tokens_per_second": 94.24057614456079,
+      "completion_tokens": 256,
+      "request_seconds": 2.756375763001415,
+      "output_sha256": "c9f5004318f766ed8ad74de21edf268d56d1fafe3099e66ecc4b111720817387"
+    },
+    {
+      "ttft_seconds": 0.11614355499841622,
+      "decode_seconds": 2.7120887950004544,
+      "decode_tokens_per_second": 94.02347020129821,
+      "completion_tokens": 256,
+      "request_seconds": 2.8283675179991405,
+      "output_sha256": "c9f5004318f766ed8ad74de21edf268d56d1fafe3099e66ecc4b111720817387"
+    },
+    {
+      "ttft_seconds": 0.060254473999521,
+      "decode_seconds": 2.715784699001233,
+      "decode_tokens_per_second": 93.89551391676216,
+      "completion_tokens": 256,
+      "request_seconds": 2.77647152499776,
+      "output_sha256": "c9f5004318f766ed8ad74de21edf268d56d1fafe3099e66ecc4b111720817387"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.060254473999521,
+    "decode_tokens_per_second_median": 94.02347020129821
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/sglang.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/sglang.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "1.0",
+  "framework": "sglang",
+  "framework_version": "0.5.18",
+  "status": "measured",
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 0.26236061600047833,
+    "decode_seconds": 0.9383760820001044,
+    "decode_tokens_per_second": 33.035795130162484,
+    "completion_tokens": 32,
+    "request_seconds": 1.2008154220002325,
+    "output_sha256": "83f9de56516ce245a7f1cc2a77cf32d9f20c24d23bb7787486c4300d23137913"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.08714153599976271,
+      "decode_seconds": 7.721950978000677,
+      "decode_tokens_per_second": 33.022742662635125,
+      "completion_tokens": 256,
+      "request_seconds": 7.809174551000069,
+      "output_sha256": "88088842f7048ac1cc395691a21fc6fe44e459e962bebc6e70bb91298308e7ab"
+    },
+    {
+      "ttft_seconds": 0.08681661299942789,
+      "decode_seconds": 7.6168231060000835,
+      "decode_tokens_per_second": 33.47852463570095,
+      "completion_tokens": 256,
+      "request_seconds": 7.703723531999458,
+      "output_sha256": "0ca81d831ee627e8c7572ccd83b7ff071de11b369c6d14f1858004709f882a5e"
+    },
+    {
+      "ttft_seconds": 0.08834320200003276,
+      "decode_seconds": 7.586978143999659,
+      "decode_tokens_per_second": 33.61021939962656,
+      "completion_tokens": 256,
+      "request_seconds": 7.675416710999343,
+      "output_sha256": "0d5ac5460ec672c35684ac990c9b5edae6fbaf960943a0b7bdef0073632d3d21"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.08714153599976271,
+    "decode_tokens_per_second_median": 33.47852463570095
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/sparklab.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/sparklab.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1.0",
+  "framework": "sparklab",
+  "framework_version": "SparkLab 0.1.0",
+  "status": "measured",
+  "weights": {
+    "source": "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW@fecab7acfd0590d2b268d8fb9ea1c88431471111",
+    "format": "FTW NVFP4"
+  },
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 0.9693077599986282,
+    "decode_seconds": 0.4998225179988367,
+    "decode_tokens_per_second": 62.02201558288366,
+    "completion_tokens": 32,
+    "request_seconds": 1.4698038309979893,
+    "output_sha256": "83f9de56516ce245a7f1cc2a77cf32d9f20c24d23bb7787486c4300d23137913"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.33298703900072724,
+      "decode_seconds": 3.7262239170013345,
+      "decode_tokens_per_second": 68.43389063027924,
+      "completion_tokens": 256,
+      "request_seconds": 4.060031838002033,
+      "output_sha256": "9a8a2116f9450197919cdacd13ea3f1b50c8f82013c78fcdcb4bfb327d7fdd45"
+    },
+    {
+      "ttft_seconds": 0.2788968940003542,
+      "decode_seconds": 3.6367349829997693,
+      "decode_tokens_per_second": 70.11783954344197,
+      "completion_tokens": 256,
+      "request_seconds": 3.916260149999289,
+      "output_sha256": "9afd6810669a1a14be940da128c95619a542941a01db3ec2d321117340c16a2a"
+    },
+    {
+      "ttft_seconds": 0.2759480099994107,
+      "decode_seconds": 3.6371646629995666,
+      "decode_tokens_per_second": 70.10955610398506,
+      "completion_tokens": 256,
+      "request_seconds": 3.913766162000684,
+      "output_sha256": "9afd6810669a1a14be940da128c95619a542941a01db3ec2d321117340c16a2a"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.2788968940003542,
+    "decode_tokens_per_second_median": 70.10955610398506
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.6-35b-a3b/vllm.json
+++ b/benchmarks/frameworks/results/qwen3.6-35b-a3b/vllm.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "1.0",
+  "framework": "vllm",
+  "framework_version": "0.28.0",
+  "status": "measured",
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 17.059296691790223,
+    "decode_seconds": 0.48245472367852926,
+    "decode_tokens_per_second": 64.25473413056686,
+    "completion_tokens": 32,
+    "request_seconds": 17.541837063618004,
+    "output_sha256": "e7df0d926f2c0fe03d5c94450acac082c78ad07540ddbddb1ac0af0ade682e67"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.16001198813319206,
+      "decode_seconds": 3.6451650047674775,
+      "decode_tokens_per_second": 69.95568092706033,
+      "completion_tokens": 256,
+      "request_seconds": 3.8052683044224977,
+      "output_sha256": "6515087516777133f5f6a5b29396f910619e1d90d6584f418a38f988b8dea4cd"
+    },
+    {
+      "ttft_seconds": 0.06649998482316732,
+      "decode_seconds": 3.636943666264415,
+      "decode_tokens_per_second": 70.11381626977911,
+      "completion_tokens": 256,
+      "request_seconds": 3.703502387739718,
+      "output_sha256": "6a6fb73b267770a4a4ff59e4a1461522a6d17e0a993b698b54206e58019444f7"
+    },
+    {
+      "ttft_seconds": 0.07887429650872946,
+      "decode_seconds": 3.6464018877595663,
+      "decode_tokens_per_second": 69.93195150978761,
+      "completion_tokens": 256,
+      "request_seconds": 3.7253712564706802,
+      "output_sha256": "49a1ca4ce9dc811674cae7c97864b13824f7cc96dee615e71346c9142f1b24ed"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.07887429650872946,
+    "decode_tokens_per_second_median": 69.95568092706033
+  }
+}

--- a/benchmarks/frameworks/results/qwen3.8-flash-next/freetoken.json
+++ b/benchmarks/frameworks/results/qwen3.8-flash-next/freetoken.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1.0",
+  "framework": "freetoken",
+  "framework_version": "freetoken version 0.1.2",
+  "status": "unsupported",
+  "reason": "FreeToken 0.1.2 cannot load this pinned FTW artifact: missing model.layers.0.linear_attn.out_proj.weight_scale in its expected artifact ABI",
+  "server_log": "benchmarks/frameworks/results/qwen3.8-flash-next/freetoken.log"
+}

--- a/benchmarks/frameworks/results/qwen3.8-flash-next/sparklab.json
+++ b/benchmarks/frameworks/results/qwen3.8-flash-next/sparklab.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "1.0",
+  "framework": "sparklab",
+  "framework_version": "SparkLab 0.1.0",
+  "status": "measured",
+  "weights": {
+    "source": "oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW@cbbcf69f52b9815b8a987fe839003fae12aa8050",
+    "format": "FTW NVFP4"
+  },
+  "warnings": [
+    "Five recoverable NVIDIA driver NV_ERR_NO_MEMORY allocation warnings occurred at 2026-08-31 01:53:36 during startup. The process was not killed and subsequently completed preload, graph capture, and all measured trials."
+  ],
+  "method": {
+    "concurrency": 1,
+    "temperature": 0,
+    "warmup_requests": 1,
+    "measured_requests": 3,
+    "max_output_tokens": 256,
+    "prompt": "Solve this problem carefully and show your reasoning. Find the smallest positive integer n for which 7n is a perfect square and 5n is a perfect cube.",
+    "ttft": "request start to first non-empty content/reasoning SSE delta",
+    "decode": "(completion_tokens - 1) / (last delta - first delta)"
+  },
+  "warmup": {
+    "ttft_seconds": 1.0205496919988946,
+    "decode_seconds": 1.9676862710002752,
+    "decode_tokens_per_second": 15.754544033201553,
+    "completion_tokens": 32,
+    "request_seconds": 2.98853181999948,
+    "output_sha256": "b092831052f990f2d6b722af2d74424cd814dd835bd0517508598f4e6758a421"
+  },
+  "trials": [
+    {
+      "ttft_seconds": 0.38599650799733354,
+      "decode_seconds": 15.864306262003083,
+      "decode_tokens_per_second": 16.07381979322699,
+      "completion_tokens": 256,
+      "request_seconds": 16.250573346998863,
+      "output_sha256": "d9cd2ec2a0c7145389eb1705c031f4dbc9f97a35631f91b7e463e95c4be6119f"
+    },
+    {
+      "ttft_seconds": 0.389334573999804,
+      "decode_seconds": 14.928146259000641,
+      "decode_tokens_per_second": 17.08182620774181,
+      "completion_tokens": 256,
+      "request_seconds": 15.317776113999571,
+      "output_sha256": "d9cd2ec2a0c7145389eb1705c031f4dbc9f97a35631f91b7e463e95c4be6119f"
+    },
+    {
+      "ttft_seconds": 0.3838914730004035,
+      "decode_seconds": 15.529134996999346,
+      "decode_tokens_per_second": 16.420747198686403,
+      "completion_tokens": 256,
+      "request_seconds": 15.91391666400159,
+      "output_sha256": "81f6bbdd4d6a9c654091b04a81592d26b0131e3f5a3e89caf54d62c22767deba"
+    }
+  ],
+  "metrics": {
+    "warm_ttft_seconds_median": 0.38599650799733354,
+    "decode_tokens_per_second_median": 16.420747198686403
+  }
+}

--- a/benchmarks/frameworks/run_framework.py
+++ b/benchmarks/frameworks/run_framework.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Launch one framework, benchmark its OpenAI endpoint, and preserve failure evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+USER_HOME = Path.home()
+DEFAULT_MODEL = USER_HOME / "models/frameworks/qwen3.6-35b-a3b/hf"
+DEFAULT_GGUF = USER_HOME / "models/frameworks/qwen3.6-35b-a3b/gguf/qwen3.6-35b-a3b.gguf"
+DEFAULT_FTW = USER_HOME / ".sparklab/models/qwen3.6-35b-a3b/prepared/0.2.0"
+INSTALL_ROOT = Path(os.environ.get(
+    "SPARKLAB_FRAMEWORK_ROOT", USER_HOME / ".local/share/sparklab-frameworks"
+))
+SERVED_MODEL = "qwen3.6-35b-a3b"
+DEFAULT_OLLAMA_MODEL = "qwen3.6:35b-a3b"
+KIB_PER_GIB = 1 << 20
+NVFP4_FRAMEWORKS = {"vllm", "sglang"}
+
+
+class MemorySafetyAbort(RuntimeError):
+    pass
+
+
+def command_for(name: str, model: Path, gguf: Path, port: int, ftw: Path | None = None,
+                model_family: str = "qwen36") -> tuple[list[str], str]:
+    ftw = ftw or DEFAULT_FTW
+    served_model = "qwen3.8-flash-next" if model_family == "qwen38" else SERVED_MODEL
+    if name == "vllm":
+        exe = INSTALL_ROOT / "vllm/bin/vllm"
+        return ([str(exe), "serve", str(model), "--host", "127.0.0.1", "--port", str(port),
+                 "--served-model-name", SERVED_MODEL, "--max-model-len", "32768",
+                 "--gpu-memory-utilization", "0.50", "--trust-remote-code"], str(exe))
+    if name == "sglang":
+        exe = INSTALL_ROOT / "sglang/bin/python"
+        return ([str(exe), "-m", "sglang.launch_server", "--model-path", str(model),
+                 "--host", "127.0.0.1", "--port", str(port), "--served-model-name", SERVED_MODEL,
+                 "--context-length", "32768", "--mem-fraction-static", "0.50",
+                 "--max-running-requests", "1", "--max-total-tokens", "32768",
+                 "--max-mamba-cache-size", "5", "--watchdog-timeout", "1200",
+                 "--moe-runner-backend", "flashinfer_cutlass", "--disable-flashinfer-autotune",
+                 "--disable-cuda-graph", "--trust-remote-code"], str(exe))
+    if name == "llama.cpp":
+        exe = INSTALL_ROOT / "llama.cpp/build/bin/llama-server"
+        return ([str(exe), "-m", str(gguf), "--host", "127.0.0.1", "--port", str(port),
+                 "--alias", SERVED_MODEL, "-ngl", "99", "-c", "32768", "--parallel", "1",
+                 "-fa", "on", "--no-webui"], str(exe))
+    if name == "ollama":
+        exe = INSTALL_ROOT / "ollama/bin/ollama"
+        return ([str(exe), "serve"], str(exe))
+    if name == "ollama-no-mtp":
+        exe = INSTALL_ROOT / "ollama/lib/ollama/llama-server"
+        return ([str(exe), "--model", str(gguf), "--host", "127.0.0.1", "--port", str(port),
+                 "--alias", SERVED_MODEL, "--no-webui", "--offline", "-c", "32768", "-np", "1",
+                 "-ngl", "99",
+                 "--no-jinja", "--chat-template", "chatml", "--load-mode", "dio",
+                 "--flash-attn", "auto", "-b", "1024", "-ub", "1024", "--keep", "4"], str(exe))
+    if name == "ktransformers":
+        exe = INSTALL_ROOT / "ktransformers/bin/python"
+        return ([str(exe), "-m", "ktransformers.server.main", "--model_path", str(model),
+                 "--gguf_path", str(gguf), "--host", "127.0.0.1", "--port", str(port)], str(exe))
+    if name in {"freetoken", "sparklab"}:
+        exe = INSTALL_ROOT / "freetoken/bin/ft" if name == "freetoken" else ROOT.parents[1] / ".venv/bin/sparklab"
+        common = [str(exe), "serve", "--model", str(ftw), "--host", "127.0.0.1",
+                 "--port", str(port), "--served-model-name", served_model,
+                 "--max-running-requests", "1", "--max-seq-len-override", "32768",
+                 "--num-tokens", "32832", "--cuda-graph-max-bs", "1",
+                 "--moe-backend", "offload", "--moe-cache-rate", "1.0",
+                 "--nvfp4-backend", "triton", "--moe-prefill-hit-d2d"]
+        if model_family == "qwen38":
+            common.extend(["--attention-backend", "qsa" if name == "sparklab" else "qsa_sparse",
+                           "--cache-type", "naive",
+                           "--page-size", "16"])
+            if name == "sparklab":
+                common.extend(["--moe-storage", "disk", "--moe-host-cache-gb", "0",
+                               "--moe-preload-all"])
+        return (common, str(exe))
+    raise ValueError(name)
+
+
+def validate_nvfp4_checkpoint(model: Path) -> None:
+    config_path = model / "config.json"
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read checkpoint quantization metadata: {error}") from error
+    quantization = config.get("quantization_config") or {}
+    layers = quantization.get("quantized_layers") or {}
+    algorithms = {
+        layer.get("quant_algo")
+        for layer in layers.values()
+        if isinstance(layer, dict)
+    }
+    if "W4A16_NVFP4" not in algorithms:
+        raise ValueError(f"checkpoint is not the required ModelOpt NVFP4 format: {model}")
+
+
+def environment_for(name: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("CUDA_VISIBLE_DEVICES", "0")
+    if name == "sglang":
+        # These are separate from --disable-flashinfer-autotune. On GB10, the FP8
+        # configuration sweep previously launched 22 cicc processes that used 60 GiB
+        # of host RAM while the model already held unified memory.
+        env.setdefault("SGLANG_ENABLE_FP8_GEMM_CONFIG_TUNE", "0")
+        # Four compiler jobs keep peak compiler RSS below the host safety margin
+        # while avoiding the impractical startup time of fully serial compilation.
+        env.setdefault("MAX_JOBS", "4")
+        env.setdefault("FLASHINFER_MM_FP4_CUTE_DSL_COMPILE_WORKERS", "1")
+    if name == "ollama":
+        env.setdefault("OLLAMA_MODELS", str(USER_HOME / "models/frameworks/ollama"))
+        env.setdefault("OLLAMA_NUM_PARALLEL", "1")
+        env.setdefault("OLLAMA_MAX_LOADED_MODELS", "1")
+        env.setdefault("OLLAMA_CONTEXT_LENGTH", "32768")
+    if name == "ollama-no-mtp":
+        lib = INSTALL_ROOT / "ollama/lib/ollama"
+        cuda = lib / "cuda_v13"
+        current = env.get("LD_LIBRARY_PATH", "")
+        env["LD_LIBRARY_PATH"] = f"{lib}:{cuda}" + (f":{current}" if current else "")
+        env["GGML_BACKEND_PATH"] = str(cuda / "libggml-cuda.so")
+    if name in {"freetoken", "sparklab"}:
+        env.setdefault("MAX_JOBS", "4")
+    return env
+
+
+def memory_safety_reason(
+    *, min_available_gib: float, min_swap_free_gib: float, meminfo: Path = Path("/proc/meminfo")
+) -> str | None:
+    values: dict[str, int] = {}
+    for line in meminfo.read_text().splitlines():
+        key, value = line.split(":", 1)
+        values[key] = int(value.strip().split()[0])
+    available = values["MemAvailable"] / KIB_PER_GIB
+    swap_free = values.get("SwapFree", 0) / KIB_PER_GIB
+    if available < min_available_gib:
+        return f"MemAvailable {available:.1f} GiB fell below {min_available_gib:.1f} GiB"
+    if values.get("SwapTotal", 0) and swap_free < min_swap_free_gib:
+        return f"SwapFree {swap_free:.1f} GiB fell below {min_swap_free_gib:.1f} GiB"
+    return None
+
+
+def terminate_group(process: subprocess.Popen, timeout: int = 30) -> None:
+    if process.poll() is not None:
+        return
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+
+
+def version_for(name: str, exe: str) -> str:
+    commands = {
+        "vllm": [exe, "--version"],
+        "sglang": [exe, "-c", "import sglang; print(sglang.__version__)"],
+        "llama.cpp": [exe, "--version"],
+        "ollama": [exe, "--version"],
+        "ollama-no-mtp": [str(INSTALL_ROOT / "ollama/bin/ollama"), "--version"],
+        "ktransformers": [exe, "-c", "import importlib.metadata as m; print(m.version('ktransformers'))"],
+        "freetoken": [exe, "--version"],
+        "sparklab": [exe, "--version"],
+    }
+    try:
+        return subprocess.check_output(commands[name], text=True, stderr=subprocess.STDOUT, timeout=30).strip()
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+def ready(base_url: str) -> bool:
+    try:
+        with urllib.request.urlopen(base_url + "/health", timeout=3) as response:
+            body = response.read()
+            if body:
+                try:
+                    health = json.loads(body)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    health = None
+                if isinstance(health, dict) and "status" in health:
+                    return health["status"] in {"ok", "ready", "healthy"}
+            return response.status < 400
+    except urllib.error.HTTPError as error:
+        # A live 503 means the framework is still loading or warming up. Do not
+        # mistake an early /v1/models response for readiness, as the old harness did.
+        if error.code != 404:
+            return False
+    except Exception:
+        return False
+    try:
+        with urllib.request.urlopen(base_url + "/v1/models", timeout=3) as response:
+            return response.status < 400
+    except Exception:
+        return False
+
+
+def classify(log: str, returncode: int | None) -> tuple[str, str]:
+    low = log.lower()
+    if re.search(r"out of memory|cuda.*oom|cannot allocate memory|oom-kill", low):
+        return "oom", "server log reports an out-of-memory allocation failure"
+    if re.search(r"unsupported|not supported|unknown model|model architecture.*not", low):
+        match = next((line.strip() for line in log.splitlines() if "support" in line.lower()), "")
+        return "unsupported", match[-500:] or "framework reports the model or quantization is unsupported"
+    if "no such file or directory" in low or returncode == 127:
+        return "unavailable", "framework executable or required artifact is missing"
+    tail = "\n".join(log.splitlines()[-8:])[-1200:]
+    return "failed", tail or f"server exited with status {returncode}"
+
+
+def write_failure(path: Path, framework: str, version: str, status: str, reason: str, log: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"schema_version": "1.0", "framework": framework,
+        "framework_version": version, "status": status, "reason": reason,
+        "server_log": str(log)}, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("framework", choices=["vllm", "sglang", "llama.cpp", "ktransformers", "ollama", "ollama-no-mtp", "freetoken", "sparklab"])
+    parser.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--gguf", type=Path, default=DEFAULT_GGUF)
+    parser.add_argument("--ftw", type=Path, default=DEFAULT_FTW)
+    parser.add_argument("--model-family", choices=["qwen36", "qwen38"], default="qwen36")
+    parser.add_argument("--ollama-model", default=DEFAULT_OLLAMA_MODEL)
+    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument("--startup-timeout", type=int, default=1200)
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--min-available-gib", type=float, default=12.0,
+        help="terminate the framework before host available memory drops below this value")
+    parser.add_argument("--min-swap-free-gib", type=float, default=2.0,
+        help="terminate the framework before free swap drops below this value")
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "results/qwen3.6-35b-a3b")
+    args = parser.parse_args()
+    output = args.output_dir / f"{args.framework.replace('.', '-')}.json"
+    log_path = args.output_dir / f"{args.framework.replace('.', '-')}.log"
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.framework in NVFP4_FRAMEWORKS:
+        try:
+            validate_nvfp4_checkpoint(args.model)
+        except ValueError as error:
+            write_failure(output, args.framework, "not-run", "unsupported", str(error), log_path)
+            raise SystemExit(2)
+    command, exe = command_for(args.framework, args.model, args.gguf, args.port, args.ftw,
+        args.model_family)
+    version = version_for(args.framework, exe)
+    if not Path(exe).exists():
+        write_failure(output, args.framework, version, "unavailable", f"executable not found: {exe}", log_path)
+        raise SystemExit(2)
+    if args.framework == "ktransformers":
+        probe = subprocess.run([exe, "-c", "import ktransformers, kt_kernel"],
+            text=True, capture_output=True)
+        if probe.returncode:
+            reason = (
+                "KTransformers runtime is unavailable on this platform: its pinned kt-kernel "
+                "release has no aarch64 wheel"
+            )
+            write_failure(output, args.framework, version, "unavailable", reason, log_path)
+            raise SystemExit(2)
+    if args.framework in {"llama.cpp", "ktransformers", "ollama-no-mtp"} and not args.gguf.exists():
+        write_failure(output, args.framework, version, "unsupported", f"GGUF artifact not found: {args.gguf}", log_path)
+        raise SystemExit(2)
+    if args.framework in {"freetoken", "sparklab"} and not args.ftw.exists():
+        write_failure(output, args.framework, version, "unavailable", f"FTW artifact not found: {args.ftw}", log_path)
+        raise SystemExit(2)
+
+    env = environment_for(args.framework)
+    if args.framework == "ollama":
+        env["OLLAMA_HOST"] = f"127.0.0.1:{args.port}"
+    with log_path.open("w") as log_file:
+        process = subprocess.Popen(command, stdout=log_file, stderr=subprocess.STDOUT,
+            env=env, start_new_session=True, text=True)
+        benchmark_process: subprocess.Popen | None = None
+        try:
+            deadline = time.monotonic() + args.startup_timeout
+            base_url = f"http://127.0.0.1:{args.port}"
+            while time.monotonic() < deadline and process.poll() is None:
+                unsafe = memory_safety_reason(
+                    min_available_gib=args.min_available_gib,
+                    min_swap_free_gib=args.min_swap_free_gib,
+                )
+                if unsafe:
+                    raise MemorySafetyAbort(unsafe)
+                if ready(base_url):
+                    break
+                time.sleep(2)
+            if process.poll() is not None or not ready(base_url):
+                log_file.flush()
+                text = log_path.read_text(errors="replace")
+                status, reason = classify(text, process.poll())
+                write_failure(output, args.framework, version, status, reason, log_path)
+                raise SystemExit(3)
+            benchmark_process = subprocess.Popen(
+                [sys.executable, str(ROOT / "bench_openai.py"), "--base-url", base_url,
+                "--model", args.ollama_model if args.framework == "ollama" else (
+                    "qwen3.8-flash-next" if args.model_family == "qwen38" else SERVED_MODEL),
+                "--framework", args.framework, "--version", version,
+                "--weight-source", (
+                    "oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW@cbbcf69f52b9815b8a987fe839003fae12aa8050" if args.framework in {"freetoken", "sparklab"} and args.model_family == "qwen38"
+                    else "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW@fecab7acfd0590d2b268d8fb9ea1c88431471111" if args.framework in {"freetoken", "sparklab"}
+                    else "ollama.com/library/qwen3.6:35b-a3b" if args.framework in {"ollama", "ollama-no-mtp"}
+                    else "ollama.com/library/qwen3.6:35b-a3b (GGUF layer sha256:d372de8e9348...)" if args.framework in {"llama.cpp", "ktransformers"}
+                    else "nvidia/Qwen3.6-35B-A3B-NVFP4"
+                ),
+                "--weight-format", (
+                    "FTW NVFP4" if args.framework in {"freetoken", "sparklab"}
+                    else "Q4_K_M" if args.framework in {"llama.cpp", "ktransformers", "ollama", "ollama-no-mtp"}
+                    else "ModelOpt NVFP4"
+                ),
+                "--trials", str(args.trials), "--output", str(output)],
+                start_new_session=True,
+            )
+            while benchmark_process.poll() is None:
+                unsafe = memory_safety_reason(
+                    min_available_gib=args.min_available_gib,
+                    min_swap_free_gib=args.min_swap_free_gib,
+                )
+                if unsafe:
+                    raise MemorySafetyAbort(unsafe)
+                time.sleep(1)
+            if benchmark_process.returncode:
+                write_failure(output, args.framework, version, "failed",
+                    f"benchmark client exited {benchmark_process.returncode}", log_path)
+                raise SystemExit(benchmark_process.returncode)
+        except MemorySafetyAbort as error:
+            message = f"memory safety watchdog stopped the run: {error}"
+            log_file.write(f"\n[benchmark] {message}\n")
+            log_file.flush()
+            write_failure(output, args.framework, version, "oom_prevented", message, log_path)
+            raise SystemExit(4)
+        finally:
+            if benchmark_process is not None:
+                terminate_group(benchmark_process)
+            terminate_group(process)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/frameworks/setup_framework.sh
+++ b/benchmarks/frameworks/setup_framework.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+framework=${1:?usage: setup_framework.sh FRAMEWORK}
+root=${SPARKLAB_FRAMEWORK_ROOT:-$HOME/.local/share/sparklab-frameworks}
+mkdir -p "$root"
+
+case "$framework" in
+  vllm)
+    uv venv --python 3.12 "$root/vllm"
+    uv pip install --python "$root/vllm/bin/python" 'vllm==0.28.0'
+    ;;
+  sglang)
+    uv venv --python 3.12 "$root/sglang"
+    uv pip install --python "$root/sglang/bin/python" 'sglang[all]==0.5.18'
+    ;;
+  ktransformers)
+    uv venv --python 3.11 "$root/ktransformers"
+    uv pip install --python "$root/ktransformers/bin/python" 'ktransformers==0.7.0.post1'
+    ;;
+  llama.cpp)
+    if [[ ! -d "$root/llama.cpp/.git" ]]; then
+      git clone https://github.com/ggml-org/llama.cpp "$root/llama.cpp"
+    fi
+    git -C "$root/llama.cpp" pull --ff-only
+    cmake -S "$root/llama.cpp" -B "$root/llama.cpp/build" \
+      -DGGML_CUDA=ON -DGGML_NATIVE=ON -DCMAKE_BUILD_TYPE=Release
+    # Keep CUDA compilation below the host-memory safety margin. Unbounded
+    # parallel compilation previously contributed to a kernel OOM on this host.
+    cmake --build "$root/llama.cpp/build" --config Release --target llama-server -j "${MAX_JOBS:-4}"
+    ;;
+  ollama)
+    mkdir -p "$root/ollama/bin"
+    archive=$(mktemp)
+    curl -fL https://ollama.com/download/ollama-linux-arm64.tar.zst -o "$archive"
+    tar --zstd -xf "$archive" -C "$root/ollama"
+    rm -f "$archive"
+    ;;
+  freetoken)
+    src="$root/freetoken-src"
+    if [[ ! -d "$src/.git" ]]; then
+      git clone https://github.com/FlashML-org/FreeToken.git "$src"
+    fi
+    git -C "$src" fetch origin 4b94bdc38a46a4dfe534e8793126160d56904c44
+    git -C "$src" checkout --detach 4b94bdc38a46a4dfe534e8793126160d56904c44
+    uv venv --python 3.12 "$root/freetoken"
+    uv pip install --python "$root/freetoken/bin/python" -e "$src[accel]"
+    ;;
+  *)
+    echo "unknown framework: $framework" >&2
+    exit 2
+    ;;
+esac

--- a/tests/test_framework_benchmark_safety.py
+++ b/tests/test_framework_benchmark_safety.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+import importlib.util
+import json
+import sys
+
+
+SCRIPT = Path(__file__).parents[1] / "benchmarks" / "frameworks" / "run_framework.py"
+SPEC = importlib.util.spec_from_file_location("run_framework_safety", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_sglang_is_limited_to_batch_one_cache():
+    command, _ = MODULE.command_for("sglang", Path("/model"), Path("/model.gguf"), 18080)
+
+    assert command[command.index("--max-running-requests") + 1] == "1"
+    assert command[command.index("--max-total-tokens") + 1] == "32768"
+    assert command[command.index("--max-mamba-cache-size") + 1] == "5"
+    assert command[command.index("--watchdog-timeout") + 1] == "1200"
+
+
+def test_sglang_disables_parallel_tuning(monkeypatch):
+    for name in (
+        "SGLANG_ENABLE_FP8_GEMM_CONFIG_TUNE",
+        "MAX_JOBS",
+        "FLASHINFER_MM_FP4_CUTE_DSL_COMPILE_WORKERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    environment = MODULE.environment_for("sglang")
+
+    assert environment["SGLANG_ENABLE_FP8_GEMM_CONFIG_TUNE"] == "0"
+    assert environment["MAX_JOBS"] == "4"
+    assert environment["FLASHINFER_MM_FP4_CUTE_DSL_COMPILE_WORKERS"] == "1"
+
+
+def test_checkpoint_must_contain_nvfp4_metadata(tmp_path: Path):
+    (tmp_path / "config.json").write_text(json.dumps({
+        "quantization_config": {
+            "quantized_layers": {"model.layers.0.mlp": {"quant_algo": "FP8"}}
+        }
+    }))
+
+    try:
+        MODULE.validate_nvfp4_checkpoint(tmp_path)
+    except ValueError as error:
+        assert "not the required ModelOpt NVFP4" in str(error)
+    else:
+        raise AssertionError("an FP8 checkpoint must not pass NVFP4 validation")
+
+
+def test_native_weight_frameworks_are_not_misclassified_as_nvfp4():
+    for framework in ("llama.cpp", "ktransformers", "ollama"):
+        assert framework not in MODULE.NVFP4_FRAMEWORKS
+
+
+def test_native_framework_commands_are_serialized():
+    llama, _ = MODULE.command_for("llama.cpp", Path("/model"), Path("/model.gguf"), 18080)
+    ollama, _ = MODULE.command_for("ollama", Path("/model"), Path("/model.gguf"), 18080)
+
+    assert llama[llama.index("--parallel") + 1] == "1"
+    assert llama[llama.index("-c") + 1] == "32768"
+    assert ollama[-1] == "serve"
+
+
+def test_ollama_control_disables_mtp_and_uses_gpu():
+    command, _ = MODULE.command_for(
+        "ollama-no-mtp", Path("/model"), Path("/model.gguf"), 18080
+    )
+
+    assert "--spec-type" not in command
+    assert command[command.index("-ngl") + 1] == "99"
+
+
+def test_freetoken_and_sparklab_use_identical_runtime_flags():
+    ftw = Path("/model.ftw")
+    freetoken, _ = MODULE.command_for("freetoken", Path("/hf"), Path("/gguf"), 18080, ftw)
+    sparklab, _ = MODULE.command_for("sparklab", Path("/hf"), Path("/gguf"), 18080, ftw)
+
+    assert freetoken[1:] == sparklab[1:]
+    assert freetoken[freetoken.index("--moe-cache-rate") + 1] == "1.0"
+    assert freetoken[freetoken.index("--max-running-requests") + 1] == "1"
+
+
+def test_qwen38_uses_each_runtime_supported_qsa_path():
+    ftw = Path("/qwen38.ftw")
+    freetoken, _ = MODULE.command_for(
+        "freetoken", Path("/hf"), Path("/gguf"), 18080, ftw, "qwen38"
+    )
+    sparklab, _ = MODULE.command_for(
+        "sparklab", Path("/hf"), Path("/gguf"), 18080, ftw, "qwen38"
+    )
+
+    assert freetoken[freetoken.index("--attention-backend") + 1] == "qsa_sparse"
+    assert sparklab[sparklab.index("--attention-backend") + 1] == "qsa"
+    assert "--moe-preload-all" not in freetoken
+    assert "--moe-preload-all" in sparklab
+    assert sparklab[sparklab.index("--moe-storage") + 1] == "disk"
+
+
+def test_memory_watchdog_detects_low_available_memory(tmp_path: Path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemAvailable:    8388608 kB\n"
+        "SwapTotal:      16777216 kB\n"
+        "SwapFree:       15728640 kB\n"
+    )
+
+    reason = MODULE.memory_safety_reason(
+        min_available_gib=12, min_swap_free_gib=2, meminfo=meminfo
+    )
+
+    assert reason == "MemAvailable 8.0 GiB fell below 12.0 GiB"
+
+
+def test_memory_watchdog_detects_low_swap(tmp_path: Path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemAvailable:   67108864 kB\n"
+        "SwapTotal:      16777216 kB\n"
+        "SwapFree:        1048576 kB\n"
+    )
+
+    reason = MODULE.memory_safety_reason(
+        min_available_gib=12, min_swap_free_gib=2, meminfo=meminfo
+    )
+
+    assert reason == "SwapFree 1.0 GiB fell below 2.0 GiB"


### PR DESCRIPTION
## Summary

- add reproducible batch-one cross-framework harness with host-memory watchdog and process-group cleanup
- publish Qwen3.6 measurements for FreeToken, SparkLab, vLLM, SGLang, llama.cpp, and Ollama
- publish a separate Qwen3.8-Flash-Next report with measured SparkLab evidence and explicit unsupported/capacity outcomes
- add `demo.md` with the requested system and two-model comparison table

## Important caveats

- Qwen3.6 llama.cpp/Ollama use Q4_K_M while FreeToken/SparkLab/vLLM/SGLang use NVFP4 variants
- Ollama native throughput includes MTP; a no-MTP control is included
- Qwen3.8 SparkLab completed all trials but emitted five recoverable NVIDIA `NV_ERR_NO_MEMORY` startup warnings; no Linux OOM kill occurred
- FreeToken 0.1.2 cannot load the pinned Qwen3.8 FTW artifact due to an artifact-ABI key mismatch

## Validation

- `./.venv/bin/pytest -q tests/test_framework_benchmark_safety.py` (10 passed)
- Python compile checks for benchmark scripts
- shell syntax check for setup script
- JSON parse checks for result artifacts