### PR TITLE
feat(dsv4): add native DSpark speculative decoding

### DIFF
--- a/benchmarks/bench_decode_moe.py
+++ b/benchmarks/bench_decode_moe.py
@@ -39,6 +39,10 @@ Run (one backend):
 
 Run (all three backends, one server per backend):
     ... --model /path/to/model --backend offload,cpu,hybrid --json out.json
+
+Run DeepSeek-V4 DSpark (the official 7-token probabilistic profile):
+    ... --model /path/to/ftw --backend offload --speculative-method dspark \
+        --speculative-tokens 7 --draft-sample-method probabilistic --json out.json
 """
 
 from __future__ import annotations
@@ -448,6 +452,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="explicit KV capacity; 0 keeps server auto-sizing",
     )
     p.add_argument(
+        "--speculative-method",
+        choices=("auto", "mtp", "dspark"),
+        default="auto",
+        help="checkpoint-native speculative decoder",
+    )
+    p.add_argument(
+        "--speculative-tokens",
+        type=int,
+        choices=range(8),
+        default=0,
+        help="draft length (0 disables, DSpark supports up to 7)",
+    )
+    p.add_argument(
+        "--draft-sample-method",
+        choices=("greedy", "probabilistic"),
+        default="greedy",
+        help="draft sampling and target verification rule",
+    )
+    p.add_argument(
         "--disable-prefill-overlap", action="store_true",
         help="disable the two-layer prefill staging reservation (permits a one-layer cache)",
     )
@@ -590,6 +613,9 @@ def serve_cmd(args: argparse.Namespace, backend: str, port: int) -> list[str]:
         "--cuda-graph-max-bs", "0" if args.no_graph else "1",
         "--moe-hybrid-max-fetch", str(args.hybrid_fetch),
         "--moe-cache-policy", args.cache_policy,
+        "--speculative-method", args.speculative_method,
+        "--speculative-tokens", str(args.speculative_tokens),
+        "--draft-sample-method", args.draft_sample_method,
     ]
     if args.num_tokens > 0:
         cmd += ["--num-tokens", str(args.num_tokens)]
@@ -629,6 +655,27 @@ def oom_marker_count(log_text: str) -> int:
         r"MemoryError",
     )
     return sum(len(re.findall(pattern, log_text, re.I)) for pattern in patterns)
+
+
+def parse_speculative_summary(log_text: str) -> dict | None:
+    """Extract the final measured request's native speculative counters."""
+    matches = re.findall(
+        r"MTP summary: steps=(\d+), accepted=(\d+)/(\d+) \(([\d.]+)%\), "
+        r"outputs=(\d+), target_forwards=(\d+), outputs/target=([\d.]+)",
+        log_text,
+    )
+    if not matches:
+        return None
+    steps, accepted, drafted, rate, outputs, forwards, efficiency = matches[-1]
+    return {
+        "steps": int(steps),
+        "accepted": int(accepted),
+        "drafted": int(drafted),
+        "acceptance_rate": float(rate) / 100.0,
+        "outputs": int(outputs),
+        "target_forwards": int(forwards),
+        "outputs_per_target_forward": float(efficiency),
+    }
 
 
 def wait_ready(origin: str, proc: subprocess.Popen, log_path: str, timeout: float) -> None:
@@ -872,6 +919,9 @@ def run_one(args: argparse.Namespace, backend: str) -> dict:
             "requested_cache_rate": args.cache_rate,
             "memory_ratio": args.mem_ratio,
             "requested_num_tokens": args.num_tokens,
+            "speculative_method": args.speculative_method,
+            "speculative_tokens": args.speculative_tokens,
+            "draft_sample_method": args.draft_sample_method,
             "cpu_threads": args.cpu_threads,
             "hybrid_fetch": args.hybrid_fetch,
             "disk_read_workers": int(os.getenv("SPARKLAB_DISK_READ_WORKERS", "16")),
@@ -921,6 +971,9 @@ def run_one(args: argparse.Namespace, backend: str) -> dict:
     }
     if args.include_output:
         row["output_text"] = r["text"]
+    speculative = parse_speculative_summary(log_text)
+    if speculative is not None:
+        row["speculative"] = speculative
     before_moe = stats_before.get("moe") or {}
     after_moe = stats.get("moe") or {}
     if after_moe:

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -8,6 +8,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
 - `results/GB10-DSV4-SPARSE-001.json` records the optimized DeepSeek V4 route-first
   sparse-prefill probe: 10.28 decode tok/s and 0.604 s warm TTFT, with the baseline
   output hash preserved.
+- `results/GB10-DSV4-DSPARK-002.json` records the fused 0731 checkpoint's fixed
+  256-token DSpark matrix. The target-only control reached 7.41 tok/s; N=1/3/5/7
+  reached 7.07/6.19/5.97/5.16 tok/s, so speculation remains opt-in for the
+  single-GB10 disk-offload recipe.
 - `results/GB10-QWEN36-FAST-001.json` records the Qwen3.6 NVFP4 Fast
   performance probe.
 - `results/GB10-QWEN38-FRONTIER-001.json` records the certified text-only

