### PR TITLE
chore: make Qwen3.8 MTP artifact self-contained

### DIFF
--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -33,10 +33,10 @@ sparklab pull qwen3.8-flash-next --root /path/to/models --prepare
 
 `pull --prepare` automatically downloads the pinned Hugging Face FTW artifact from
 [`oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW`](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW),
-plus the publisher's pinned 1.49 GiB MTP sidecar, then validates their immutable
-revisions, sizes, and FTW fingerprint. The artifact preserves the publisher's ModelOpt
-NVFP4 precision. Use `--from-source` only to reproduce the FTW conversion locally; that
-path copies the MTP sidecar into the prepared checkpoint automatically.
+which now contains the pinned 1.49 GiB native MTP sidecar. SparkLab validates the
+artifact's immutable revision, total size, and FTW fingerprint. The artifact preserves
+the publisher's ModelOpt NVFP4 precision. Use `--from-source` only to reproduce the FTW
+conversion locally; that path also copies the MTP sidecar into the prepared checkpoint.
 
 ## Run
 

--- a/python/sparklab/recipes/qwen3.8-flash-next.json
+++ b/python/sparklab/recipes/qwen3.8-flash-next.json
@@ -10,17 +10,9 @@
   "prepared_bytes": 182030550080,
   "runtime_artifact": {
     "repo_id": "oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW",
-    "revision": "cbbcf69f52b9815b8a987fe839003fae12aa8050",
-    "bytes": 180433108992,
-    "fingerprint": "47e11ddb878adf4c",
-    "supplemental_files": [
-      {
-        "repo_id": "Inferact/Qwen3.8-Flash-Next-NVFP4",
-        "revision": "103a7608316173ca6edd49929544244de7ffda70",
-        "filename": "nvfp4_experts_mtp.safetensors",
-        "bytes": 1597441088
-      }
-    ]
+    "revision": "5ab790b83f149a96594237a35905d84be24599a3",
+    "bytes": 182030550080,
+    "fingerprint": "47e11ddb878adf4c"
   },
   "minimum_free_bytes": 503115074662,
   "intended_tier": "frontier",
@@ -71,7 +63,7 @@
   "limitations": [
     "Beta 0.1 FTW preparation preserves Inferact's native ModelOpt NVFP4 routed experts without conversion-time requantization; all served non-expert tensors retain their published precision.",
     "The published BF16 n-gram table is extracted into an approximately 102.4 GB random-read artifact during preparation.",
-    "The complete pinned checkpoint and 180,433,108,992-byte FTW artifact were validated; immutable full-expert preload, a 128K KV cap, hybrid prefix reuse, and dense-QSA CUDA-graph replay through batch four measured 16.84 single-stream tok/s, 0.306 s repeated-prompt TTFT, and 61.79 aggregate tok/s at concurrency four on GB10.",
+    "The complete pinned checkpoint and 182,030,550,080-byte self-contained FTW artifact were validated; immutable full-expert preload, a 128K KV cap, hybrid prefix reuse, and dense-QSA CUDA-graph replay through batch four measured 16.84 single-stream tok/s, 0.306 s repeated-prompt TTFT, and 61.79 aggregate tok/s at concurrency four on GB10.",
     "Full expert preload takes about 35 seconds at startup, eliminates steady-state routed-expert disk I/O and the pageable host LRU, and requires all 24,576 routed experts to fit in unified memory.",
     "GB10-QWEN38-FRONTIER-001 and GB10-QWEN38-FP8-001 describe superseded recipe/checkpoint tuples and do not transfer to this 0.5.0 release.",
     "QSA decode uses CUDA-graph replay through batch four while every request's complete-group count remains within the exact dense budget (up to 2,051 visible tokens); longer sparse-QSA decode automatically runs eagerly.",

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -81,12 +81,11 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert qwen.runtime_memory == {"total_bytes": 107374182400}
     assert qwen.runtime_artifact is not None
     assert qwen.runtime_artifact.repo_id == "oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW"
-    assert qwen.runtime_artifact.revision == "cbbcf69f52b9815b8a987fe839003fae12aa8050"
+    assert qwen.runtime_artifact.revision == "5ab790b83f149a96594237a35905d84be24599a3"
     assert qwen.runtime_artifact.fingerprint == "47e11ddb878adf4c"
+    assert qwen.runtime_artifact.bytes == 182030550080
     assert qwen.runtime_artifact.total_bytes == 182030550080
-    assert qwen.runtime_artifact.supplemental_files[0].filename == (
-        "nvfp4_experts_mtp.safetensors"
-    )
+    assert qwen.runtime_artifact.supplemental_files == ()
     kimi = get_recipe("kimi-k3")
     assert kimi.recipe_version == "0.3.0"
     assert kimi.deployment.runtime_format == "ftw-nvfp4"


### PR DESCRIPTION
## Summary
- pin the new self-contained Qwen3.8 FTW Hugging Face revision
- account for the mirrored 1.49 GiB native MTP sidecar in the artifact size
- remove the cross-repository supplemental download from the recipe
- update model documentation and catalog assertions

## Hugging Face
- artifact revision: `5ab790b83f149a96594237a35905d84be24599a3`
- MTP SHA-256: `0d44e6d705d2313c713e60114e56874adf358ed5f646dc8704bb5be15f5ddbf7`

## Tests
- `828 passed, 20 skipped` in the CPU CI-equivalent suite
- `27 passed` in focused catalog/acquisition/MTP tests