### PR TITLE
docs: publish Qwen3.8 MTP benchmark performance

### DIFF
--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -17,6 +17,12 @@ recipes. Raw logs and large result streams stay outside the source repository.
   the current Inferact NVFP4 recipe.
 - `results/GB10-QWEN38-NVFP4-001.json` records the current Inferact NVFP4 recipe's
   complete-checkpoint performance probe: 12.58 decode tok/s and 0.786 s warm TTFT.
+- `results/GB10-QWEN38-NVFP4-OPT-003.json` records the current default concurrent
+  profile: 16.84 single-stream decode tok/s, 0.306 s repeated-prompt TTFT, and
+  61.79 aggregate tok/s at concurrency four.
+- `results/GB10-QWEN38-NVFP4-OPT-004.json` records the native MTP sweep. The selected
+  opt-in two-draft profile measured 20.31 decode tok/s and 0.212 s warm TTFT, a 34.2%
+  improvement over its controlled eager run with exact output parity.
 - `results/GB10-GLM53-NVFP4-001.json` records the GLM-5.3 Flash NVFP4
   complete-checkpoint probe: 4.46 decode tok/s and 5.760 s warm TTFT. Its corrected
   greedy probe reaches the reference answer; the broader quality gates remain outstanding.
@@ -25,9 +31,11 @@ recipes. Raw logs and large result streams stay outside the source repository.
   395.405 s warm TTFT, exact 256-token completion, and zero runtime OOM/swap-out.
   Cross-rung greedy determinism and answer correctness are explicitly not established.
 
-The Qwen3.8 recipe version 0.5.0 passes the Frontier performance thresholds but remains
-Experimental because its context, capability, quality, and endurance gates are outstanding.
-Neither historical Qwen3.8 result transfers across its checkpoint revision and recipe version.
+The Qwen3.8 recipe version 0.8.0 passes the Frontier performance, context, capability,
+and focused quality gates but remains Experimental because its clean-revision 60-minute
+endurance gate is outstanding. MTP is an opt-in batch-one greedy profile; its result does
+not replace the separate default/concurrent-profile measurements. Historical Qwen3.8
+results do not transfer across checkpoint revisions and recipe versions.
 
 A model catalog entry may cite a result ID, but that evidence does not make the
 recipe Certified by itself. Tier latency, context, correctness, agent, and

--- a/benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json
@@ -46,10 +46,13 @@
     "page_size": 16,
     "kv_tokens": 131072,
     "max_running_requests": 1,
+    "selected_speculative_tokens": 2,
     "cuda_graphs": false,
     "overlap_scheduling": false
   },
   "metrics": {
+    "decode_tokens_per_second": 20.30646577455425,
+    "warm_ttft_seconds": 0.21166132600046694,
     "eager_decode_tokens_per_second": 15.127319157329877,
     "mtp1_decode_tokens_per_second": 18.206939933638584,
     "mtp2_decode_tokens_per_second": 20.30646577455425,

--- a/docs/models.md
+++ b/docs/models.md
@@ -33,7 +33,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
-| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW | `qwen3.8-flash-next` | Experimental | 16.61 | 0.403 |
+| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP2 | `qwen3.8-flash-next` | Experimental | 20.31 | 0.212 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 | `deepseek-v4` | Preview | 10.28 | 0.604 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 6.27 | 5.681 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
@@ -47,12 +47,16 @@ Parameter counts come from model publishers, and performance values come from th
 evidence attached to each recipe. Certification applies only to that exact checkpoint
 and recipe version.
 
+The Qwen3.8-Flash-Next row reports its selected two-draft MTP profile. It is opt-in with
+`-- --speculative-tokens 2` and currently applies only to batch-one greedy requests;
+the default profile remains available for concurrent or sampled traffic.
+
 ## Evidence and caveats
 
 | Model | Current result | Evidence |
 |---|---|---|
 | Qwen3.6-35B-A3B | Fast-certified, including exact 32K recall and a 60-minute zero-swap run. Certification is operational; its five-problem AIME sample scored 0/5 after reaching the output cap. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json) |
