### PR TITLE
release: prepare 0.1.1

### DIFF
--- a/python/sparklab/version.py
+++ b/python/sparklab/version.py
@@ -1,5 +1,5 @@
 """SparkLab product version, independent of any runtime backend version."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- bump the SparkLab runtime and kernel-cache release line from `0.1.0` to `0.1.1`
- package the reviewed Qwen3.6 certification, Qwen3.8 and GLM-5.3 performance work, kernel-cache compatibility checks, and benchmark additions merged since `v0.1.0`

## Validation

- exact hosted CPU suite: 814 passed, 20 skipped
- package import reports `0.1.1`
- public-tree hygiene and `git diff --check` pass

## Release gates after merge

- TestPyPI rehearsal through `release.yml`
- clean GB10 wheel smoke test
- protected `v0.1.1` tag build and PyPI/GitHub publication