--- a/benchmarks/gb10/results/GB10-DSV4-DSPARK-002.json
+++ b/benchmarks/gb10/results/GB10-DSV4-DSPARK-002.json
@@ -1,0 +1,135 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-DSV4-DSPARK-002",
+  "status": "measured",
+  "platform": {
+    "device": "NVIDIA GB10",
+    "memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "driver": "580.126.09"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "revision": "7d5808cb7e5d99268aa32010a36d2e40a39a9cf9",
+    "tracked_dirty": true
+  },
+  "model": {
+    "repository": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "revision": "7872f01b1d1fe23eabc4c98b48bffcef5a386062",
+    "checkpoint_format": "ftw-ds-fp4",
+    "fingerprint": "aeb9734fe8747554",
+    "checkpoint_bytes": 168424579072,
+    "prepared_shards": 24,
+    "expert_layers": 46,
+    "target_layers": 43,
+    "draft_layers": 3
+  },
+  "workload": {
+    "name": "AIME-25 problem 0 fixed 256-token decode probe",
+    "batch_size": 1,
+    "sampling": "target greedy; DSpark probabilistic draft",
+    "prompt_tokens": 48,
+    "requested_completion_tokens": 256,
+    "returned_completion_tokens": 256,
+    "timed_decode_steps": 255,
+    "warmup_requests": 1,
+    "measured_requests": 1,
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "metrics": {
+    "baseline_decode_tokens_per_second": 7.407656188456706,
+    "baseline_warm_ttft_seconds": 2.1198420680011623,
+    "baseline_output_hash": "461810a57c7c",
+    "best_speculative_tokens": 1,
+    "best_speculative_decode_tokens_per_second": 7.071858733952631,
+    "best_speculative_speedup": 0.954672905271216,
+    "matrix": [
+      {
+        "speculative_tokens": 0,
+        "decode_tokens_per_second": 7.407656188456706,
+        "warm_ttft_seconds": 2.1198420680011623,
+        "device_allocation_gib": 81.34375,
+        "physical_io_gib": 38.43672561645508,
+        "expert_cache_miss_rate_percent": 3.281653746770026,
+        "output_hash": "461810a57c7c"
+      },
+      {
+        "speculative_tokens": 1,
+        "decode_tokens_per_second": 7.071858733952631,
+        "warm_ttft_seconds": 2.23359107800934,
+        "device_allocation_gib": 81.333984375,
+        "physical_io_gib": 49.58056640625,
+        "expert_cache_miss_rate_percent": 4.106141736686846,
+        "accepted": 98,
+        "drafted": 127,
+        "acceptance_rate": 0.772,
+        "outputs_per_target_forward": 1.62,
+        "output_hash": "98ceaba767cb"
+      },
+      {
+        "speculative_tokens": 3,
+        "decode_tokens_per_second": 6.19210463077472,
+        "warm_ttft_seconds": 2.3886677859991323,
+        "device_allocation_gib": 81.40625,
+        "physical_io_gib": 52.6435546875,
+        "expert_cache_miss_rate_percent": 2.944903981038069,
+        "accepted": 104,
+        "drafted": 246,
+        "acceptance_rate": 0.423,
+        "outputs_per_target_forward": 1.68,
+        "output_hash": "2caea7db1988"
+      },
+      {
+        "speculative_tokens": 5,
+        "decode_tokens_per_second": 5.972442887555408,
+        "warm_ttft_seconds": 2.3057911780051654,
+        "device_allocation_gib": 81.794921875,
+        "physical_io_gib": 59.865234375,
+        "expert_cache_miss_rate_percent": 3.346028047851606,
+        "accepted": 115,
+        "drafted": 352,
+        "acceptance_rate": 0.327,
+        "outputs_per_target_forward": 1.82,
+        "output_hash": "7e300c342042"
+      },
+      {
+        "speculative_tokens": 7,
+        "decode_tokens_per_second": 5.15963574314919,
+        "warm_ttft_seconds": 2.5049645520048216,
+        "device_allocation_gib": 81.85546875,
+        "physical_io_gib": 61.55859375,
+        "expert_cache_miss_rate_percent": 2.7300942882779518,
+        "accepted": 96,
+        "drafted": 548,
+        "acceptance_rate": 0.175,
+        "outputs_per_target_forward": 1.6,
+        "output_hash": "2caea7db1988"
+      }
+    ]
+  },
+  "validation": {
+    "checkpoint_checksum_verified": true,
+    "complete_checkpoint_loaded": true,
+    "draft_weights_loaded": true,
+    "api_stream_completed": true,
+    "all_runs_returned_requested_tokens": true,
+    "all_runs_oom_count": 0,
+    "all_runs_swap_growth_bytes": 0,
+    "baseline_output_hash_preserved": false,
+    "answer_reached_in_all_samples": true,
+    "memory_bounded": true,
+    "quality_gate_run": false,
+    "endurance_gate_run": false
+  },
+  "source": {
+    "summary": "benchmarks/gb10/results/GB10-DSV4-DSPARK-002.json",
+    "raw_artifact": "$HOME/results/dsv4-dspark/gb10-dspark-matrix.jsonl"
+  },
+  "limitations": [
+    "This is a one-request single-stream performance matrix, not a quality or endurance certification.",
+    "The target uses disk-backed experts on one GB10; vLLM's official DSpark recipe expects a resident deployment spanning two DGX Spark systems.",
+    "Greedy output hashes differ because target verification uses the multi-token sparse-prefill kernels rather than the single-token decode kernels; all sampled outputs still reached the same answer.",
+    "The tracked-dirty revision includes the DSpark implementation under test and unrelated workspace changes."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -34,7 +34,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP2 | `qwen3.8-flash-next` | Experimental | 20.31 | 0.212 |
-| [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 | `deepseek-v4` | Preview | 10.28 | 0.604 |
+| [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 | `deepseek-v4` | Preview | 7.41 | 2.120 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 6.27 | 5.681 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.2](https://huggingface.co/nvidia/GLM-5.2-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.2` | Experimental fallback | 0.80 | 2.570 |
@@ -57,7 +57,7 @@ the default profile remains available for concurrent or sampled traffic.
 |---|---|---|
 | Qwen3.6-35B-A3B | Fast-certified, including exact 32K recall and a 60-minute zero-swap run. Certification is operational; its five-problem AIME sample scored 0/5 after reaching the output cap. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json) |
 | Qwen3.8-Flash-Next | The opt-in two-draft MTP profile measured 20.31 tok/s with exact eager-output parity; the default concurrent profile remains 16.84 single-stream tok/s. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-NVFP4-OPT-004](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json) |
-| DeepSeek V4 Flash | Passes Frontier speed; broader certification remains incomplete. | [Experiment](../exps/exp_dsv4_gb10.md) |
+| DeepSeek V4 Flash | Native DSpark is available but remains opt-in: every N=1/3/5/7 setting was slower than target-only decoding with disk-backed experts on one GB10. | [GB10-DSV4-DSPARK-002](../benchmarks/gb10/results/GB10-DSV4-DSPARK-002.json) |
 | GLM-5.3 Flash | Passes Frontier speed; NVMe-sensitive TTFT and remaining certification gates keep it Experimental. | [GB10-GLM53-MHC-003](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json) |
 | GLM-5.2 | Below Frontier speed and recorded swap growth, so it remains Experimental. | [Experiment](../exps/exp_glm5_2_gb10.md) |
 | GLM-5.3 | Correctness is not established; the measured output reached its length cap before answering. | [GB10-GLM53-RESEARCH-001](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json) |

--- a/docs/models/deepseek-v4.md
+++ b/docs/models/deepseek-v4.md
@@ -1,7 +1,8 @@
 # Run DeepSeek V4 Flash
 
 DeepSeek V4 Flash is SparkLab's Preview Frontier recipe. It preserves the source DS-FP4
-precision and uses NVMe-backed MoE execution on one NVIDIA DGX Spark.
+precision, includes the fused checkpoint's three DSpark draft blocks, and uses NVMe-backed
+MoE execution on one NVIDIA DGX Spark.
 
 For prompts up to 512 tokens, the recipe loads only the routed expert rows and preserves
 the warmed GPU expert cache. Longer prompts automatically use bounded full-layer streaming.
@@ -51,3 +52,34 @@ curl http://127.0.0.1:1919/v1/models
 ```
 
 See the [quick start](../quickstart.md) for API and agent examples.
+
+## Optional DSpark speculative decoding
+
+The fused 0731 checkpoint supports one to seven speculative tokens. DSpark is deliberately
+disabled in the default single-GB10 recipe because its extra three MoE draft layers and wider
+target verification increase expert traffic when experts are disk-backed. To experiment with
+the official probabilistic draft policy:
+
+```bash
+sparklab run deepseek-v4 --root /path/to/models -- \
+  --speculative-method dspark \
+  --speculative-tokens 1 \
+  --draft-sample-method probabilistic
+```
+
+The measured 256-token, batch-one matrix on one GB10 was:
+
+| DSpark tokens | Decode tok/s | Acceptance | Outputs / target forward | Physical expert I/O |
+|---:|---:|---:|---:|---:|
+| disabled | 7.41 | — | 1.00 | 38.44 GiB |
+| 1 | 7.07 | 77.2% | 1.62 | 49.58 GiB |
+| 3 | 6.19 | 42.3% | 1.68 | 52.64 GiB |
+| 5 | 5.97 | 32.7% | 1.82 | 59.87 GiB |
+| 7 | 5.16 | 17.5% | 1.60 | 61.56 GiB |
+
+These numbers are not directly comparable to vLLM's resident two-DGX-Spark setup. SparkLab's
+single-GB10 path makes the 167 GB fused checkpoint fit by keeping most experts on NVMe, and the
+additional draft/verification routes can cost more I/O than the accepted tokens save. Greedy
+verification also uses multi-token sparse-prefill kernels, so its output need not be bitwise
+identical to single-token decode even though speculative rejection preserves the target choice
+at each verification call.

--- a/python/sparklab/attention/dsv4_sparse.py
+++ b/python/sparklab/attention/dsv4_sparse.py
@@ -170,7 +170,7 @@ class DSV4SparseAttnBackend(BaseAttnBackend, CompressorBackendMixin, IndexerBack
         last = torch.tensor(
             [r.extend_len for r in batch.padded_reqs], dtype=torch.int32, device=self.device
         ).cumsum_(0) - 1
-        if not batch.is_decode:
+        if batch.uses_prefill_kernels:
             # Segments tile the flat token stream per request: (offset, extend_len, table_idx,
             # start_pos). Built host-side here (the scheduler stream under overlap) from the
             # same Req counters every backend's prepare_metadata reads, so the model's forward

--- a/python/sparklab/backends/native.py
+++ b/python/sparklab/backends/native.py
@@ -32,7 +32,9 @@ _VALUE_OPTIONS: dict[str, tuple[str, type | tuple[type, ...]]] = {
     "page_size": ("--page-size", int),
     "max_running_req": ("--max-running-requests", int),
     "num_tokens": ("--num-tokens", int),
+    "speculative_method": ("--speculative-method", str),
     "speculative_tokens": ("--speculative-tokens", int),
+    "draft_sample_method": ("--draft-sample-method", str),
 }
 _FLAG_OPTIONS: dict[str, str] = {
     "disable_startup_prefill_warmup": "--disable-startup-prefill-warmup",
@@ -66,7 +68,9 @@ _OPTION_ORDER = (
     "page_size",
     "max_running_req",
     "num_tokens",
+    "speculative_method",
     "speculative_tokens",
+    "draft_sample_method",
     "kimi_mlp_fp8",
     "disable_startup_prefill_warmup",
 )

--- a/python/sparklab/checkpoint/convert.py
+++ b/python/sparklab/checkpoint/convert.py
@@ -328,6 +328,20 @@ def _convert_checkpoint(
         nvfp4_backend=nvfp4_backend,
     )
     mc = cfg.model_config
+    # A fused DSV4 checkpoint carries three DSpark MoE layers under ``mtp.*``.
+    # Convert them into the same expert-bank artifact even though target-only
+    # serving does not instantiate the draft. FTW readers can expose either the
+    # 43-layer prefix or the complete 46-layer bank at runtime.
+    dsv4_args = getattr(mc, "dsv4_args", None)
+    if dsv4_args is not None and (
+        int(getattr(dsv4_args, "n_mtp_layers", 0) or 0) > 0
+        and tuple(getattr(dsv4_args, "dspark_target_layer_ids", ()) or ())
+        and int(getattr(dsv4_args, "dspark_markov_rank", 0) or 0) > 0
+    ):
+        from dataclasses import replace
+
+        object.__setattr__(mc, "dsv4_args", replace(dsv4_args, dspark_enabled=True))
+        object.__setattr__(mc, "speculative_method", "dspark")
     # Conversion bypasses Engine._adjust_config(), which normally copies this runtime
     # choice onto the parsed ModelConfig before expert-bank construction. Do it here so
     # FTW is written in the requested backend-owned layout (for example SM12x b12x), not
@@ -349,7 +363,7 @@ def _convert_checkpoint(
     from sparklab.utils.progress import byte_bar, count_bar
 
     writer = FTWWriter(out_dir, shard_limit=shard_limit)
-    n_weight = n_bank = n_alpha = 0
+    n_weight = n_speculative = n_bank = n_alpha = 0
 
     # 1) dense weights (host tensors; load straight to CPU to avoid GPU pressure)
     _progress("dense", 0, 0)  # phase start; per-tensor cumulative bytes follow (total unknown)
@@ -361,6 +375,23 @@ def _convert_checkpoint(
         n_weight += 1
         dense_bytes += tensor.numel() * tensor.element_size()
         _progress("dense", dense_bytes, 0)
+
+    # Optional checkpoint-native draft weights are a separate kind so ordinary
+    # target serving never reads or allocates them.
+    from sparklab.models.register import _load_attr, get_model_spec
+
+    spec = get_model_spec(mc.architectures[0])
+    try:
+        iter_speculative = _load_attr(spec.module, "iter_speculative_weights")
+    except AttributeError:
+        iter_speculative = None
+    if iter_speculative is not None:
+        for name, tensor in count_bar(
+            iter_speculative(model_path, torch.device("cpu")),
+            "Converting speculative weights",
+        ):
+            writer.add_tensor(name, tensor, kind="speculative_weight")
+            n_speculative += 1
 
     # 2) offload expert banks (post-repack) + alpha scales (slow path auto-picks parallel/serial)
     quant_format = None
@@ -436,9 +467,6 @@ def _convert_checkpoint(
     # Models with very large non-parameter runtime stores can stream a self-contained
     # side artifact beside FTW (Qwen4 PLE's 95 GiB random-row n-gram table). The hook
     # runs before finalize, so a failed extraction never publishes a valid FTW index.
-    from sparklab.models.register import _load_attr, get_model_spec
-
-    spec = get_model_spec(mc.architectures[0])
     try:
         external_hook = _load_attr(spec.module, "copy_external_artifacts")
     except AttributeError:
@@ -468,7 +496,15 @@ def _convert_checkpoint(
         # checkpoint); recording it here too gives load_ftw_banks a cross-check that
         # the banks match the config they ship with. None for non-offload checkpoints.
         "expert_bank_num_layers": num_layers,
-        "counts": {"weight": n_weight, "experts_bank": n_bank + n_alpha},
+        "counts": {
+            kind: count
+            for kind, count in (
+                ("weight", n_weight),
+                ("speculative_weight", n_speculative),
+                ("experts_bank", n_bank + n_alpha),
+            )
+            if count
+        },
         "copied_metadata": copied,
         "external_artifacts": external_artifacts,
     })

--- a/python/sparklab/checkpoint/ftw.py
+++ b/python/sparklab/checkpoint/ftw.py
@@ -324,15 +324,22 @@ class FTWReader:
         if mixed:
             raise ValueError(f"FTW bank(s) mix flat and per-layer layouts: {sorted(mixed)}")
 
+        stored_layers = int(self.meta("expert_bank_num_layers", num_layers))
+        if stored_layers < num_layers:
+            raise ValueError(
+                f"FTW expert banks contain {stored_layers} layers, fewer than the "
+                f"requested {num_layers}"
+            )
+
         result: dict[tuple[int, int, str], ExpertRowDescriptor] = {}
         for entry in flat:
             total, *row_shape = entry["shape"]
-            if total % num_layers:
+            if total % stored_layers:
                 raise ValueError(
                     f"FTW bank {entry['name']!r} has {total} rows, not divisible by "
-                    f"num_layers={num_layers}"
+                    f"stored num_layers={stored_layers}"
                 )
-            num_experts = total // num_layers
+            num_experts = total // stored_layers
             dtype = _dtype_of(entry["dtype"])
             row_bytes = (math.prod(row_shape) if row_shape else 1) * _elsize(dtype)
             for layer_id in range(num_layers):
@@ -353,11 +360,14 @@ class FTWReader:
 
         for bank_name, by_layer in layered.items():
             expected = list(range(num_layers))
-            if sorted(by_layer) != expected:
+            available = sorted(by_layer)
+            if available[:num_layers] != expected:
                 raise ValueError(
-                    f"FTW bank {bank_name!r} has layers {sorted(by_layer)}, expected {expected}"
+                    f"FTW bank {bank_name!r} has layers {available}, expected {expected} "
+                    "or a contiguous superset"
                 )
-            for layer_id, entry in by_layer.items():
+            for layer_id in expected:
+                entry = by_layer[layer_id]
                 num_experts = entry["shape"][0]
                 for expert_id in range(num_experts):
                     desc = _expert_row_descriptor(
@@ -1065,13 +1075,14 @@ def load_ftw_banks(
     row_entries = [e for e in bank_entries if e["name"] not in _ALPHA_NAMES]
 
     meta_layers = reader.meta("expert_bank_num_layers")
-    if meta_layers is not None and meta_layers != num_layers:
+    if meta_layers is not None and meta_layers < num_layers:
         reader.close()
         raise RuntimeError(
             f"{path!r} was converted with {meta_layers} expert-bank layers but the "
-            f"model config says num_moe_layers={num_layers}; the checkpoint does not "
-            "match its config"
+            f"runtime needs num_moe_layers={num_layers}; the checkpoint does not "
+            "contain enough layers"
         )
+    stored_layers = int(meta_layers or num_layers)
 
     # Alphas: unchanged, one flat HostBank per entry.
     alpha_specs = {e["name"]: (tuple(e["shape"]), _dtype_of(e["dtype"])) for e in alpha_entries}
@@ -1101,12 +1112,14 @@ def load_ftw_banks(
     for e in flat_entries:
         name = e["name"]
         total, *row_shape = e["shape"]
-        assert total % num_layers == 0, (name, total, num_layers)
-        num_experts = total // num_layers
+        assert total % stored_layers == 0, (name, total, stored_layers)
+        num_experts = total // stored_layers
         dtype = _dtype_of(e["dtype"])
         row_bytes = (math.prod(row_shape) if row_shape else 1) * _elsize(dtype)
         layer_bytes = num_experts * row_bytes
-        assert layer_bytes * num_layers == e["nbytes"], (name, layer_bytes, num_layers, e["nbytes"])
+        assert layer_bytes * stored_layers == e["nbytes"], (
+            name, layer_bytes, stored_layers, e["nbytes"]
+        )
         row_hb[name] = []
         row_view_args[name] = []
         for layer_id in range(num_layers):
@@ -1120,9 +1133,10 @@ def load_ftw_banks(
             row_jobs.append((name, bank, win_off, win_end - win_off, layer_bytes))
 
     for base, by_layer in per_layer_groups.items():
-        assert sorted(by_layer) == list(range(num_layers)), (
+        expected = list(range(num_layers))
+        assert sorted(by_layer)[:num_layers] == expected, (
             f"FTW bank {base!r} has per-layer entries for layers {sorted(by_layer)}, "
-            f"expected exactly range({num_layers})"
+            f"expected at least range({num_layers})"
         )
         row_hb[base] = []
         row_view_args[base] = []

--- a/python/sparklab/core.py
+++ b/python/sparklab/core.py
@@ -70,6 +70,9 @@ class Req:
     # Greedy MTP proposals waiting to be verified by the next target forward.
     # Kept on device so the scheduler can stage them without a host round trip.
     speculative_drafts: torch.Tensor | None = None
+    # Full-vocabulary draft distributions for exact stochastic rejection
+    # sampling. None for deterministic/greedy speculative decoding.
+    speculative_draft_probs: torch.Tensor | None = None
     # A terminal token can occur before the end of a verified multi-token result.
     # In that case recurrent state ran past the client-visible sequence and must
     # not be donated to the radix tree at finish.

--- a/python/sparklab/models/config.py
+++ b/python/sparklab/models/config.py
@@ -318,10 +318,10 @@ class ModelConfig:
     glm5_next_args: Any | None = None
     # Qwen4-Exp text-tower payload: QSA, Hyper-Connection and PLE geometry.
     qwen4_exp_args: Any | None = None
-    # Number of greedy Qwen4 MTP draft tokens proposed per target forward.
-    # Runtime configuration injects this after parsing; zero keeps every other
-    # model and the ordinary Qwen4 path byte-for-byte unchanged.
+    # Runtime speculative-decoding selection injected after parsing.
+    speculative_method: str = "none"
     speculative_tokens: int = 0
+    draft_sample_method: str = "greedy"
     # Generic execution-path capability flags (set by a model's parse_config) so the engine and
     # factories stay model-agnostic instead of branching on dsv4_args:
     single_stream_only: bool = False  # model runs one sequence at a time -> force bs=1
@@ -337,7 +337,10 @@ class ModelConfig:
         Models with leading dense layers (``first_k_dense_replace`` > 0, e.g. GLM-4)
         only store experts for the trailing layers; everything else has all layers MoE.
         """
-        return self.num_layers - self.first_k_dense_replace
+        base = self.num_layers - self.first_k_dense_replace
+        if self.speculative_method == "dspark" and self.dsv4_args is not None:
+            base += int(self.dsv4_args.n_mtp_layers)
+        return base
 
     @property
     def routed_expert_hidden_size(self) -> int:

--- a/python/sparklab/models/deepseek_v4/__init__.py
+++ b/python/sparklab/models/deepseek_v4/__init__.py
@@ -16,7 +16,7 @@ addressed by page tables, and sparse attention is a physical-slot gather (see
 from .args import DeepseekV4Args, load_args
 from .config import parse_config
 from .model import DeepseekV4ForCausalLM
-from .weight import iter_weights, load_dsfp4_expert_sources
+from .weight import iter_speculative_weights, iter_weights, load_dsfp4_expert_sources
 
 __all__ = [
     "DeepseekV4Args",
@@ -24,5 +24,6 @@ __all__ = [
     "parse_config",
     "DeepseekV4ForCausalLM",
     "iter_weights",
+    "iter_speculative_weights",
     "load_dsfp4_expert_sources",
 ]

--- a/python/sparklab/models/deepseek_v4/args.py
+++ b/python/sparklab/models/deepseek_v4/args.py
@@ -69,14 +69,40 @@ class DeepseekV4Args:
     hc_sinkhorn_iters: int = 20
     hc_eps: float = 1e-6
 
+    # ----- fused DSpark draft -----
+    # The 0731 checkpoint ships three draft decoder blocks under ``mtp.*``.
+    # They are optional at runtime: ordinary target-only serving keeps the
+    # original 43-layer cache/expert geometry byte-for-byte unchanged.
+    dspark_block_size: int = 0
+    dspark_noise_token_id: int = -1
+    dspark_target_layer_ids: Tuple[int, ...] = ()
+    dspark_markov_rank: int = 0
+    dspark_enabled: bool = False
+
     def __post_init__(self) -> None:
         # JSON lists -> tuple so the dataclass stays hashable / immutable-ish.
         if isinstance(self.compress_ratios, list):
             self.compress_ratios = tuple(self.compress_ratios)
+        if isinstance(self.dspark_target_layer_ids, list):
+            self.dspark_target_layer_ids = tuple(self.dspark_target_layer_ids)
 
     @property
     def nope_head_dim(self) -> int:
         return self.head_dim - self.rope_head_dim
+
+    @property
+    def runtime_n_layers(self) -> int:
+        return self.n_layers + (self.n_mtp_layers if self.dspark_enabled else 0)
+
+    @property
+    def runtime_compress_ratios(self) -> Tuple[int, ...]:
+        ratios = tuple(self.compress_ratios)[: self.runtime_n_layers]
+        if self.dspark_enabled and len(ratios) != self.runtime_n_layers:
+            raise ValueError(
+                f"DeepSeek-V4 config has {len(ratios)} compression ratios for "
+                f"{self.runtime_n_layers} runtime layers"
+            )
+        return ratios
 
 
 def _config_path(model_path: str) -> str:

--- a/python/sparklab/models/deepseek_v4/attention.py
+++ b/python/sparklab/models/deepseek_v4/attention.py
@@ -235,6 +235,64 @@ class Attention(nn.Module):
         apply_rotary_emb(o[..., -rd:], freqs, True)
         return self._wo(o, 1, T)
 
+    def store_dspark_context(
+        self, x: torch.Tensor, positions: torch.Tensor, window_slots: torch.Tensor
+    ) -> None:
+        """Project target auxiliary states into this draft layer's context KV."""
+        if self.compress_ratio:
+            raise RuntimeError("DSpark draft layers must use sliding-window attention")
+        rd = self.rope_head_dim
+        freqs = self.freqs_cis.index_select(0, positions.long())
+        kv = self.kv_norm(self.wkv(x))
+        apply_rotary_emb(kv[..., -rd:], freqs)
+        act_quant_fp8_inplace(kv[..., :-rd], 64)
+        self.attn.store_window(kv.reshape(-1, self.head_dim), self.layer_id, window_slots)
+
+    def forward_dspark_block(
+        self,
+        x: torch.Tensor,
+        *,
+        positions: torch.Tensor,
+        table_idx: int,
+        context_start: int,
+    ) -> torch.Tensor:
+        """Non-causal DSpark query block over context plus all parallel queries."""
+        if self.compress_ratio:
+            raise RuntimeError("DSpark draft layers must have compress_ratio=0")
+        _, n_query, _ = x.shape
+        rd = self.rope_head_dim
+        freqs = self.freqs_cis.index_select(0, positions.long())
+        qr = self.q_norm(self.wq_a(x))
+        q = self.wq_b(qr).unflatten(-1, (self.n_heads, self.head_dim))
+        q = rms_norm(q, None, self.eps)
+        apply_rotary_emb(q[..., -rd:], freqs)
+
+        kv = self.kv_norm(self.wkv(x))
+        apply_rotary_emb(kv[..., -rd:], freqs)
+        act_quant_fp8_inplace(kv[..., :-rd], 64)
+        query_start = int(positions[0].item())
+        query_end = query_start + n_query
+        query_slots = self.attn.window_slots_of(table_idx, query_start, query_end)
+        if bool((query_slots < 0).any()):
+            raise RuntimeError("DSpark query crossed an unallocated KV page")
+        self.attn.store_window(kv[0], self.layer_id, query_slots)
+
+        context_slots = self.attn.window_slots_of(table_idx, context_start, query_start)
+        candidates = torch.cat((context_slots, query_slots)).view(1, 1, -1)
+        topk_idxs = candidates.expand(1, n_query, -1).to(torch.int32)
+        n_window = topk_idxs.shape[-1]
+        o = self.attn.attend(
+            q,
+            self.layer_id,
+            topk_idxs,
+            n_window,
+            self.attn_sink,
+            self.softmax_scale,
+            has_compression=False,
+        )
+        apply_rotary_emb(o[..., -rd:], freqs, True)
+        return self._wo(o, 1, n_query)
+
     def _compress_topk_extend(self, seqlen, start_pos, end, offset, device, bsz):
         # ratio-128 layers (no indexer): each new query at abs pos p attends compressed blocks
         # [0, (p+1)//ratio); pool index = block + offset, causal-masked to -1 beyond (p+1)//ratio.

--- a/python/sparklab/models/deepseek_v4/compress.py
+++ b/python/sparklab/models/deepseek_v4/compress.py
@@ -191,23 +191,27 @@ class Compressor(nn.Module):
     def extend(self, x, start_pos: int, window_slots: torch.Tensor, tail_window_slot: int, ti: int = 0):
         """Carry-aware compressor extend for new tokens [start_pos, start_pos+seqlen).
 
-        ``start_pos`` is 128-aligned (== the radix match boundary, divisible by both ratios).
-        The carry needed at ``start_pos`` lives in the matched window TAIL page's ring block;
-        seed the register from it, then run the SAME reduction as the from-scratch prefill on the
-        new tokens (the seeded ``ks[:ratio]`` overlap provides the first new block's previous-
-        block overlap, exactly as the from-scratch overlap-seed does). Compressed blocks scatter
-        to their arithmetic rows (full_loc // ratio). ``window_slots`` is the new tokens' window
-        slots (translate(full_loc_map[ti, start_pos:start_pos+seqlen])) for the boundary
-        write-through; ``tail_window_slot`` is the matched tail page slot at start_pos-1.
+        Radix/chunk continuations normally start at a 128-aligned page boundary. Speculative
+        verification is also a continuation, but starts at the current decode position and is
+        therefore usually unaligned. In both cases the exact carry needed at ``start_pos`` lives
+        in the matched window TAIL page's ring block. The aligned path reduces whole blocks in
+        parallel; the short unaligned path advances the ring exactly like consecutive decode
+        steps and emits only blocks which finish inside this call.
+
+        ``window_slots`` is the new tokens' window slots
+        (translate(full_loc_map[ti, start_pos:start_pos+seqlen])) for carry write-through;
+        ``tail_window_slot`` is the matched tail page slot at start_pos-1.
         """
         assert self.cmp_pool is not None
-        assert start_pos % self.P == 0, "radix re-prefill boundary must be 128-aligned"
         bsz, seqlen, _ = x.size()
         ratio, overlap, d, rd = self.compress_ratio, self.overlap, self.head_dim, self.rope_head_dim
         dtype = x.dtype
         # Seed the register carry FROM the ring (the matched tail page covering
         # [start_pos-128, start_pos)). The producing request wrote this boundary carry by value.
         self._seed_carry_from_ring(tail_window_slot)
+
+        if start_pos % self.P:
+            return self._extend_unaligned(x, start_pos, window_slots, ti)
 
         x = x.float()
         kv = self.wkv(x)
@@ -288,6 +292,79 @@ class Compressor(nn.Module):
         self.attn.scatter_compressed(
             self.layer_id, self.tier,
             self.attn.compress_rows_of(ti, block_starts, self.compress_ratio), reduced[0],
+        )
+        return reduced
+
+    def _extend_unaligned(
+        self, x: torch.Tensor, start_pos: int, window_slots: torch.Tensor, ti: int
+    ) -> torch.Tensor | None:
+        """Advance a short, non-page-aligned continuation from its persisted carry.
+
+        This is the verification counterpart of :meth:`decode_step`. Unlike the page-aligned
+        radix path, the first token may land in the middle of a ratio-4/128 compression block, so
+        grouping ``x`` from column zero would pool the wrong boundaries. Verification spans at
+        most eight tokens; advancing those positions in order is exact while the expensive target
+        attention, dense projections, and MoE remain batched.
+        """
+        bsz, seqlen, _ = x.size()
+        assert bsz == 1, "unaligned compressor continuation currently supports batch size 1"
+        ratio, overlap, d, rd = (
+            self.compress_ratio, self.overlap, self.head_dim, self.rope_head_dim
+        )
+        dtype = x.dtype
+        x = x.float()
+        kv = self.wkv(x)
+        score = self.wgate(x)
+        ks, ss = self._kv_state, self._score_state
+        completed: list[torch.Tensor] = []
+        block_starts: list[int] = []
+
+        for i in range(seqlen):
+            pos = start_pos + i
+            idx = pos % ratio
+            kv_i = kv[:, i : i + 1]
+            score_i = score[:, i : i + 1] + self.ape[idx : idx + 1]
+            if overlap:
+                # A holds the preceding complete block and B the block being filled. At a block
+                # boundary pool A.left with B.right, then roll B into A for the next block.
+                ks[:, ratio + idx : ratio + idx + 1] = kv_i
+                ss[:, ratio + idx : ratio + idx + 1] = score_i
+                if idx == ratio - 1:
+                    kv_eff = torch.cat([ks[:, :ratio, :d], ks[:, ratio:, d:]], dim=1)
+                    score_eff = torch.cat([ss[:, :ratio, :d], ss[:, ratio:, d:]], dim=1)
+                    completed.append(gated_pool(kv_eff, score_eff, dtype))
+                    block_starts.append(pos + 1 - ratio)
+                    ks[:, :ratio].copy_(ks[:, ratio:].clone())
+                    ss[:, :ratio].copy_(ss[:, ratio:].clone())
+            else:
+                ks[:, idx : idx + 1] = kv_i
+                ss[:, idx : idx + 1] = score_i
+                if idx == ratio - 1:
+                    completed.append(gated_pool(ks, ss, dtype))
+                    block_starts.append(pos + 1 - ratio)
+
+            # Preserve the boundary carry in the physical page which just closed. The register
+            # itself continues into the next page; the final write below seeds that page.
+            if pos % self.P == self.P - 1:
+                self._write_through_carry(int(window_slots[i].item()))
+
+        end = start_pos + seqlen
+        if seqlen and end % self.P:
+            self._write_through_carry(int(window_slots[-1].item()))
+        if not completed:
+            return None
+
+        reduced = self.norm(torch.cat(completed, dim=1))
+        starts = torch.tensor(block_starts, device=self._device, dtype=torch.int64)
+        apply_rotary_emb(reduced[..., -rd:], self.freqs_cis.index_select(0, starts))
+        if self.rotate:
+            reduced = hadamard_transform(reduced)
+            fp4_act_quant_inplace(reduced, 32)
+        else:
+            act_quant_fp8_inplace(reduced[..., :-rd], 64)
+        self.attn.scatter_compressed(
+            self.layer_id, self.tier,
+            self.attn.compress_rows_of(ti, starts, ratio), reduced[0],
         )
         return reduced
 

--- a/python/sparklab/models/deepseek_v4/dspark.py
+++ b/python/sparklab/models/deepseek_v4/dspark.py
@@ -1,0 +1,211 @@
+"""Fused DeepSeek-V4 DSpark draft model.
+
+The three checkpoint ``mtp.*`` blocks share the target embedding and LM head.
+Target auxiliary states seed their sliding-window context KV; a parallel block
+of anchor/noise queries is then refined by a sequential low-rank Markov bias.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sparklab.core import get_global_ctx
+from sparklab.kernels.triton.dsv4.hc import hc_pre_combine
+
+from .args import DeepseekV4Args
+from .layers import Linear, RMSNorm
+from .model import Block
+
+
+def draft_query_geometry(
+    device_len: int, page_size: int, max_steps: int
+) -> tuple[int, int]:
+    """Return the sampled anchor position and page-local DSpark block width."""
+    if device_len <= 0 or page_size <= 0 or max_steps <= 0:
+        return max(0, device_len - 1), 0
+    anchor_pos = device_len - 1
+    page_end = (anchor_pos // page_size + 1) * page_size
+    return anchor_pos, min(max_steps, page_end - anchor_pos)
+
+
+class DSparkDraft(nn.Module):
+    def __init__(self, args: DeepseekV4Args, steps: int, sample_method: str):
+        super().__init__()
+        self.args = args
+        self.steps = int(steps)
+        self.sample_method = sample_method
+        self.hc_mult = args.hc_mult
+        self.norm_eps = args.norm_eps
+        self.hc_eps = args.hc_eps
+        n_aux = len(args.dspark_target_layer_ids)
+        self.main_proj = Linear(n_aux * args.dim, args.dim, kind="fp8")
+        self.main_norm = RMSNorm(args.dim, args.norm_eps)
+        self.layers = nn.ModuleList(
+            [Block(args.n_layers + i, args) for i in range(args.n_mtp_layers)]
+        )
+        self.norm = RMSNorm(args.dim, args.norm_eps)
+        hc_dim = args.hc_mult * args.dim
+        self.hc_head_fn = nn.Parameter(
+            torch.empty(args.hc_mult, hc_dim, dtype=torch.float32),
+            requires_grad=False,
+        )
+        self.hc_head_base = nn.Parameter(
+            torch.empty(args.hc_mult, dtype=torch.float32), requires_grad=False
+        )
+        self.hc_head_scale = nn.Parameter(
+            torch.empty(1, dtype=torch.float32), requires_grad=False
+        )
+        self.markov_w1 = nn.Parameter(
+            torch.empty(args.vocab_size, args.dspark_markov_rank, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+        self.markov_w2 = nn.Parameter(
+            torch.empty(args.vocab_size, args.dspark_markov_rank, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+        self.confidence_weight = nn.Parameter(
+            torch.empty(1, args.dim + args.dspark_markov_rank, dtype=torch.float32),
+            requires_grad=False,
+        )
+        self._bound = False
+        self.last_draft_probs: torch.Tensor | None = None
+
+    def bind(self, pool, device: torch.device) -> None:
+        if self._bound:
+            return
+        for layer in self.layers:
+            layer.attn.bind(pool, device)
+        self._bound = True
+
+    def mark_for_rebind(self) -> None:
+        self._bound = False
+
+    def hc_head(self, x: torch.Tensor) -> torch.Tensor:
+        shape, dtype = x.size(), x.dtype
+        xf = x.flatten(2).float()
+        rsqrt = torch.rsqrt(
+            xf.square().mean(-1, keepdim=True) + self.norm_eps
+        )
+        mixes = F.linear(xf, self.hc_head_fn) * rsqrt
+        pre = (
+            torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base)
+            + self.hc_eps
+        )
+        m = shape[0] * shape[1]
+        return hc_pre_combine(
+            xf.view(m, self.hc_mult, self.args.dim),
+            pre.view(m, self.hc_mult),
+            dtype,
+        ).view(*shape[:2], self.args.dim)
+
+    @torch.inference_mode()
+    def store_target_context(
+        self,
+        aux_states: list[torch.Tensor],
+        *,
+        segments,
+        positions: torch.Tensor,
+    ) -> None:
+        """Project selected post-target-layer states and persist draft context KV."""
+        if not aux_states:
+            return
+        pool = get_global_ctx().kv_cache
+        self.bind(pool, pool.device)
+        main = self.main_norm(self.main_proj(torch.cat(aux_states, dim=-1)))
+        for off, n, table_idx, start_pos in segments:
+            pos = positions[off : off + n].long()
+            slots = get_global_ctx().attn_backend.window_slots_of(
+                table_idx, start_pos, start_pos + n
+            )
+            part = main[:, off : off + n]
+            for layer in self.layers:
+                layer.attn.store_dspark_context(part, pos, slots)
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        batch,
+        next_token: torch.Tensor,
+        *,
+        embedding_weight: torch.Tensor,
+        head_weight: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if batch.size != 1:
+            return None
+        ctx = get_global_ctx()
+        pool = ctx.kv_cache
+        self.bind(pool, pool.device)
+        req = batch.reqs[0]
+        self.last_draft_probs = None
+        if self.sample_method == "greedy" and not req.sampling_params.is_greedy:
+            return None
+        # ``next_token`` is the just-sampled anchor at device_len - 1.  Draft
+        # outputs begin at device_len; positioning the anchor one row later
+        # shifts every RoPE phase and can cross into an unallocated page.
+        query_start, n_query = draft_query_geometry(
+            req.device_len, pool.P, self.steps
+        )
+        if n_query <= 0:
+            return None
+        anchor_slot = ctx.attn_backend.window_slots_of(
+            req.table_idx, query_start, query_start + 1
+        )
+        if bool((anchor_slot < 0).any()):
+            # The sampled anchor opened a new page.  Its target forward on the
+            # next scheduler step allocates that page, after which drafting
+            # resumes; cache allocation remains scheduler-owned.
+            return None
+
+        anchor = next_token.reshape(1).long()
+        noise = torch.full(
+            (n_query - 1,),
+            self.args.dspark_noise_token_id,
+            dtype=torch.long,
+            device=anchor.device,
+        )
+        input_ids = torch.cat((anchor, noise)).view(1, -1)
+        positions = torch.arange(
+            query_start,
+            query_start + n_query,
+            dtype=torch.long,
+            device=anchor.device,
+        )
+        context_width = max(0, self.args.window_size - n_query)
+        context_start = max(0, query_start - context_width)
+        hidden = F.embedding(input_ids, embedding_weight)
+        hidden = hidden.unsqueeze(2).repeat(1, 1, self.hc_mult, 1)
+        for layer in self.layers:
+            hidden = layer.dspark_forward(
+                hidden,
+                input_ids,
+                positions=positions,
+                table_idx=req.table_idx,
+                context_start=context_start,
+            )
+        head_hidden = self.hc_head(hidden)
+        base_logits = F.linear(self.norm(head_hidden)[0], head_weight)
+
+        previous = anchor
+        drafts = []
+        draft_probs = []
+        for row in range(n_query):
+            markov = F.embedding(previous, self.markov_w1)
+            logits = base_logits[row : row + 1] + F.linear(markov, self.markov_w2)
+            if req.sampling_params.is_greedy:
+                token = torch.argmax(logits, dim=-1)
+            else:
+                from sparklab.runtime.engine.sample import sampling_distribution
+
+                probs = sampling_distribution(logits, req.sampling_params)
+                token = torch.multinomial(probs, 1).squeeze(-1)
+                draft_probs.append(probs.squeeze(0))
+            drafts.append(token.squeeze(0).to(torch.int32))
+            previous = token
+        if draft_probs:
+            self.last_draft_probs = torch.stack(draft_probs)
+        return torch.stack(drafts)
+
+
+__all__ = ["DSparkDraft"]

--- a/python/sparklab/models/deepseek_v4/model.py
+++ b/python/sparklab/models/deepseek_v4/model.py
@@ -126,6 +126,30 @@ class Block(nn.Module):
         x = self.hc_post(x, residual, post, comb)
         return x
 
+    def dspark_forward(
+        self, x, input_ids, *, positions, table_idx: int, context_start: int
+    ):
+        residual = x
+        x, post, comb = self.hc_pre(
+            x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
+        )
+        x = self.attn_norm(x)
+        x = self.attn.forward_dspark_block(
+            x,
+            positions=positions,
+            table_idx=table_idx,
+            context_start=context_start,
+        )
+        x = self.hc_post(x, residual, post, comb)
+
+        residual = x
+        x, post, comb = self.hc_pre(
+            x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
+        )
+        x = self.ffn_norm(x)
+        x = self.ffn(x, input_ids)
+        return self.hc_post(x, residual, post, comb)
+
 
 class Transformer(nn.Module):
     def __init__(self, args: DeepseekV4Args):
@@ -160,8 +184,9 @@ class Transformer(nn.Module):
 
     def prefill_batched(
         self, input_ids: torch.Tensor, segments, flat_positions: torch.Tensor,
-        last_indices: torch.Tensor,
-    ) -> torch.Tensor:
+        last_indices: torch.Tensor, *, return_all_logits: bool = False,
+        aux_layer_ids: tuple[int, ...] = (),
+    ):
         # Ragged batched prefill (bs >= 1). ``input_ids`` is [1, T] -- the requests' NEW tokens
         # concatenated (cu_seqlens, no padding); each request starts at its own cached_len
         # (cold == 0, radix hit / chunk continuation > 0). Per-token ops run batched over all T
@@ -174,15 +199,22 @@ class Transformer(nn.Module):
         # final token -> its next-token logits row.
         h = self.embed(input_ids)
         h = h.unsqueeze(2).repeat(1, 1, self.hc_mult, 1)
+        aux = []
+        selected = set(aux_layer_ids)
         for layer in self.layers:
             h = layer.prefill_batched(h, input_ids, segments, flat_positions)
+            if layer.layer_id + 1 in selected:
+                aux.append(h.mean(dim=2))
         h = self.hc_head(h)
         h = self.norm(h)
-        return F.linear(h[0, last_indices], self.head)  # [B, vocab]
+        rows = h[0] if return_all_logits else h[0, last_indices]
+        logits = F.linear(rows, self.head)
+        return (logits, aux) if aux_layer_ids else logits
 
     def decode(
-        self, input_ids: torch.Tensor, pos: torch.Tensor, cmp_stage_cap: int
-    ) -> torch.Tensor:
+        self, input_ids: torch.Tensor, pos: torch.Tensor, cmp_stage_cap: int,
+        *, aux_layer_ids: tuple[int, ...] = (),
+    ):
         # input_ids [B,1], pos [B] (GPU int). cmp_stage_cap = max position any row reaches; each
         # layer derives its compressed staging width = (cmp_stage_cap+1)//ratio (max valid count
         # over rows in eager; a static capture width = max_seq-1 under graph).
@@ -202,11 +234,16 @@ class Transformer(nn.Module):
         # into every layer. They read only the shared snapshot / positions, so they are identical
         # across layers.
         wctx = get_global_ctx().batch.attn_metadata.window_ctx(pos, rows)
+        aux = []
+        selected = set(aux_layer_ids)
         for layer in self.layers:
             h = layer.decode_step(h, pos, rows, cmp_stage_cap, input_ids, wctx)
+            if layer.layer_id + 1 in selected:
+                aux.append(h.mean(dim=2))
         h = self.hc_head(h)
         h = self.norm(h)
-        return F.linear(h[:, -1], self.head)
+        logits = F.linear(h[:, -1], self.head)
+        return (logits, aux) if aux_layer_ids else logits
 
 
 class DeepseekV4ForCausalLM(BaseLLMModel):
@@ -221,6 +258,15 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
         self._config = config
         self._args: DeepseekV4Args = config.dsv4_args
         self._transformer = Transformer(self._args)
+        self._dspark = None
+        if self._args.dspark_enabled:
+            from .dspark import DSparkDraft
+
+            self._dspark = DSparkDraft(
+                self._args,
+                config.speculative_tokens,
+                getattr(config, "draft_sample_method", "greedy"),
+            )
         self._bound = False
 
     def _ensure_bound(self) -> None:
@@ -228,6 +274,8 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
             return
         pool = get_global_ctx().kv_cache
         self._transformer.bind(pool, pool.device)
+        if self._dspark is not None:
+            self._dspark.bind(pool, pool.device)
         self._bound = True
 
     def mark_for_rebind(self) -> None:
@@ -236,6 +284,8 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
         when the engine drops ctx.kv_cache. But the per-bind scratch (the indexer's arange over the
         block count, freqs) depends on the new pool's geometry, so re-derive it via _ensure_bound."""
         self._bound = False
+        if self._dspark is not None:
+            self._dspark.mark_for_rebind()
 
     def _iter_offload_moe_layers(self):
         # Hook for moe.offload_cache.iter_offload_moe_layers: DSV4's MoE block (block.ffn)
@@ -243,6 +293,9 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
         # layer instead, whose .offload_cache the generic attach sets.
         for block in self._transformer.layers:
             yield block.ffn.experts
+        if self._dspark is not None:
+            for block in self._dspark.layers:
+                yield block.ffn.experts
 
     def state_dict(self, *, prefix: str = "", result=None):
         result = {} if result is None else result
@@ -261,22 +314,50 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
             raise RuntimeError(f"Unexpected keys in state_dict: {list(state_dict.keys())}")
         self._transformer.load_state_dict(casted, assign=True, strict=False)
 
+    def speculative_state_dict(self):
+        if self._dspark is None:
+            return {}
+        return dict(self._dspark.named_parameters())
+
+    def load_speculative_state_dict(self, state_dict) -> None:
+        if self._dspark is None:
+            if state_dict:
+                raise RuntimeError("received DSpark weights while DSpark is disabled")
+            return
+        casted = {}
+        for name, parameter in self._dspark.named_parameters():
+            if name not in state_dict:
+                raise RuntimeError(f"Missing DSpark weight: {name}")
+            casted[name] = state_dict.pop(name).to(parameter.dtype)
+        if state_dict:
+            raise RuntimeError(f"Unexpected DSpark weights: {list(state_dict)}")
+        self._dspark.load_state_dict(casted, assign=True, strict=False)
+
     def forward(self) -> torch.Tensor:
         self._ensure_bound()
         batch = get_global_ctx().batch
         input_ids = batch.input_ids.long()
         md = batch.attn_metadata
-        if batch.is_prefill:
+        aux_ids = self._args.dspark_target_layer_ids if self._dspark is not None else ()
+        if batch.uses_prefill_kernels:
             # Ragged batched prefill (bs >= 1): each request starts from its own cached_len.
             # A cold segment (start_pos == 0) re-seeds the compressor carry register inside its
             # own attention segment; a radix hit / chunk continuation (start_pos > 0) resumes it
             # FROM THE RING. Per-token ops (embed / HC / norm / MoE) run batched over the
             # concatenated tokens; attention runs per segment so the carry / slot maps never
             # cross requests.
-            return self._transformer.prefill_batched(
+            result = self._transformer.prefill_batched(
                 input_ids.view(1, -1), md.segments, batch.positions.long(),
-                md.last_indices.long(),
+                md.last_indices.long(), return_all_logits=batch.return_all_logits,
+                aux_layer_ids=aux_ids,
             )
+            if self._dspark is None:
+                return result
+            logits, aux = result
+            self._dspark.store_target_context(
+                aux, segments=md.segments, positions=batch.positions.long()
+            )
+            return logits
         # DECODE (bs>=1): per-row position (GPU int tensor -> no host syncs / graph safe). The
         # compressed staging cap is the max position any row reaches (eager); a static max_seq-1
         # under graph capture (so the captured static-shape graph serves any real replay position).
@@ -290,7 +371,35 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
             cmp_stage_cap = md.stage_width - 1
         else:
             cmp_stage_cap = int(pos.max().item())
-        return self._transformer.decode(input_ids.view(B, 1), pos, cmp_stage_cap)
+        result = self._transformer.decode(
+            input_ids.view(B, 1), pos, cmp_stage_cap, aux_layer_ids=aux_ids
+        )
+        if self._dspark is None:
+            return result
+        logits, aux = result
+        req = batch.reqs[0]
+        segments = [(0, 1, req.table_idx, int(pos[0].item()))]
+        self._dspark.store_target_context(
+            aux, segments=segments, positions=pos[:1]
+        )
+        return logits
+
+    def propose_mtp(self, batch, next_token: torch.Tensor) -> torch.Tensor | None:
+        if self._dspark is None:
+            return None
+        return self._dspark.propose(
+            batch,
+            next_token,
+            embedding_weight=self._transformer.embed.weight,
+            head_weight=self._transformer.head,
+        )
+
+    def take_speculative_probs(self) -> torch.Tensor | None:
+        if self._dspark is None:
+            return None
+        probs = self._dspark.last_draft_probs
+        self._dspark.last_draft_probs = None
+        return probs
 
 
 __all__ = ["Transformer", "DeepseekV4ForCausalLM"]

--- a/python/sparklab/models/deepseek_v4/weight.py
+++ b/python/sparklab/models/deepseek_v4/weight.py
@@ -163,13 +163,92 @@ def iter_weights(
         reader.close()
 
 
+def iter_speculative_weights(model_path: str, device):
+    """Stream the resident ``mtp.*`` DSpark tensors under draft-model names.
+
+    Routed experts remain in the shared expert-bank artifact. The target embedding
+    and LM head are aliased at runtime and therefore are not duplicated here.
+    """
+    args = load_args(model_path, max_batch_size=1)
+    if not (
+        args.n_mtp_layers
+        and args.dspark_target_layer_ids
+        and args.dspark_markov_rank
+    ):
+        return
+    reader = _ShardReader(model_path, _weight_map(model_path), device)
+
+    def get(name: str) -> torch.Tensor:
+        return reader.get(name)
+
+    def linear(source: str, target: str):
+        yield f"{target}.weight", get(f"{source}.weight")
+        if reader.has(f"{source}.scale"):
+            yield f"{target}.scale", get(f"{source}.scale")
+
+    try:
+        yield from linear("mtp.0.main_proj", "main_proj")
+        yield "main_norm.weight", get("mtp.0.main_norm.weight")
+        for stage in range(args.n_mtp_layers):
+            source = f"mtp.{stage}"
+            target = f"layers.{stage}"
+            a_source, a_target = f"{source}.attn", f"{target}.attn"
+            yield from linear(f"{a_source}.wq_a", f"{a_target}.wq_a")
+            yield f"{a_target}.q_norm.weight", get(f"{a_source}.q_norm.weight")
+            yield from linear(f"{a_source}.wq_b", f"{a_target}.wq_b")
+            yield from linear(f"{a_source}.wkv", f"{a_target}.wkv")
+            yield f"{a_target}.kv_norm.weight", get(f"{a_source}.kv_norm.weight")
+            yield f"{a_target}.wo_a", _dequant_fp8_block(
+                get(f"{a_source}.wo_a.weight"), get(f"{a_source}.wo_a.scale")
+            )
+            yield from linear(f"{a_source}.wo_b", f"{a_target}.wo_b")
+            yield f"{a_target}.attn_sink", get(f"{a_source}.attn_sink")
+            yield f"{target}.attn_norm.weight", get(f"{source}.attn_norm.weight")
+            yield f"{target}.ffn_norm.weight", get(f"{source}.ffn_norm.weight")
+
+            gate = f"{target}.ffn.gate"
+            yield f"{gate}.weight", get(f"{source}.ffn.gate.weight")
+            yield f"{gate}.bias", get(f"{source}.ffn.gate.bias")
+            for proj in ("w1", "w2", "w3"):
+                yield from linear(
+                    f"{source}.ffn.shared_experts.{proj}",
+                    f"{target}.ffn.shared_experts.{proj}",
+                )
+            for name in (
+                "hc_attn_fn", "hc_ffn_fn", "hc_attn_base", "hc_ffn_base",
+                "hc_attn_scale", "hc_ffn_scale",
+            ):
+                yield f"{target}.{name}", get(f"{source}.{name}")
+
+        final = args.n_mtp_layers - 1
+        for name in ("hc_head_fn", "hc_head_base", "hc_head_scale"):
+            yield name, get(f"mtp.{final}.{name}")
+        yield "norm.weight", get(f"mtp.{final}.norm.weight")
+        yield "markov_w1", get(f"mtp.{final}.markov_head.markov_w1.weight")
+        yield "markov_w2", get(f"mtp.{final}.markov_head.markov_w2.weight")
+        if reader.has(f"mtp.{final}.confidence_head.proj.weight"):
+            yield "confidence_weight", get(
+                f"mtp.{final}.confidence_head.proj.weight"
+            )
+    finally:
+        reader.close()
+
+
 # --------------------------------------------------------------------------------------
 # Routed FP4 expert pinned banks.
 # --------------------------------------------------------------------------------------
 _EXPERT_RE = re.compile(
-    r"^layers\.(?P<layer>\d+)\.ffn\.experts\.(?P<expert>\d+)\."
+    r"^(?:layers\.(?P<layer>\d+)|mtp\.(?P<mtp_layer>\d+))\.ffn\.experts\."
+    r"(?P<expert>\d+)\."
     r"(?P<proj>w1|w2|w3)\.(?P<kind>weight|scale)$"
 )
+
+
+def _expert_layer(match: re.Match, target_layers: int) -> int:
+    layer = match.group("layer")
+    if layer is not None:
+        return int(layer)
+    return target_layers + int(match.group("mtp_layer"))
 
 
 def load_dsfp4_expert_sources(
@@ -191,7 +270,7 @@ def load_dsfp4_expert_sources(
 
     folder = model_path
     weight_map = _weight_map(folder)
-    L, E = args.n_layers, args.n_routed_experts
+    L, E = args.runtime_n_layers, args.n_routed_experts
     H, I = args.dim, args.moe_inter_dim
 
     for shard in sorted(set(weight_map.values())):
@@ -202,7 +281,7 @@ def load_dsfp4_expert_sources(
         m = _EXPERT_RE.match(name)
         if m is None:
             continue
-        if int(m.group("layer")) >= L:  # skip the MTP layer (index L)
+        if _expert_layer(m, args.n_layers) >= L:
             continue
         shards[shard].append((name, m))
 
@@ -223,7 +302,9 @@ def load_dsfp4_expert_sources(
             path = os.path.join(folder, shard)
             with safetensors.safe_open(path, framework="pt", device="cpu") as f:
                 for name, m in shards[shard]:
-                    layer = _place_dsfp4(banks, name, f.get_tensor(name), I)
+                    layer = _place_dsfp4(
+                        banks, name, f.get_tensor(name), I, args.n_layers
+                    )
                     tracker.note(layer)
                     placed += 1
             drop_page_cache(path)
@@ -244,7 +325,7 @@ def dummy_dsfp4_expert_sources(args: DeepseekV4Args) -> dict[str, list[torch.Ten
     """Fabricate the 4 ds_fp4 banks for --dummy-weight (no checkpoint on disk)."""
     from sparklab.moe.host_banks import alloc_layer_banks, pin_banks
 
-    L, E = args.n_layers, args.n_routed_experts
+    L, E = args.runtime_n_layers, args.n_routed_experts
     H, I = args.dim, args.moe_inter_dim
     e8m0 = torch.float8_e8m0fnu
     specs = {
@@ -268,11 +349,14 @@ def is_expert_tensor(name: str) -> bool:
     return _EXPERT_RE.match(name) is not None
 
 
-def _place_dsfp4(banks: dict, name: str, t: torch.Tensor, I: int) -> int:
+def _place_dsfp4(
+    banks: dict, name: str, t: torch.Tensor, I: int, target_layers: int
+) -> int:
     """Copy one expert tensor into its layer/expert slot (shared by serial + parallel
     readers): w1->gate_up[:,:I], w3->gate_up[:,I:], w2->down. Returns the layer index."""
     m = _EXPERT_RE.match(name)
-    layer, expert = int(m.group("layer")), int(m.group("expert"))
+    layer = _expert_layer(m, target_layers)
+    expert = int(m.group("expert"))
     proj, kind = m.group("proj"), m.group("kind")
     if kind == "weight":
         t = t.view(torch.uint8)
@@ -302,7 +386,7 @@ def load_dsfp4_expert_sources_parallel(
     from sparklab.models.weight import iter_expert_tensors_parallel
     from sparklab.moe.host_banks import LayerCompletionTracker, PinPipeline, alloc_layer_banks
 
-    L, E = args.n_layers, args.n_routed_experts
+    L, E = args.runtime_n_layers, args.n_routed_experts
     H, I = args.dim, args.moe_inter_dim
     e8m0 = torch.float8_e8m0fnu
     specs = {
@@ -316,13 +400,13 @@ def load_dsfp4_expert_sources_parallel(
 
     def _is_expert(name: str) -> bool:
         m = _EXPERT_RE.match(name)
-        return m is not None and int(m.group("layer")) < L  # skip the MTP layer (index L)
+        return m is not None and _expert_layer(m, args.n_layers) < L
 
     def _load(sink) -> int:
         tracker = LayerCompletionTracker(E * 6, hb, sink)
         placed = 0
         for name, t in iter_expert_tensors_parallel(model_path, _is_expert, workers=workers, chunk=chunk):
-            layer = _place_dsfp4(banks, name, t, I)
+            layer = _place_dsfp4(banks, name, t, I, args.n_layers)
             tracker.note(layer)
             placed += 1
         return placed
@@ -340,6 +424,7 @@ def load_dsfp4_expert_sources_parallel(
 
 __all__ = [
     "iter_weights",
+    "iter_speculative_weights",
     "load_dsfp4_expert_sources",
     "load_dsfp4_expert_sources_parallel",
     "is_expert_tensor",

--- a/python/sparklab/recipes/deepseek-v4.json
+++ b/python/sparklab/recipes/deepseek-v4.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.2.0",
+  "recipe_version": "0.3.0",
   "slug": "deepseek-v4",
   "name": "DeepSeek V4 Flash",
   "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
   "parameters": "284B total / 13B active",
   "revision": "7872f01b1d1fe23eabc4c98b48bffcef5a386062",
   "source_bytes": 166878536440,
-  "prepared_bytes": 157460918272,
-  "minimum_free_bytes": 461778408184,
+  "prepared_bytes": 168424579072,
+  "minimum_free_bytes": 472742068984,
   "intended_tier": "frontier",
   "status": "preview",
   "implementation": "available",
@@ -37,16 +37,17 @@
     "total_bytes": 107374182400
   },
   "performance": {
-    "decode_tokens_per_second": 10.282266070445095,
-    "warm_ttft_seconds": 0.6035212678834796,
-    "evidence": "GB10-DSV4-SPARSE-001",
-    "note": "Auto-sized route-first sparse-prefill probe; not a complete Frontier certification."
+    "decode_tokens_per_second": 7.407656188456706,
+    "warm_ttft_seconds": 2.1198420680011623,
+    "evidence": "GB10-DSV4-DSPARK-002",
+    "note": "Fused 0731 checkpoint, fixed 256-token probe with DSpark disabled. DSpark is supported as an opt-in experiment; every measured N=1/3/5/7 setting was slower with disk-backed experts on one GB10."
   },
-  "description": "Optimized DS-FP4 Frontier recipe with auto-sized expert residency and route-first sparse prefill on one NVIDIA GB10.",
-  "evidence": ["GB10-DSV4-SPARSE-001"],
+  "description": "Fused DS-FP4 Frontier recipe with optional native DSpark speculative decoding, auto-sized expert residency, and route-first sparse prefill on one NVIDIA GB10.",
+  "evidence": ["GB10-DSV4-DSPARK-002"],
   "limitations": [
     "The 64K context and 60-minute agent gates have not passed.",
-    "The fixed probe passed Frontier performance thresholds, but capability, quality, parser, and agent gates remain incomplete.",
+    "Capability, quality, parser, and agent gates remain incomplete.",
+    "DSpark is opt-in: the one-GB10 disk-offload matrix measured 7.07, 6.19, 5.97, and 5.16 tok/s for N=1, 3, 5, and 7 versus a 7.41 tok/s target-only control.",
     "The 512-token sparse-prefill threshold is optimized for short interactive prompts; longer prefills retain the bounded full-layer streaming path."
   ]
 }

--- a/python/sparklab/runtime/engine/config.py
+++ b/python/sparklab/runtime/engine/config.py
@@ -95,9 +95,11 @@ class EngineConfig:
     # KV capacity in tokens; resolved into num_page_override by _adjust_config once page_size
     # is final. Mutually exclusive with num_page_override.
     num_token_override: int | None = None
-    # Native Qwen4 MTP speculative decoding. Zero disables it; the first
-    # implementation intentionally caps the checkpoint's one-layer head at 3.
+    # Native speculative decoding. ``auto`` selects Qwen MTP or the fused DSV4
+    # DSpark head from checkpoint metadata. Zero tokens disables the path.
+    speculative_method: str = "auto"
     speculative_tokens: int = 0
+    draft_sample_method: str = "greedy"
 
     @cached_property
     def hf_config(self):

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -271,16 +271,74 @@ def _validate_attention_backend_choice(config, override, required: frozenset[Att
 
 
 def _adjust_speculative_config(config: EngineConfig, override) -> None:
-    """Inject the Qwen4 MTP layer before cache/backend resolution."""
+    """Resolve and inject checkpoint-native speculation before cache sizing."""
     speculative_tokens = int(getattr(config, "speculative_tokens", 0) or 0)
-    if speculative_tokens < 0 or speculative_tokens > 3:
-        raise ValueError("--speculative-tokens must be between 0 and 3")
+    if speculative_tokens < 0 or speculative_tokens > 7:
+        raise ValueError("--speculative-tokens must be between 0 and 7")
     if not speculative_tokens:
         return
 
     model_config = config.model_config
-    if getattr(model_config, "qwen4_exp_args", None) is None:
-        raise ValueError("--speculative-tokens currently supports Qwen4-Exp only")
+    requested = str(getattr(config, "speculative_method", "auto") or "auto")
+    qwen_mtp = getattr(model_config, "qwen4_exp_args", None) is not None
+    dsv4_args = getattr(model_config, "dsv4_args", None)
+    dsv4_dspark = bool(
+        dsv4_args is not None
+        and int(getattr(dsv4_args, "n_mtp_layers", 0) or 0) > 0
+        and tuple(getattr(dsv4_args, "dspark_target_layer_ids", ()) or ())
+        and int(getattr(dsv4_args, "dspark_markov_rank", 0) or 0) > 0
+    )
+    if requested == "auto":
+        method = "dspark" if dsv4_dspark else "mtp" if qwen_mtp else "none"
+    else:
+        method = requested
+    if method == "none":
+        raise ValueError(
+            "--speculative-tokens was provided, but this checkpoint has no supported draft"
+        )
+
+    if method == "dspark":
+        if not dsv4_dspark:
+            raise ValueError(
+                "--speculative-method dspark requires a fused DeepSeek-V4 DSpark checkpoint"
+            )
+        if getattr(config, "draft_sample_method", "greedy") not in {
+            "greedy", "probabilistic"
+        }:
+            raise ValueError("unsupported --draft-sample-method")
+        from sparklab.models.config import DSV4AttentionGroupConfig
+
+        args = replace(dsv4_args, dspark_enabled=True)
+        first = model_config.num_layers
+        draft_ids = tuple(range(first, first + args.n_mtp_layers))
+        groups = []
+        for group in model_config.attention_groups:
+            if isinstance(group, DSV4AttentionGroupConfig):
+                missing = tuple(layer for layer in draft_ids if layer not in group.layer_ids)
+                group = replace(group, layer_ids=(*group.layer_ids, *missing))
+            groups.append(group)
+        object.__setattr__(model_config, "dsv4_args", args)
+        object.__setattr__(model_config, "attention_groups", tuple(groups))
+        object.__setattr__(model_config, "speculative_method", "dspark")
+        object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
+        object.__setattr__(
+            model_config, "draft_sample_method", config.draft_sample_method
+        )
+        override("speculative_method", "dspark")
+        # Correctness-first verification is eager and batch one. The DSpark
+        # query block itself is still parallel inside one model forward.
+        override("max_running_req", 1)
+        override("cache_type", "radix")
+        override("cuda_graph_bs", [])
+        override("cuda_graph_max_bs", 0)
+        return
+
+    if method != "mtp" or not qwen_mtp:
+        raise ValueError("--speculative-method mtp currently supports Qwen4-Exp only")
+    if speculative_tokens > 3:
+        raise ValueError("Qwen4 MTP supports at most 3 speculative tokens")
+    if getattr(config, "draft_sample_method", "greedy") != "greedy":
+        raise ValueError("Qwen4 MTP currently supports greedy draft sampling only")
     # The draft layer owns an independent QSA KV/index slot at the first layer
     # id beyond the target tower. Inject it without changing num_layers, which
     # still constructs exactly the target blocks. Do this before hybrid-cache
@@ -302,7 +360,9 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         groups.append(group)
     object.__setattr__(model_config, "qwen4_exp_args", args)
     object.__setattr__(model_config, "attention_groups", tuple(groups))
+    object.__setattr__(model_config, "speculative_method", "mtp")
     object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
+    override("speculative_method", "mtp")
     # Transactional verification is eager and currently batch-one. This is an
     # explicit bring-up constraint, not a silent numerical compromise.
     override("max_running_req", 1)
@@ -366,6 +426,44 @@ def _longest_accepted_prefix(truth: torch.Tensor, drafts: torch.Tensor) -> int:
     return accepted
 
 
+def _verify_speculative_tokens(
+    logits: torch.Tensor,
+    drafts: torch.Tensor,
+    draft_probs: torch.Tensor | None,
+    sampling_params,
+) -> tuple[int, torch.Tensor]:
+    """Verify deterministic drafts or apply exact stochastic rejection sampling."""
+    drafts = drafts.to(torch.int64)
+    if sampling_params.is_greedy or draft_probs is None:
+        truth = torch.argmax(logits, dim=-1).to(torch.int64)
+        accepted = _longest_accepted_prefix(truth, drafts)
+        chosen = torch.cat((drafts[:accepted], truth[accepted : accepted + 1]))
+        return accepted, chosen.to(torch.int32)
+
+    from sparklab.runtime.engine.sample import sampling_distribution
+
+    target_probs = sampling_distribution(logits, sampling_params)
+    draft_probs = draft_probs[: drafts.numel()].float()
+    accepted = 0
+    for index, token in enumerate(drafts):
+        target_p = target_probs[index, token]
+        draft_p = draft_probs[index, token].clamp_min(1e-20)
+        accept_p = torch.minimum(target_p / draft_p, target_p.new_tensor(1.0))
+        if bool((torch.rand((), device=logits.device) <= accept_p).item()):
+            accepted += 1
+            continue
+        residual = (target_probs[index] - draft_probs[index]).clamp_min(0)
+        total = residual.sum()
+        correction_probs = (
+            residual / total if bool((total > 0).item()) else target_probs[index]
+        )
+        correction = torch.multinomial(correction_probs, 1).to(torch.int32)
+        return accepted, torch.cat((drafts[:accepted].to(torch.int32), correction))
+
+    bonus = torch.multinomial(target_probs[drafts.numel()], 1).to(torch.int32)
+    return accepted, torch.cat((drafts.to(torch.int32), bonus))
+
+
 class ForwardOutput(NamedTuple):
     next_tokens_gpu: torch.Tensor
     next_tokens_cpu: torch.Tensor
@@ -422,6 +520,12 @@ class Engine:
                 config.model_path, dummy=config.use_dummy_weight
             )
         self.model.load_state_dict(self._load_weight_state_dict(config))
+        if hasattr(self.model, "speculative_state_dict"):
+            speculative = self.model.speculative_state_dict()
+            if speculative:
+                self.model.load_speculative_state_dict(
+                    self._load_speculative_weight_state_dict(config, speculative)
+                )
         post_weights_free = self._sync_get_memory()[0]
         self._weights_bytes = self._baseline_free - post_weights_free
         # Pool-budget baseline for the desktop cache sliders: free VRAM after the weights are
@@ -575,6 +679,27 @@ class Engine:
                 include_moe_experts=not is_offload_moe_backend(config.moe_backend),
             ),
             device=self.device,
+        )
+
+    def _load_speculative_weight_state_dict(
+        self, config: EngineConfig, model_state: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
+        if config.use_dummy_weight:
+            return _make_dummy_weight_state_dict(model_state, device=self.device)
+        from sparklab.checkpoint.ftw import is_ftw_checkpoint, iter_ftw_weights
+
+        if is_ftw_checkpoint(config.model_path):
+            weights = iter_ftw_weights(
+                config.model_path, kinds=("speculative_weight",)
+            )
+        else:
+            from sparklab.models.register import _load_attr, get_model_spec
+
+            spec = get_model_spec(config.model_config.architectures[0])
+            loader = _load_attr(spec.module, "iter_speculative_weights")
+            weights = loader(config.model_path, torch.device("cpu"))
+        return _materialize_loaded_weight_state_dict(
+            model_state, weights, device=self.device
         )
 
     def _resolve_auto_moe_cache_size(
@@ -1047,16 +1172,25 @@ class Engine:
         if self.config.speculative_tokens:
             self.mtp_stats["target_forwards"] += 1
         state_snapshots: list[tuple[int, int]] = []
+        kv_snapshot = None
         if batch.is_verify:
-            pool = self.linear_state_pool
-            if pool is None:
-                raise RuntimeError("MTP verification requires a recurrent-state pool")
-            for req in batch.reqs:
-                if req.linear_slot_idx is None or req.mamba_ping_pong is None:
-                    raise RuntimeError("MTP verification requires hybrid-radix state slots")
-                scratch = req.mamba_ping_pong[req.mamba_next_track_idx]
-                pool.copy_from(req.linear_slot_idx, scratch)
-                state_snapshots.append((req.linear_slot_idx, scratch))
+            if self.config.speculative_method == "dspark":
+                if batch.size != 1:
+                    raise RuntimeError("DSpark verification currently supports batch size 1")
+                start = batch.verify_cached_lens[0]
+                kv_snapshot = self.kv_cache.snapshot_speculative(
+                    batch.reqs[0].table_idx, start, start + batch.input_ids.numel()
+                )
+            else:
+                pool = self.linear_state_pool
+                if pool is None:
+                    raise RuntimeError("MTP verification requires a recurrent-state pool")
+                for req in batch.reqs:
+                    if req.linear_slot_idx is None or req.mamba_ping_pong is None:
+                        raise RuntimeError("MTP verification requires hybrid-radix state slots")
+                    scratch = req.mamba_ping_pong[req.mamba_next_track_idx]
+                    pool.copy_from(req.linear_slot_idx, scratch)
+                    state_snapshots.append((req.linear_slot_idx, scratch))
         with self.ctx.forward_batch(batch):
             if not batch.is_verify and self.graph_runner.can_use_cuda_graph(batch):
                 logits = self.graph_runner.replay(batch)
@@ -1069,23 +1203,34 @@ class Engine:
 
         if batch.is_verify:
             if batch.size != 1:
-                raise RuntimeError("Qwen4 MTP verification currently supports batch size 1")
+                raise RuntimeError("speculative verification currently supports batch size 1")
             req = batch.reqs[0]
             start = batch.verify_cached_lens[0]
-            truth = torch.argmax(logits, dim=-1).to(torch.int32)
             drafts = batch.input_ids[1:].to(torch.int32)
-            accepted = _longest_accepted_prefix(truth, drafts)
+            accepted, chosen = _verify_speculative_tokens(
+                logits,
+                drafts,
+                req.speculative_draft_probs,
+                req.sampling_params,
+            )
             self.mtp_stats["drafted"] += int(drafts.numel())
             self.mtp_stats["accepted"] += accepted
-            chosen = torch.cat((drafts[:accepted], truth[accepted : accepted + 1]))
             if accepted < drafts.numel():
-                live, scratch = state_snapshots[0]
-                self.linear_state_pool.copy_from(scratch, live)
+                if self.config.speculative_method == "dspark":
+                    self.kv_cache.restore_speculative(kv_snapshot)
+                else:
+                    live, scratch = state_snapshots[0]
+                    self.linear_state_pool.copy_from(scratch, live)
                 self._replay_verified_prefix(batch, accepted + 1, start)
                 req.speculative_drafts = None
+                req.speculative_draft_probs = None
             else:
-                req.speculative_drafts = self.model.propose_mtp(
-                    batch, truth[-1:]
+                req.speculative_drafts = self._propose_speculative(
+                    batch, chosen[-1:]
+                )
+                take_probs = getattr(self.model, "take_speculative_probs", None)
+                req.speculative_draft_probs = (
+                    take_probs() if take_probs is not None else None
                 )
             req.cached_len = start + accepted + 1
             req.device_len = req.cached_len + 1
@@ -1100,10 +1245,12 @@ class Engine:
         else:
             batch_logits = logits[: batch.size]
             next_tokens_gpu = self.sampler.sample(batch_logits, args).to(torch.int32)
-            proposer = getattr(self.model, "propose_mtp", None)
-            proposals = proposer(batch, next_tokens_gpu) if proposer is not None else None
+            proposals = self._propose_speculative(batch, next_tokens_gpu)
+            take_probs = getattr(self.model, "take_speculative_probs", None)
+            proposal_probs = take_probs() if take_probs is not None else None
             for index, req in enumerate(batch.reqs):
                 req.speculative_drafts = proposals if index == 0 else None
+                req.speculative_draft_probs = proposal_probs if index == 0 else None
                 req.complete_one()
             token_counts = tuple(1 for _ in batch.reqs)
             managed_writes = False
@@ -1120,9 +1267,23 @@ class Engine:
             token_counts, managed_writes,
         )
 
+    def _propose_speculative(
+        self, batch: Batch, next_tokens: torch.Tensor
+    ) -> torch.Tensor | None:
+        """Run the checkpoint-native draft with the target batch context active.
+
+        Draft blocks execute after target sampling, so the target forward's context
+        manager has already exited.  Their MoE layers still need ``ctx.batch`` to
+        select the multi-token prefill/decode dispatch and collect cache telemetry.
+        """
+        proposer = getattr(self.model, "propose_mtp", None)
+        if proposer is None:
+            return None
+        with self.ctx.forward_batch(batch):
+            return proposer(batch, next_tokens)
+
     def _replay_verified_prefix(self, batch: Batch, length: int, start: int) -> None:
-        """Rebuild GDN/PLE state after a partial speculative rejection."""
-        from sparklab.attention.linear import build_fla_metadata
+        """Rebuild stateful target/draft cache after a partial rejection."""
 
         original = batch.reqs[0]
         query = batch.input_ids[:length]
@@ -1146,13 +1307,19 @@ class Engine:
         replay.input_ids = query
         replay.positions = batch.positions[:length]
         replay.out_loc = batch.out_loc[:length]
-        replay.linear_table_idx = torch.tensor(
-            [original.linear_slot_idx], dtype=torch.int32, device=self.device
-        )
-        replay.fla_metadata = build_fla_metadata(replay, self.device)
+        if self.linear_state_pool is not None:
+            from sparklab.attention.linear import build_fla_metadata
+
+            replay.linear_table_idx = torch.tensor(
+                [original.linear_slot_idx], dtype=torch.int32, device=self.device
+            )
+            replay.fla_metadata = build_fla_metadata(replay, self.device)
         self.attn_backend.prepare_metadata(replay)
         with self.ctx.forward_batch(replay):
-            self.model.model.forward(replay.input_ids)
+            if self.config.speculative_method == "dspark":
+                self.model.forward()
+            else:
+                self.model.model.forward(replay.input_ids)
 
     @torch.inference_mode()
     def _warmup_prefill(self) -> None:

--- a/python/sparklab/runtime/engine/sample.py
+++ b/python/sparklab/runtime/engine/sample.py
@@ -7,7 +7,7 @@ import torch
 from sparklab.utils import is_sm90_supported, nvtx_annotate
 
 if TYPE_CHECKING:
-    from sparklab.core import Batch
+    from sparklab.core import Batch, SamplingParams
 
 
 @dataclass
@@ -48,6 +48,23 @@ def sample_impl(
 
     assert top_k is not None and top_p is not None
     return sampling.top_k_top_p_sampling_from_probs(probs, top_k, top_p)
+
+
+def sampling_distribution(logits: torch.Tensor, params: SamplingParams) -> torch.Tensor:
+    """Reference torch distribution used by stochastic speculative verification."""
+    values = logits.float() / max(float(params.temperature), 1e-6)
+    if params.top_k >= 1 and params.top_k < values.shape[-1]:
+        threshold = values.topk(int(params.top_k), dim=-1).values[..., -1, None]
+        values = values.masked_fill(values < threshold, float("-inf"))
+    if float(params.top_p) < 1.0:
+        ordered, indices = values.sort(dim=-1, descending=True)
+        ordered_probs = ordered.softmax(dim=-1)
+        remove = ordered_probs.cumsum(dim=-1) - ordered_probs > float(params.top_p)
+        ordered = ordered.masked_fill(remove, float("-inf"))
+        values = torch.full_like(values, float("-inf")).scatter(
+            -1, indices, ordered
+        )
+    return values.softmax(dim=-1)
 
 
 @dataclass

--- a/python/sparklab/runtime/kvcache/dsv4_cost_model.py
+++ b/python/sparklab/runtime/kvcache/dsv4_cost_model.py
@@ -27,6 +27,13 @@ _BF16_BYTES = 2
 _FP32_BYTES = 4
 
 
+def _runtime_ratios(args) -> tuple[int, ...]:
+    ratios = getattr(args, "runtime_compress_ratios", None)
+    if ratios is not None:
+        return tuple(ratios)
+    return tuple(args.compress_ratios)[: args.n_layers]
+
+
 def dsv4_reserved_window_pages(max_running_req: int, radix: bool) -> int:
     """Window pages the sliding pool must always keep for the concurrent working set: each
     running request's decode transients (2 per req + dummy) plus, in radix mode, PER concurrent
@@ -80,7 +87,7 @@ def dsv4_cache_per_page(args, swa_ratio: float, P: int = 128) -> int:
     idx_b = _index_bytes(args)
 
     total = 0
-    for ratio in tuple(args.compress_ratios)[: args.n_layers]:
+    for ratio in _runtime_ratios(args):
         # Window tier exists on EVERY layer (all-sliding), scaled by swa_ratio.
         total += round(swa_ratio * P) * kv_b
         if ratio == 0:
@@ -107,7 +114,7 @@ def dsv4_kv_unit_bytes(args, P: int = 128) -> int:
     kv_b = _kv_bytes(args)
     idx_b = _index_bytes(args)
     per_page = P * _INT64_BYTES  # full_to_window map: one int64 slot per full token
-    for ratio in tuple(args.compress_ratios)[: args.n_layers]:
+    for ratio in _runtime_ratios(args):
         if ratio == 0:
             continue
         per_page += (P // ratio) * kv_b  # compressed KV
@@ -122,7 +129,7 @@ def dsv4_window_unit_bytes(args, P: int = 128) -> int:
     ``state_slots = n_win_pages * ring_size``). Independent of ``swa_ratio`` -- the ratio only sets
     how many window tokens exist, not the per-token cost. This is ``swa_bytes_per_token``."""
     kv_b = _kv_bytes(args)
-    ratios = tuple(args.compress_ratios)[: args.n_layers]
+    ratios = _runtime_ratios(args)
     per_page = len(ratios) * P * kv_b  # window KV: P slots per page, every layer
     for ratio in ratios:
         if ratio == 0:
@@ -174,7 +181,7 @@ def dsv4_pool_sizes(
     state_slots: list[int | None] = []
     ring_sizes: list[int | None] = []
     idx_state_slots: list[int | None] = []
-    for ratio in tuple(args.compress_ratios)[: args.n_layers]:
+    for ratio in _runtime_ratios(args):
         if ratio == 0:
             cmp_blocks.append(None)
             idx_blocks.append(None)
@@ -213,7 +220,7 @@ def dsv4_pool_bytes(sizes: DSV4PoolSizes, args, n_scratch: int = 1) -> int:
     +1 ring scratch row, +1 mapping sentinel row)."""
     kv_b = _kv_bytes(args)
     idx_b = _index_bytes(args)
-    ratios = tuple(args.compress_ratios)[: args.n_layers]
+    ratios = _runtime_ratios(args)
 
     total = len(ratios) * sizes.n_win_slots * kv_b  # window pool, every layer
     total += (sizes.full_token + 1) * _INT64_BYTES  # full_to_window (+ sentinel row)

--- a/python/sparklab/runtime/kvcache/dsv4_paged_pool.py
+++ b/python/sparklab/runtime/kvcache/dsv4_paged_pool.py
@@ -167,12 +167,10 @@ class DSV4PagedKVCache(BaseKVCachePool):
         self._device = device
         self._dtype = dtype
         self.P = P
-        self._n_layers = args.n_layers
+        self._n_layers = args.runtime_n_layers
         self.head_dim = args.head_dim
         self.index_head_dim = args.index_head_dim
-        # The checkpoint can ship one extra trailing ratio (44 for 43 layers); the model only uses
-        # the first n_layers, so truncate to match.
-        self.compress_ratios = tuple(args.compress_ratios)[: self._n_layers]
+        self.compress_ratios = args.runtime_compress_ratios
         assert len(self.compress_ratios) == self._n_layers
         # Scratch rows appended to each cmp/idx pool tensor BEYOND the allocator's capacity
         # (never handed out): batched decode routes each row whose compressed block did NOT
@@ -568,6 +566,49 @@ class DSV4PagedKVCache(BaseKVCachePool):
         pool = self.idx_pool[layer_id]
         assert pool is not None, f"layer {layer_id} has no indexer pool (only ratio-4)"
         pool.index_copy_(0, idx_slot, k.to(self._dtype))
+
+    def snapshot_speculative(self, table_idx: int, start: int, end: int):
+        """Snapshot only compressor carry blocks touched by speculative verification."""
+        if end <= start:
+            return []
+        full = self.full_loc_map[table_idx, start:end]
+        slots = self.translate_full_to_window(full)
+        slots = slots[slots >= 0]
+        if slots.numel() == 0:
+            return []
+        page_bases = torch.unique(
+            torch.div(slots, self.P, rounding_mode="floor") * self.P
+        )
+        snapshots = []
+        for layer_id, ratio in enumerate(self.compress_ratios):
+            if not ratio:
+                continue
+            ring_size = ring_size_for_ratio(ratio)
+            state_bases = torch.div(
+                page_bases, self.P, rounding_mode="floor"
+            ) * ring_size
+            rows = (
+                state_bases[:, None]
+                + torch.arange(ring_size, device=self._device)[None, :]
+            ).flatten()
+            ring = self.state_ring[layer_id]
+            snapshots.append((ring, rows, ring.buffer.index_select(0, rows).clone()))
+            index_ring = self.indexer_state_ring[layer_id]
+            if index_ring is not None:
+                snapshots.append(
+                    (
+                        index_ring,
+                        rows,
+                        index_ring.buffer.index_select(0, rows).clone(),
+                    )
+                )
+        return snapshots
+
+    @staticmethod
+    def restore_speculative(snapshots) -> None:
+        for ring, rows, values in snapshots:
+            ring.buffer.index_copy_(0, rows, values)
+            ring._clear_scratch()
 
     def total_bytes(self) -> int:
         n = self.full_to_window.numel() * self.full_to_window.element_size()

--- a/python/sparklab/serving/args.py
+++ b/python/sparklab/serving/args.py
@@ -321,11 +321,23 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--speculative-method",
+        choices=("auto", "mtp", "dspark"),
+        default=ServerArgs.speculative_method,
+        help="Speculative decoder (auto selects the checkpoint-native method).",
+    )
+    parser.add_argument(
         "--speculative-tokens",
         type=int,
-        choices=range(0, 4),
+        choices=range(0, 8),
         default=ServerArgs.speculative_tokens,
-        help="Qwen4 MTP draft length (0 disables; supported values: 1, 2, 3).",
+        help="Draft length (0 disables; Qwen MTP supports 1-3, DSV4 DSpark 1-7).",
+    )
+    parser.add_argument(
+        "--draft-sample-method",
+        choices=("greedy", "probabilistic"),
+        default=ServerArgs.draft_sample_method,
+        help="Draft sampling/verification rule for speculative decoding.",
     )
 
     parser.add_argument(

--- a/tests/checkpoint/test_ftw_expert_rows.py
+++ b/tests/checkpoint/test_ftw_expert_rows.py
@@ -15,11 +15,11 @@ from sparklab.checkpoint.ftw import (
 )
 
 
-def _write_ftw(path, tensors):
+def _write_ftw(path, tensors, *, num_layers=2):
     writer = FTWWriter(str(path), shard_limit=4096 * 3)
     for name, tensor in tensors:
         writer.add_tensor(name, tensor, kind="experts_bank")
-    writer.finalize({"expert_bank_num_layers": 2, "quant_format": "test"})
+    writer.finalize({"expert_bank_num_layers": num_layers, "quant_format": "test"})
 
 
 def test_writer_syncs_and_evicts_each_completed_shard(tmp_path, monkeypatch):
@@ -91,6 +91,34 @@ def test_flat_expert_rows_round_trip(tmp_path):
             for expert_id in range(3):
                 got = reader.read_expert_row(index[(layer_id, expert_id, "weight")])
                 assert torch.equal(got, flat[layer_id * 3 + expert_id])
+    finally:
+        reader.close()
+
+
+@pytest.mark.parametrize("layout", ["flat", "layered"])
+def test_expert_row_index_can_open_prefix_of_superset(tmp_path, layout):
+    layers = [
+        torch.arange(2 * 17, dtype=torch.int16).view(2, 17) + layer * 1_000
+        for layer in range(3)
+    ]
+    if layout == "flat":
+        tensors = [("weight", torch.cat(layers))]
+    else:
+        tensors = [
+            (layer_bank_entry_name("weight", layer), value)
+            for layer, value in enumerate(layers)
+        ]
+    _write_ftw(tmp_path, tensors, num_layers=3)
+
+    reader = FTWReader(str(tmp_path))
+    try:
+        index = reader.expert_row_descriptors(num_layers=2)
+        assert len(index) == 2 * 2
+        assert not any(layer_id == 2 for layer_id, _, _ in index)
+        for layer_id in range(2):
+            for expert_id in range(2):
+                got = reader.read_expert_row(index[(layer_id, expert_id, "weight")])
+                assert torch.equal(got, layers[layer_id][expert_id])
     finally:
         reader.close()
 

--- a/tests/models/test_dsv4_dspark.py
+++ b/tests/models/test_dsv4_dspark.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from types import SimpleNamespace
+
+import torch
+
+from sparklab.models import create_model
+from sparklab.models.deepseek_v4.args import DeepseekV4Args
+from sparklab.models.deepseek_v4.config import parse_config
+from sparklab.models.deepseek_v4 import weight as dsv4_weight
+from sparklab.models.deepseek_v4.compress import Compressor
+from sparklab.models.deepseek_v4.dspark import draft_query_geometry
+from sparklab.core import Context, SamplingParams
+from sparklab.runtime.distributed import set_tp_info, try_get_tp_info
+from sparklab.runtime.engine.engine import (
+    Engine,
+    _adjust_speculative_config,
+    _verify_speculative_tokens,
+)
+
+
+def _fused_config(tmp_path):
+    ratios = [0, 0, 4, 128, 4, 128, 4] + [0] * 39
+    raw = asdict(
+        DeepseekV4Args(
+            n_layers=43,
+            n_mtp_layers=3,
+            compress_ratios=tuple(ratios),
+            dspark_block_size=5,
+            dspark_noise_token_id=128799,
+            dspark_target_layer_ids=(40, 41, 42),
+            dspark_markov_rank=256,
+        )
+    )
+    folder = tmp_path / "inference"
+    folder.mkdir()
+    (folder / "config.json").write_text(json.dumps(raw))
+    return parse_config(
+        SimpleNamespace(_name_or_path=str(tmp_path), max_position_embeddings=1_048_576)
+    )
+
+
+def test_dspark_config_injects_three_draft_layers(tmp_path):
+    model_config = _fused_config(tmp_path)
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="auto",
+        speculative_tokens=7,
+        draft_sample_method="probabilistic",
+        max_running_req=8,
+        cache_type="naive",
+        cuda_graph_bs=[1, 2, 4],
+        cuda_graph_max_bs=4,
+    )
+
+    def override(name, value):
+        setattr(config, name, value)
+
+    _adjust_speculative_config(config, override)
+    _adjust_speculative_config(config, override)
+
+    assert config.speculative_method == "dspark"
+    assert model_config.speculative_method == "dspark"
+    assert model_config.dsv4_args.dspark_enabled is True
+    assert model_config.dsv4_args.runtime_n_layers == 46
+    assert model_config.num_moe_layers == 46
+    assert model_config.attention_groups[0].layer_ids[-3:] == (43, 44, 45)
+    assert config.max_running_req == 1
+    assert config.cache_type == "radix"
+    assert config.cuda_graph_bs == [] and config.cuda_graph_max_bs == 0
+
+
+def test_target_only_fused_config_keeps_43_layers(tmp_path):
+    model_config = _fused_config(tmp_path)
+    assert model_config.speculative_method == "none"
+    assert model_config.dsv4_args.dspark_enabled is False
+    assert model_config.dsv4_args.runtime_n_layers == 43
+    assert model_config.num_moe_layers == 43
+
+
+def test_probabilistic_verifier_accepts_and_emits_bonus():
+    logits = torch.tensor(
+        [[float("-inf"), 0.0, float("-inf")], [float("-inf"), float("-inf"), 0.0]]
+    )
+    drafts = torch.tensor([1])
+    draft_probs = torch.tensor([[0.0, 1.0, 0.0]])
+    accepted, chosen = _verify_speculative_tokens(
+        logits, drafts, draft_probs, SamplingParams(temperature=1.0)
+    )
+    assert accepted == 1
+    assert chosen.tolist() == [1, 2]
+
+
+def test_probabilistic_verifier_rejects_from_positive_residual():
+    logits = torch.tensor([[float("-inf"), 0.0, float("-inf")], [0.0, 0.0, 0.0]])
+    drafts = torch.tensor([0])
+    draft_probs = torch.tensor([[1.0, 0.0, 0.0]])
+    accepted, chosen = _verify_speculative_tokens(
+        logits, drafts, draft_probs, SamplingParams(temperature=1.0)
+    )
+    assert accepted == 0
+    assert chosen.tolist() == [1]
+
+
+def test_speculative_weight_names_match_draft_module(tmp_path, monkeypatch):
+    model_config = _fused_config(tmp_path)
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="dspark",
+        speculative_tokens=7,
+        draft_sample_method="probabilistic",
+        max_running_req=1,
+        cache_type="radix",
+        cuda_graph_bs=[],
+        cuda_graph_max_bs=0,
+    )
+    _adjust_speculative_config(config, lambda name, value: setattr(config, name, value))
+    if try_get_tp_info() is None:
+        set_tp_info(0, 1)
+    with torch.device("meta"):
+        model = create_model(model_config)
+    expected = set(model.speculative_state_dict())
+
+    class FakeReader:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def has(self, _name):
+            return True
+
+        def get(self, _name):
+            return torch.zeros(1)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(dsv4_weight, "_weight_map", lambda _path: {})
+    monkeypatch.setattr(dsv4_weight, "_ShardReader", FakeReader)
+    monkeypatch.setattr(
+        dsv4_weight, "_dequant_fp8_block", lambda _weight, _scale: torch.zeros(1)
+    )
+    names = {
+        name
+        for name, _ in dsv4_weight.iter_speculative_weights(
+            str(tmp_path), torch.device("cpu")
+        )
+    }
+    assert names == expected
+
+
+def test_draft_proposal_runs_with_active_batch_context():
+    engine = Engine.__new__(Engine)
+    engine.ctx = Context(page_size=1)
+    batch = object()
+
+    class Model:
+        def propose_mtp(self, received_batch, next_tokens):
+            assert received_batch is batch
+            assert engine.ctx.batch is batch
+            return next_tokens + 1
+
+    engine.model = Model()
+    result = engine._propose_speculative(batch, torch.tensor([4]))
+
+    assert result.tolist() == [5]
+    assert engine.ctx._batch is None
+
+
+def test_dspark_query_block_starts_at_sampled_anchor_and_stays_in_page():
+    assert draft_query_geometry(device_len=127, page_size=128, max_steps=7) == (126, 2)
+    assert draft_query_geometry(device_len=128, page_size=128, max_steps=7) == (127, 1)
+    assert draft_query_geometry(device_len=129, page_size=128, max_steps=7) == (128, 7)
+
+
+def test_speculative_verification_uses_unaligned_compressor_continuation(monkeypatch):
+    compressor = Compressor(DeepseekV4Args(dim=8), compress_ratio=4, head_dim=2)
+    compressor.P = 128
+    seeded = []
+    monkeypatch.setattr(
+        Compressor, "cmp_pool", property(lambda _self: torch.empty(1))
+    )
+    monkeypatch.setattr(
+        compressor, "_seed_carry_from_ring", lambda slot: seeded.append(slot)
+    )
+    sentinel = object()
+    received = []
+
+    def extend_unaligned(x, start_pos, window_slots, ti):
+        received.append((x.shape, start_pos, window_slots.tolist(), ti))
+        return sentinel
+
+    monkeypatch.setattr(compressor, "_extend_unaligned", extend_unaligned)
+    result = compressor.extend(
+        torch.zeros(1, 2, 8, dtype=torch.bfloat16),
+        start_pos=48,
+        window_slots=torch.tensor([304, 305]),
+        tail_window_slot=303,
+        ti=7,
+    )
+
+    assert result is sentinel
+    assert seeded == [303]
+    assert received == [((1, 2, 8), 48, [304, 305], 7)]

--- a/tests/runtime/kvcache/test_dsv4_pool.py
+++ b/tests/runtime/kvcache/test_dsv4_pool.py
@@ -106,6 +106,31 @@ def test_indexer_state_ring_separate_object_and_shape():
             assert pool.indexer_state_ring[L] is None
 
 
+def test_speculative_snapshot_restores_only_touched_ring_blocks():
+    pool, _, _ = _pool()
+    pool.full_loc_map = torch.arange(256, dtype=torch.int64).view(1, -1)
+    pool.bind_window_pages(0, 0)
+    pool.bind_window_pages(P, P)
+    ring = pool.state_ring[2]  # ratio-4
+    index_ring = pool.indexer_state_ring[2]
+    ring.buffer[:-1].copy_(
+        torch.arange(ring.buffer[:-1].numel()).view_as(ring.buffer[:-1])
+    )
+    index_ring.buffer[:-1].copy_(
+        torch.arange(index_ring.buffer[:-1].numel()).view_as(index_ring.buffer[:-1])
+    )
+    original = ring.buffer.clone()
+    original_index = index_ring.buffer.clone()
+
+    snapshots = pool.snapshot_speculative(0, P - 2, P + 2)
+    for saved_ring, rows, _ in snapshots:
+        saved_ring.buffer[rows] = -123
+    pool.restore_speculative(snapshots)
+
+    assert torch.equal(ring.buffer, original)
+    assert torch.equal(index_ring.buffer, original_index)
+
+
 # --------------------------------------------------------------------------- #
 # state_loc derivation
 # --------------------------------------------------------------------------- #

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -114,13 +114,13 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert glm52.performance.decode_tokens_per_second == pytest.approx(0.802)
     assert glm52.performance.warm_ttft_seconds == pytest.approx(2.57)
     deepseek = get_recipe("deepseek-v4")
-    assert deepseek.recipe_version == "0.2.0"
+    assert deepseek.recipe_version == "0.3.0"
     assert deepseek.revision == "7872f01b1d1fe23eabc4c98b48bffcef5a386062"
     assert deepseek.performance.decode_tokens_per_second == pytest.approx(
-        10.282266070445095
+        7.407656188456706
     )
     assert deepseek.performance.warm_ttft_seconds == pytest.approx(
-        0.6035212678834796
+        2.1198420680011623
     )
     assert deepseek.deployment.backend_options["moe_prefill_sparse_max_tokens"] == 512
     assert deepseek.deployment.backend_options["moe_cache_auto"] is True
@@ -189,7 +189,7 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert glm53.performance.warm_ttft_seconds == pytest.approx(2.530337787233293)
     assert glm53.evidence == ("GB10-GLM53-RESEARCH-001",)
     assert deepseek.source_bytes == 166878536440
-    assert deepseek.prepared_bytes == 157460918272
+    assert deepseek.prepared_bytes == 168424579072
     assert qwen.execution_policy == glm.execution_policy == "nvme-moe"
     assert qwen.minimum_free_bytes > qwen.source_bytes + qwen.prepared_bytes
     assert glm.minimum_free_bytes > glm.source_bytes + glm.prepared_bytes
@@ -199,26 +199,27 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert deepseek.minimum_free_bytes > deepseek.source_bytes + deepseek.prepared_bytes
 
 
-def test_deepseek_recipe_points_to_checked_in_optimized_evidence():
+def test_deepseek_recipe_points_to_checked_in_dspark_evidence():
     recipe = get_recipe("deepseek-v4")
-    assert recipe.evidence == ("GB10-DSV4-SPARSE-001",)
+    assert recipe.evidence == ("GB10-DSV4-DSPARK-002",)
     root = Path(__file__).resolve().parents[2]
     result = json.loads(
-        (root / "benchmarks/gb10/results/GB10-DSV4-SPARSE-001.json").read_text()
+        (root / "benchmarks/gb10/results/GB10-DSV4-DSPARK-002.json").read_text()
     )
     assert result["result_id"] == recipe.evidence[0]
     assert result["status"] == "measured"
-    assert result["recipe"]["recipe_version"] == recipe.recipe_version
-    assert result["recipe"]["revision"] == recipe.revision
-    assert result["metrics"]["decode_tokens_per_second"] == pytest.approx(
-        10.282266070445095
+    assert result["model"]["revision"] == recipe.revision
+    assert result["model"]["checkpoint_bytes"] == recipe.prepared_bytes
+    assert result["metrics"]["baseline_decode_tokens_per_second"] == pytest.approx(
+        7.407656188456706
     )
-    assert result["metrics"]["warm_ttft_seconds"] == pytest.approx(
-        0.6035212678834796
+    assert result["metrics"]["baseline_warm_ttft_seconds"] == pytest.approx(
+        2.1198420680011623
     )
-    assert result["metrics"]["expert_cache_miss_rate_percent"] == 0
-    assert result["metrics"]["physical_io_gib"] == 0
-    assert result["validation"]["output_hash"] == "fbf178b2bde5"
+    assert result["metrics"]["best_speculative_tokens"] == 1
+    assert result["metrics"]["best_speculative_speedup"] < 1
+    assert result["validation"]["all_runs_oom_count"] == 0
+    assert result["validation"]["baseline_output_hash_preserved"] is False
 
 
 def test_glm53_recipe_points_to_checked_in_fused_mhc_evidence():

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -52,7 +52,7 @@ def test_models_human_table_groups_tiers_and_shows_performance_metrics(capsys):
     assert "FAST — Routine chat, editing, and short agent loops" in output
     assert "FRONTIER — Hard coding, reasoning, and long agent work" in output
     assert "RESEARCH — Complete or novel models" in output
-    assert "10.28" in output and "0.604" in output
+    assert "7.41" in output and "2.120" in output
     assert "Qwen3.6 35B A3B" in output and "NVFP4" in output
     assert "35B total / 3B active" in output
     assert "Qwen3.6 35B A3B NVFP4" not in output

--- a/tests/sparklab/test_mtp_integration.py
+++ b/tests/sparklab/test_mtp_integration.py
@@ -69,3 +69,15 @@ def test_native_backend_compiles_speculative_token_option():
         "--speculative-tokens",
         "2",
     )
+
+
+def test_native_backend_compiles_dspark_options():
+    assert _compile_options({
+        "speculative_method": "dspark",
+        "speculative_tokens": 7,
+        "draft_sample_method": "probabilistic",
+    }) == (
+        "--speculative-method", "dspark",
+        "--speculative-tokens", "7",
+        "--draft-sample-method", "probabilistic",
+    )

--- a/tests/test_bench_decode_moe_speculative.py
+++ b/tests/test_bench_decode_moe_speculative.py
@@ -1,0 +1,41 @@
+import pytest
+
+from benchmarks.bench_decode_moe import (
+    parse_args,
+    parse_speculative_summary,
+    serve_cmd,
+)
+
+
+def test_decode_benchmark_forwards_speculative_options():
+    args = parse_args([
+        "--model", "/tmp/model",
+        "--speculative-method", "dspark",
+        "--speculative-tokens", "7",
+        "--draft-sample-method", "probabilistic",
+    ])
+
+    command = serve_cmd(args, "offload", 12345)
+
+    assert command[command.index("--speculative-method") + 1] == "dspark"
+    assert command[command.index("--speculative-tokens") + 1] == "7"
+    assert command[command.index("--draft-sample-method") + 1] == "probabilistic"
+
+
+def test_decode_benchmark_extracts_final_speculative_summary():
+    log = """
+MTP summary: steps=7, accepted=4/7 (57.1%), outputs=6, target_forwards=3, outputs/target=2.00
+MTP summary: steps=7, accepted=190/252 (75.4%), outputs=256, target_forwards=66, outputs/target=3.88
+"""
+
+    summary = parse_speculative_summary(log)
+
+    assert summary == {
+        "steps": 7,
+        "accepted": 190,
+        "drafted": 252,
+        "acceptance_rate": pytest.approx(0.754),
+        "outputs": 256,
+        "target_forwards": 66,
+        "outputs_per_target_forward": pytest.approx(3.88),
+    }


### PR DESCRIPTION
## Summary

- load the fused DeepSeek-V4-Flash-0731 DSpark weights and three draft MoE layers from FTW
- add transactional batch-one verification with greedy and exact probabilistic rejection sampling
- support 1-7 speculative tokens through serve, recipe, and benchmark CLIs
- preserve compressor/indexer state across unaligned multi-token verification and rollback
- publish the single-GB10 N=0/1/3/5/7 performance matrix and keep DSpark opt-in

## Benchmark

On one GB10 with disk-backed experts, target-only reached 7.41 tok/s. DSpark N=1/3/5/7 reached 7.07/6.19/5.97/5.16 tok/s, with no OOM or swap growth. This differs from the resident two-DGX-Spark deployment in the official vLLM recipe, so the recipe does not enable DSpark by default.

## Validation

- focused exact-branch suite: 79 passed
- installed primary checkout full suite: 1630 passed, 8 skipped
- real 167 GB fused checkpoint converted to 24-shard FTW and loaded successfully
- five 256-token GB10 runs completed without OOM

The temporary clean worktree cannot import the two locally built CUDA extension modules, so its broad GPU suite was not used as a correctness signal; repository CI remains authoritative for the clean branch.