-| Qwen3.8-Flash-Next | Passes Frontier speed and 64K capability probes; the clean-revision endurance gate remains outstanding. | [GB10-QWEN38-NVFP4-OPT-002](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-002.json) |
+| Qwen3.8-Flash-Next | The opt-in two-draft MTP profile measured 20.31 tok/s with exact eager-output parity; the default concurrent profile remains 16.84 single-stream tok/s. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-NVFP4-OPT-004](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json) |
 | DeepSeek V4 Flash | Passes Frontier speed; broader certification remains incomplete. | [Experiment](../exps/exp_dsv4_gb10.md) |
 | GLM-5.3 Flash | Passes Frontier speed; NVMe-sensitive TTFT and remaining certification gates keep it Experimental. | [GB10-GLM53-MHC-003](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json) |
 | GLM-5.2 | Below Frontier speed and recorded swap growth, so it remains Experimental. | [Experiment](../exps/exp_glm5_2_gb10.md) |

--- a/exps/exp_qwen3_8_nvfp4_gb10.md
+++ b/exps/exp_qwen3_8_nvfp4_gb10.md
@@ -5,9 +5,12 @@ Last updated: 2026-08-31
 ## Result
 
 The complete pinned `Inferact/Qwen3.8-Flash-Next-NVFP4` checkpoint was prepared into
-SparkLab's FTW layout and ran through the OpenAI-compatible streaming API at **16.84
-single-stream decode tok/s** with **0.306 s repeated-prompt TTFT** on one NVIDIA GB10.
-At concurrency four it reached **61.79 aggregate tok/s**. Recipe 0.8.0 preloads all
+SparkLab's FTW layout and ran through the OpenAI-compatible streaming API at **20.31
+single-stream decode tok/s** with **0.212 s warm TTFT** on one NVIDIA GB10 using the
+selected opt-in two-draft native MTP profile. Its controlled eager run measured 15.13
+tok/s, so MTP improved decode throughput by 34.2% with exact output parity. The default
+concurrent profile measured 16.84 single-stream tok/s and 0.306 s repeated-prompt TTFT;
+at concurrency four it reached **61.79 aggregate tok/s**. Recipe 0.8.0 preloads all
 24,576 routed experts into deterministic immutable slots, removing steady-state expert
 disk staging, the pageable host LRU, and decode-time cache ownership updates. Dense QSA
 uses CUDA-graph replay through batch four and automatically returns to eager execution
@@ -107,8 +110,12 @@ The optimized path combines several changes:
 
 | Metric | Value |
 |---|---:|
-| Single-stream decode throughput | 16.84 tok/s |
-| Hybrid warm TTFT | 0.306 s |
+| Selected MTP2 decode throughput | 20.31 tok/s |
+| Selected MTP2 warm TTFT | 0.212 s |
+| Controlled eager decode throughput | 15.13 tok/s |
+| MTP2 decode improvement | 34.24% |
+| Default-profile single-stream throughput | 16.84 tok/s |
+| Default-profile hybrid warm TTFT | 0.306 s |
 | Naive-cache warm TTFT control | 0.404 s |
 | Reused prompt tokens | 64 / 96 |
 | Concurrency-two aggregate throughput | 36.781 tok/s |
@@ -126,13 +133,13 @@ choose different wording at a low-margin greedy token because their GEMM reducti
 differ; correctness and within-batch determinism are the acceptance criteria across batch
 sizes.
 
-The published checkpoint also contains one MTP layer, and the official vLLM multi-GPU
-recipe drafts three speculative tokens. SparkLab intentionally continues to exclude the
-MTP weights. Safe MTP support needs a multi-token verification scheduler plus
-accepted-boundary commit/rollback for paged KV, GDN recurrent state, PLE convolution
-history, and QSA pooled-index state. The existing fused GDN kernel contains part of the
-verification primitive, but the transactional scheduler/state protocol is not present;
-adding a weight loader alone would silently corrupt state after rejected draft tokens.
+SparkLab now loads the checkpoint's native MTP layer and transactionally verifies draft
+tokens across paged KV, GDN recurrent state, PLE convolution history, and QSA pooled-index
+state. One, two, and three drafts measured 18.21, 20.31, and 17.10 tok/s respectively;
+two drafts were selected. Their accepted-draft rates were 90.3%, 86.0%, and 66.7%, and
+every width reproduced the eager output hash on both fresh prompts and 64-token prefix
+hits. The current MTP path is opt-in, batch-one, and greedy; it disables CUDA graphs and
+overlap scheduling while transactional verification is active.
 
 The API returned 64 completion tokens and produced 63 timed decode steps. The measured
 request grew neither swap nor expert disk I/O and completed without an OOM or service

--- a/python/sparklab/recipes/qwen3.8-flash-next.json
+++ b/python/sparklab/recipes/qwen3.8-flash-next.json
@@ -47,11 +47,11 @@
   "profile": "quality",
   "description": "Precision-preserving text-only recipe for Inferact's ModelOpt NVFP4 Qwen3.8 checkpoint on one NVIDIA GB10.",
   "performance": {
-    "decode_tokens_per_second": 16.84,
-    "warm_ttft_seconds": 0.3057,
+    "decode_tokens_per_second": 20.30646577455425,
+    "warm_ttft_seconds": 0.21166132600046694,
     "context_tokens": 65536,
-    "evidence": "GB10-QWEN38-NVFP4-OPT-003",
-    "note": "The complete pinned publisher-NVFP4 checkpoint passed a graph-enabled 64-token GB10 performance probe with the established exact output hash. Hybrid prefix reuse lowered repeated-prompt TTFT by 24.3%; dense QSA graphs reached 61.79 aggregate tok/s at concurrency four and automatically fall back to eager sparse QSA. The clean-revision 60-minute endurance gate remains outstanding."
+    "evidence": "GB10-QWEN38-NVFP4-OPT-004",
+    "note": "The selected opt-in two-draft native MTP profile measured 20.31 tok/s and 0.212 s warm TTFT in a controlled batch-one greedy GB10 run, 34.2% faster than its eager control with exact output parity. The default concurrent profile remains 16.84 single-stream tok/s and reaches 61.79 aggregate tok/s at concurrency four. The clean-revision 60-minute endurance gate remains outstanding."
   },
   "evidence": [
     "GB10-QWEN38-NVFP4-OPT-004",
@@ -63,7 +63,7 @@
   "limitations": [
     "Beta 0.1 FTW preparation preserves Inferact's native ModelOpt NVFP4 routed experts without conversion-time requantization; all served non-expert tensors retain their published precision.",
     "The published BF16 n-gram table is extracted into an approximately 102.4 GB random-read artifact during preparation.",
-    "The complete pinned checkpoint and 182,030,550,080-byte self-contained FTW artifact were validated; immutable full-expert preload, a 128K KV cap, hybrid prefix reuse, and dense-QSA CUDA-graph replay through batch four measured 16.84 single-stream tok/s, 0.306 s repeated-prompt TTFT, and 61.79 aggregate tok/s at concurrency four on GB10.",
+    "The complete pinned checkpoint and 182,030,550,080-byte self-contained FTW artifact were validated; the default concurrent profile measured 16.84 single-stream tok/s, 0.306 s repeated-prompt TTFT, and 61.79 aggregate tok/s at concurrency four, while opt-in two-draft MTP measured 20.31 tok/s and 0.212 s warm TTFT in its controlled batch-one greedy workload.",
     "Full expert preload takes about 35 seconds at startup, eliminates steady-state routed-expert disk I/O and the pageable host LRU, and requires all 24,576 routed experts to fit in unified memory.",
     "GB10-QWEN38-FRONTIER-001 and GB10-QWEN38-FP8-001 describe superseded recipe/checkpoint tuples and do not transfer to this 0.5.0 release.",
     "QSA decode uses CUDA-graph replay through batch four while every request's complete-group count remains within the exact dense budget (up to 2,051 visible tokens); longer sparse-QSA decode automatically runs eagerly.",

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -71,8 +71,12 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert qwen.deployment.quantization == "nvfp4"
     assert "convert_expert_quantization" not in qwen.deployment.backend_options
     assert qwen.deployment.backend_options["nvfp4_backend"] == "triton"
-    assert qwen.performance.decode_tokens_per_second == pytest.approx(16.84)
-    assert qwen.performance.warm_ttft_seconds == pytest.approx(0.3057)
+    assert qwen.performance.decode_tokens_per_second == pytest.approx(
+        20.30646577455425
+    )
+    assert qwen.performance.warm_ttft_seconds == pytest.approx(
+        0.21166132600046694
+    )
     assert qwen.deployment.backend_options["moe_host_cache_gb"] == 0
     assert qwen.deployment.backend_options["moe_preload_all"] is True
     assert qwen.deployment.backend_options["num_tokens"] == 131_072
@@ -352,7 +356,7 @@ def test_historical_qwen_fp8_evidence_does_not_transfer_to_nvfp4_recipe():
     assert any("recipe_version mismatch" in reason for reason in evaluation.reasons)
 
 
-def test_current_qwen_nvfp4_evidence_passes_all_non_endurance_frontier_gates():
+def test_qwen_default_profile_evidence_passes_all_non_endurance_frontier_gates():
     from sparklab.certification import evaluate_tier
 
     recipe = get_recipe("qwen3.8-flash-next")
@@ -360,7 +364,7 @@ def test_current_qwen_nvfp4_evidence_passes_all_non_endurance_frontier_gates():
     result = json.loads(
         (root / "benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-003.json").read_text()
     )
-    assert result["result_id"] == recipe.performance.evidence
+    assert result["result_id"] in recipe.evidence
     assert result["admission"]["performance_gate_passed"] is True
     assert result["metrics"]["decode_tokens_per_second"] == pytest.approx(
         16.84
@@ -389,8 +393,15 @@ def test_qwen_native_mtp_evidence_selects_two_drafts_with_parity():
     )
 
     assert result["result_id"] in recipe.evidence
+    assert result["result_id"] == recipe.performance.evidence
     assert result["recipe"]["recipe_version"] == recipe.recipe_version
     metrics = result["metrics"]
+    assert metrics["decode_tokens_per_second"] == pytest.approx(
+        recipe.performance.decode_tokens_per_second
+    )
+    assert metrics["warm_ttft_seconds"] == pytest.approx(
+        recipe.performance.warm_ttft_seconds
+    )
     assert metrics["mtp2_decode_tokens_per_second"] > metrics[
         "mtp1_decode_tokens_per_second"
     ]

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -60,7 +60,7 @@ def test_models_human_table_groups_tiers_and_shows_performance_metrics(capsys):
     assert "CERTIFIED" in qwen36_row
     assert qwen36_row.split()[-2:] == ["67.79", "0.329"]
     qwen38_row = next(line for line in output.splitlines() if line.startswith("Qwen3.8"))
-    assert qwen38_row.split()[-2:] == ["16.84", "0.306"]
+    assert qwen38_row.split()[-2:] == ["20.31", "0.212"]
     assert "No recipe is certified yet" not in output
 
 


### PR DESCRIPTION
## Summary
- promote the verified two-draft MTP result to the Qwen3.8 catalog performance summary
- expose canonical selected throughput and TTFT fields in OPT-004
- update the GB10 benchmark index, model portfolio, and experiment report
- keep the opt-in MTP2 and default concurrent-profile measurements clearly separated

## Result
- MTP2: `20.306 tok/s`, `0.212 s` warm TTFT
- controlled eager: `15.127 tok/s`
- improvement: `34.237%`
- exact eager-output parity: passed

## Tests
- `828 passed, 20 skipped` in the CPU CI-equivalent suite
- `24 passed` in focused catalog/CLI/MTP tests