### PR TITLE
feat(qwen36): add native MTP speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ a SparkLab support claim.
     <tr>
       <td><a href="https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW">Qwen3.6-35B-A3B</a></td>
       <td>35B total / 3B active</td>
-      <td>NVFP4 · FTW</td>
+      <td>NVFP4 · FTW + optional MTP3</td>
       <td>Certified</td>
       <td align="right">67.79</td>
       <td align="right">0.329</td>

--- a/benchmarks/frameworks/run_framework.py
+++ b/benchmarks/frameworks/run_framework.py
@@ -307,7 +307,7 @@ def main() -> None:
                 "--framework", args.framework, "--version", version,
                 "--weight-source", (
                     "oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW@cbbcf69f52b9815b8a987fe839003fae12aa8050" if args.framework in {"freetoken", "sparklab"} and args.model_family == "qwen38"
-                    else "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW@fecab7acfd0590d2b268d8fb9ea1c88431471111" if args.framework in {"freetoken", "sparklab"}
+                    else "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW@4826bc15c0f91ab9de7c57040bda36cfc57b3974" if args.framework in {"freetoken", "sparklab"}
                     else "ollama.com/library/qwen3.6:35b-a3b" if args.framework in {"ollama", "ollama-no-mtp"}
                     else "ollama.com/library/qwen3.6:35b-a3b (GGUF layer sha256:d372de8e9348...)" if args.framework in {"llama.cpp", "ktransformers"}
                     else "nvidia/Qwen3.6-35B-A3B-NVFP4"

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -17,6 +17,9 @@ recipes. Raw logs and large result streams stay outside the source repository.
   from 7.41 to 8.67 tok/s and DSpark N=1 from 7.07 to 8.27 tok/s.
 - `results/GB10-QWEN36-FAST-001.json` records the Qwen3.6 NVFP4 Fast
   performance probe.
+- `results/GB10-QWEN36-MTP-003.json` records the native BF16 MTP sweep. Three drafts
+  reproduced the target-only output hash and accepted 41/50 proposals, but measured only
+  8.57 tok/s versus the 52.63 tok/s control, so MTP remains experimental and opt-in.
 - `results/GB10-QWEN38-27B-001.json` records the dense Qwen3.8-27B ModelOpt
   NVFP4 result: 8.83 decode tok/s, 0.144 s warm TTFT, exact 64K recall, and
   passing reasoning, tool-call, and coding-agent probes.

--- a/benchmarks/gb10/results/GB10-QWEN36-MTP-003.json
+++ b/benchmarks/gb10/results/GB10-QWEN36-MTP-003.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN36-MTP-003",
+  "status": "measured",
+  "recipe": {
+    "slug": "qwen3.6-35b-a3b",
+    "recipe_version": "0.4.0",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "9a139fcfcbddf7e538d77e84c20e328215d2bfc2",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "repository": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+    "format": "ftw-nvfp4 + native BF16 MTP shard",
+    "quantization": "nvfp4 target + bf16 MTP",
+    "fingerprint": "bda7268c3e0afd7b",
+    "ftw_bytes": 22580867072,
+    "mtp_shard_bytes": 1689288704,
+    "mtp_payload_bytes": 1689281536
+  },
+  "workload": {
+    "single_stream": "greedy AIME25 problem 0, 54 prompt tokens, 64 completion tokens",
+    "client_path": "OpenAI-compatible streaming HTTP API",
+    "warmup_requests": 1,
+    "measured_trials": 1,
+    "prefix_reuse": "fresh prompt per measured server process"
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "expert_storage": "ram",
+    "expert_cache_rate": 1.0,
+    "attention_backend": "fi",
+    "cache_type": "hybrid_radix",
+    "page_size": 1,
+    "kv_tokens": 4096,
+    "max_running_requests": 1,
+    "cuda_graphs": false,
+    "selected_speculative_tokens": 0
+  },
+  "metrics": {
+    "target_only_decode_tokens_per_second": 52.625303258220434,
+    "mtp1_decode_tokens_per_second": 5.67721028648248,
+    "mtp2_decode_tokens_per_second": 7.019028706134907,
+    "mtp3_decode_tokens_per_second": 8.57093812836239,
+    "mtp1_relative_percent": -89.212,
+    "mtp2_relative_percent": -86.6623,
+    "mtp3_relative_percent": -83.7133,
+    "target_only_warm_ttft_seconds": 0.36497568897902966,
+    "mtp1_warm_ttft_seconds": 0.357016603986267,
+    "mtp2_warm_ttft_seconds": 0.36094987799879164,
+    "mtp3_warm_ttft_seconds": 0.36596807499881834,
+    "target_only_vram_gib": 20.44140625,
+    "mtp_vram_gib": 22.005859375,
+    "mtp1_accepted_drafts": "28/31 (90.3%)",
+    "mtp2_accepted_drafts": "35/42 (83.3%)",
+    "mtp3_accepted_drafts": "41/50 (82.0%)",
+    "mtp1_outputs_per_target_forward": 1.78,
+    "mtp2_outputs_per_target_forward": 2.21,
+    "mtp3_outputs_per_target_forward": 2.78
+  },
+  "validation": {
+    "checkpoint_checksum_verified": true,
+    "complete_checkpoint_loaded": true,
+    "native_mtp_weights_loaded": true,
+    "transactional_rejection_rollback": true,
+    "speculative_page_reclamation": true,
+    "target_only_output_sha1": "001f6b4d0dba",
+    "mtp1_output_sha1": "67c515109ea8",
+    "mtp2_output_sha1": "67c515109ea8",
+    "mtp3_output_sha1": "001f6b4d0dba",
+    "selected_width_matches_target_only": true,
+    "all_widths_match_target_only": false,
+    "api_stream_completed": true,
+    "oom_count": 0,
+    "service_restarts": 0
+  },
+  "admission": {
+    "tier": "fast",
+    "performance_gate_passed": false,
+    "passed": false,
+    "reasons": [
+      "The native MTP implementation loaded the complete upstream BF16 draft layer and width three reproduced the target-only greedy output hash.",
+      "Every measured MTP width was substantially slower than target-only NVFP4 decode on one GB10; width three reached 8.57 tok/s versus 52.63 tok/s.",
+      "MTP therefore remains an experimental opt-in path and does not replace the certified target-only recipe profile."
+    ]
+  },
+  "source": {
+    "target_only_artifact": "/tmp/qwen36-mtp-benchmark.jsonl row 0",
+    "mtp_sweep_artifact": "/tmp/qwen36-mtp-corrected-sweep.jsonl",
+    "prior_evidence": "GB10-QWEN36-FAST-002"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The sweep contains one measured trial per width and covers batch-one greedy generation only.",
+    "Widths one and two selected a different close greedy continuation from the multi-token verification path; only width three matched the controlled target-only hash.",
+    "The existing 32K context, capability, agent, and endurance gates were not rerun for this optional path."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -31,7 +31,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | Model | Parameter | Quantization | Recipe | Status | tok/s | TTFT(s) |
 |---|---|---|---|---|---:|---:|
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
-| [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
+| [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP3 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW | `qwen3.8-27b` | Experimental | 8.83 | 0.144 |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP2 | `qwen3.8-flash-next` | Experimental | 20.31 | 0.212 |
@@ -52,11 +52,15 @@ The Qwen3.8-Flash-Next row reports its selected two-draft MTP profile. It is opt
 `-- --speculative-tokens 2` and currently applies only to batch-one greedy requests;
 the default profile remains available for concurrent or sampled traffic.
 
+Qwen3.6's published FTW artifact includes its native BF16 MTP weights, but the portfolio
+row continues to report the certified target-only profile. The measured three-draft path
+was 83.7% slower on GB10 and remains experimental.
+
 ## Evidence and caveats
 
 | Model | Current result | Evidence |
 |---|---|---|
-| Qwen3.6-35B-A3B | Fast-certified, including exact 32K recall and a 60-minute zero-swap run. Certification is operational; its five-problem AIME sample scored 0/5 after reaching the output cap. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json) |
+| Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Native MTP3 is available but measured 8.57 tok/s versus its 52.63 tok/s control, so it remains opt-in. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json) |
 | Qwen3.8-27B | Passes Frontier speed, exact 64K recall, reasoning/tool parsing, and the coding-agent probe; the clean-revision 60-minute endurance gate remains outstanding. | [GB10-QWEN38-27B-001](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json) |
 | Qwen3.8-Flash-Next | The opt-in two-draft MTP profile measured 20.31 tok/s with exact eager-output parity; the default concurrent profile remains 16.84 single-stream tok/s. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-NVFP4-OPT-004](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json) |
 | DeepSeek V4 Flash | GPU-first expert residency reaches 8.67 tok/s. Native DSpark remains opt-in because N=1 still trails target-only decoding with disk-backed experts on one GB10. | [GB10-DSV4-RESIDENCY-003](../benchmarks/gb10/results/GB10-DSV4-RESIDENCY-003.json) |

--- a/docs/models/qwen3.6-35b-a3b.md
+++ b/docs/models/qwen3.6-35b-a3b.md
@@ -34,14 +34,38 @@ sparklab pull qwen3.6-35b-a3b --root /path/to/models --prepare
 `pull --prepare` downloads the immutable FTW revision from
 [`oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW`](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW)
 and validates its fingerprint before it can run. The artifact preserves the source NVFP4
-quantization; it does not requantize the model. Use `--from-source` only when you want to
-reproduce the FTW repack locally from NVIDIA's pinned source checkpoint.
+quantization and includes the upstream model's BF16 MTP layer as a fourth FTW shard; it
+does not requantize either component. Use `--from-source` only when you want to reproduce
+the complete FTW repack locally from NVIDIA's pinned source checkpoint.
 
 ## Run
 
 ```bash
 sparklab run qwen3.6-35b-a3b --root /path/to/models
 ```
+
+## Experimental speculative decoding
+
+SparkLab can load Qwen3.6's native MTP layer, verify its draft tokens with the target,
+and commit or roll back paged KV and GDN recurrent state at the accepted boundary. The
+[upstream vLLM profile](https://recipes.vllm.ai/Qwen/Qwen3.6-35B-A3B) uses three drafts:
+
+```bash
+sparklab run qwen3.6-35b-a3b --root /path/to/models -- \
+  --speculative-method mtp \
+  --speculative-tokens 3
+```
+
+This path is available for experimentation, not recommended for production on GB10. In
+a controlled 64-token greedy sweep, target-only decode reached 52.63 tok/s. Draft widths
+one, two, and three reached 5.68, 7.02, and 8.57 tok/s respectively. Width three accepted
+41/50 drafts and reduced the run to 23 target forwards, but the resident BF16 draft layer
+cost more than the saved NVFP4 target work. It was also the only measured width that
+reproduced the target-only output hash. Keep the default target-only recipe for normal
+chat and agent use. See [GB10-QWEN36-MTP-003](../../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json).
+
+MTP currently applies to one running greedy request. Sampled requests fall back to target
+decoding, and target verification runs eagerly.
 
 Wait for the API to listen on `127.0.0.1:1919`, then verify it:
 

--- a/python/sparklab/attention/base.py
+++ b/python/sparklab/attention/base.py
@@ -108,11 +108,15 @@ class HybridBackend(BaseAttnBackend):
         batch: Batch,
         attn_spec: AttentionSpec | None = None,
     ) -> torch.Tensor:
-        backend = self.prefill_backend if batch.is_prefill else self.decode_backend
+        backend = (
+            self.prefill_backend if batch.uses_prefill_kernels else self.decode_backend
+        )
         return backend.forward(q, k, v, layer_id, batch, attn_spec=attn_spec)
 
     def prepare_metadata(self, batch: Batch) -> None:
-        backend = self.prefill_backend if batch.is_prefill else self.decode_backend
+        backend = (
+            self.prefill_backend if batch.uses_prefill_kernels else self.decode_backend
+        )
         return backend.prepare_metadata(batch)
 
     def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:

--- a/python/sparklab/attention/fi.py
+++ b/python/sparklab/attention/fi.py
@@ -256,7 +256,15 @@ class FlashInferBackend(BaseAttnBackend):
             pos_encoding_mode="NONE",
             seq_lens_cpu=seq_len_cpu,
             dtype=self.kvcache.dtype,
-            wrapper=self.decode_wrappers if batch.is_decode else self.prefill_wrapper,
+            # Verification extends one request with anchor + draft tokens.  It is
+            # still part of the decode lifecycle, but FlashInfer must process it
+            # with the causal multi-token wrapper rather than the one-query decode
+            # wrapper.
+            wrapper=(
+                self.prefill_wrapper
+                if batch.uses_prefill_kernels
+                else self.decode_wrappers
+            ),
         )
 
     def reset_capture(self) -> None:

--- a/python/sparklab/attention/trtllm.py
+++ b/python/sparklab/attention/trtllm.py
@@ -67,7 +67,7 @@ class TensorRTLLMBackend(BaseAttnBackend):
         self.kvcache.store_kv(k, v, batch.out_loc, layer_id)
         kv_cache = (self.kvcache.k_cache(layer_id), self.kvcache.v_cache(layer_id))
 
-        if batch.is_prefill:
+        if batch.uses_prefill_kernels:
             return trtllm_batch_context_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,

--- a/python/sparklab/kernels/triton/nvfp4_linear.py
+++ b/python/sparklab/kernels/triton/nvfp4_linear.py
@@ -925,6 +925,14 @@ class Nvfp4LMHead(BaseOP):
         if batch.is_prefill:
             indices = batch.attn_metadata.get_last_indices(batch.size)
             x = x[indices].contiguous()
+        return self.forward_all(x)
+
+    def forward_all(self, x: torch.Tensor) -> torch.Tensor:
+        """Project exactly the supplied rows without prefill last-token slicing.
+
+        Native MTP already selects its one draft row while the surrounding
+        target-shaped batch can still be a multi-token prefill.
+        """
         if self._transposed:
             return nvfp4_dense_linear_t(x, self.weight, self.weight_scale, self.weight_global)
         return nvfp4_dense_linear(x, self.weight, self.weight_scale, self.weight_global)

--- a/python/sparklab/models/config.py
+++ b/python/sparklab/models/config.py
@@ -318,6 +318,10 @@ class ModelConfig:
     glm5_next_args: Any | None = None
     # Qwen4-Exp text-tower payload: QSA, Hyper-Connection and PLE geometry.
     qwen4_exp_args: Any | None = None
+    # Number of checkpoint-native Qwen3.5/3.6 MTP decoder layers. These draft
+    # weights are opt-in at runtime and stored separately in FTW so target-only
+    # serving does not allocate them.
+    mtp_num_hidden_layers: int = 0
     # Runtime speculative-decoding selection injected after parsing.
     speculative_method: str = "none"
     speculative_tokens: int = 0

--- a/python/sparklab/models/loader.py
+++ b/python/sparklab/models/loader.py
@@ -182,6 +182,10 @@ class ShardReader:
     def names_in(self, file: str) -> list[str]:
         return [name for name, shard in self._map.items() if shard == file]
 
+    def names(self) -> tuple[str, ...]:
+        """All indexed tensor names without opening any weight shard."""
+        return tuple(self._map)
+
     def get_tensor(self, name: str) -> torch.Tensor:
         import safetensors
 

--- a/python/sparklab/models/qwen3_5_moe/__init__.py
+++ b/python/sparklab/models/qwen3_5_moe/__init__.py
@@ -3,6 +3,7 @@ from .model import Qwen3_5MoEForCausalLM
 from .weight import (
     iter_weights,
     iter_weights_parallel,
+    iter_speculative_weights,
     load_nvfp4_expert_sources,
     load_nvfp4_expert_sources_parallel,
     setup_offload_expert_banks,
@@ -13,6 +14,7 @@ __all__ = [
     "parse_config",
     "iter_weights",
     "iter_weights_parallel",
+    "iter_speculative_weights",
     "load_nvfp4_expert_sources",
     "load_nvfp4_expert_sources_parallel",
     "setup_offload_expert_banks",

--- a/python/sparklab/models/qwen3_5_moe/config.py
+++ b/python/sparklab/models/qwen3_5_moe/config.py
@@ -273,6 +273,7 @@ def parse_config(hf_config: Any) -> ModelConfig:
         attn_quant=attn_quant,
         dense_quant=dense_quant,
         lm_head_quant=lm_head_quant,
+        mtp_num_hidden_layers=int(getattr(text, "mtp_num_hidden_layers", 0) or 0),
     )
 
 

--- a/python/sparklab/models/qwen3_5_moe/model.py
+++ b/python/sparklab/models/qwen3_5_moe/model.py
@@ -107,11 +107,90 @@ class Qwen3_5MoEForCausalLM(BaseLLMModel):
                 tie_word_embeddings=config.tie_word_embeddings,
                 tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
             )
+        self._mtp = None
+        self._mtp_steps = int(getattr(config, "speculative_tokens", 0) or 0)
+        if self._mtp_steps:
+            from .mtp import Qwen3_5MultiTokenPredictor
+
+            self._mtp = Qwen3_5MultiTokenPredictor(config)
+        self._mtp_target_hidden: torch.Tensor | None = None
         super().__init__()
 
     def forward(self) -> torch.Tensor:
         output = self.model.forward(get_global_ctx().batch.input_ids)
+        if self._mtp is not None:
+            self._mtp_target_hidden = output
         return self.lm_head.forward(output)
+
+    def speculative_state_dict(self):
+        return {} if self._mtp is None else self._mtp.state_dict()
+
+    def load_speculative_state_dict(self, state_dict) -> None:
+        if self._mtp is None:
+            if state_dict:
+                raise RuntimeError("received Qwen MTP weights while MTP is disabled")
+            return
+        self._mtp.load_state_dict(state_dict)
+
+    def propose_mtp(self, batch, next_token: torch.Tensor) -> torch.Tensor | None:
+        if self._mtp is None or self._mtp_target_hidden is None or batch.size != 1:
+            return None
+        from sparklab.core import Batch, Req
+
+        req = batch.reqs[0]
+        if not req.sampling_params.is_greedy:
+            return None
+        ctx = get_global_ctx()
+        project_logits = getattr(self.lm_head, "forward_all", self.lm_head.forward)
+        query = batch.input_ids
+        shifted = torch.cat((query[1:], next_token.reshape(1)))
+        original_input = batch.input_ids
+        batch.input_ids = shifted
+        try:
+            with ctx.forward_batch(batch):
+                feedback = self._mtp.forward(
+                    self.model.embed_tokens.forward(shifted), self._mtp_target_hidden
+                )
+                last = batch.attn_metadata.get_last_indices(1).to(torch.long)
+                feedback = feedback.index_select(0, last)
+                draft = torch.argmax(project_logits(feedback), dim=-1)
+        finally:
+            batch.input_ids = original_input
+
+        drafts = [draft.squeeze(0).to(torch.int32)]
+
+        steps = min(
+            self._mtp_steps, max(1, req.max_device_len - req.device_len)
+        )
+        for step in range(1, steps):
+            position = req.device_len + step - 1
+            draft_req = Req(
+                input_ids=torch.zeros(position + 1, dtype=req.input_ids.dtype),
+                table_idx=req.table_idx,
+                cached_len=position,
+                output_len=1,
+                uid=req.uid,
+                sampling_params=req.sampling_params,
+                cache_handle=req.cache_handle,
+            )
+            draft_req.linear_slot_idx = req.linear_slot_idx
+            draft_batch = Batch(reqs=[draft_req], phase="decode")
+            draft_batch.padded_reqs = draft_batch.reqs
+            draft_batch.input_ids = draft.reshape(1)
+            draft_batch.positions = torch.tensor(
+                [position], dtype=torch.int32, device=draft.device
+            )
+            draft_batch.out_loc = ctx.page_table[
+                draft_req.table_idx, position : position + 1
+            ]
+            ctx.attn_backend.prepare_metadata(draft_batch)
+            with ctx.forward_batch(draft_batch):
+                feedback = self._mtp.forward(
+                    self.model.embed_tokens.forward(draft_batch.input_ids), feedback
+                )
+                draft = torch.argmax(project_logits(feedback), dim=-1)
+            drafts.append(draft.squeeze(0).to(torch.int32))
+        return torch.stack(drafts)
 
 
 __all__ = ["Qwen3_5MoEForCausalLM"]

--- a/python/sparklab/models/qwen3_5_moe/mtp.py
+++ b/python/sparklab/models/qwen3_5_moe/mtp.py
@@ -1,0 +1,131 @@
+"""Checkpoint-native multi-token predictor for Qwen3.5/3.6.
+
+The NVIDIA Qwen3.6 NVFP4 checkpoint deliberately leaves the complete MTP head
+in BF16.  It is a projection over the shifted token embedding and target hidden
+state followed by one full-attention decoder layer.  The draft's small routed
+expert bank stays resident and is independent of the target offload cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import torch
+
+from sparklab.layers import (
+    BaseOP,
+    GemmaRMSNorm,
+    LinearColParallelMerged,
+    LinearReplicated,
+    LinearRowParallel,
+    MoELayer,
+    OPList,
+    silu_and_mul,
+)
+from sparklab.moe.fused import fused_topk
+
+from .attention import Qwen3_5Attention
+
+
+class _Bf16SharedExpert(BaseOP):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        self.gate_up_proj = LinearColParallelMerged(
+            hidden_size, [intermediate_size, intermediate_size], has_bias=False
+        )
+        self.down_proj = LinearRowParallel(
+            intermediate_size, hidden_size, has_bias=False
+        )
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        return self.down_proj.forward(silu_and_mul(self.gate_up_proj.forward(hidden)))
+
+
+class _ResidentBf16MTPMoE(BaseOP):
+    """One resident BF16 routed layer plus Qwen's gated shared expert."""
+
+    def __init__(self, config):
+        self.experts = MoELayer(
+            num_experts=config.num_experts,
+            top_k=config.num_experts_per_tok,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            renormalize=True,
+            weight_format="bf16",
+        )
+        self.gate = LinearReplicated(
+            config.hidden_size, config.num_experts, has_bias=False
+        )
+        self.shared_expert = _Bf16SharedExpert(
+            config.hidden_size, config.shared_expert_intermediate_size
+        )
+        self.shared_expert_gate = LinearReplicated(
+            config.hidden_size, 1, has_bias=False
+        )
+        self.top_k = config.num_experts_per_tok
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        router_logits = self.gate.forward(hidden)
+        # The resident grouped GEMM may reuse its input storage.
+        shared_input = hidden.clone()
+        shared = self.shared_expert.forward(shared_input)
+        shared.mul_(torch.sigmoid(self.shared_expert_gate.forward(shared_input)))
+        weights, ids = fused_topk(
+            hidden_states=hidden,
+            gating_output=router_logits,
+            topk=self.top_k,
+            renormalize=True,
+        )
+        return self.experts.routed_forward(hidden, weights, ids) + shared
+
+
+class _MTPDecoderLayer(BaseOP):
+    def __init__(self, config):
+        # All published MTP tensors are BF16, even when the target is NVFP4.
+        draft_config = replace(
+            config,
+            attn_quant="none",
+            dense_quant="none",
+            expert_quant="none",
+            shared_expert_quant="none",
+        )
+        self.self_attn = Qwen3_5Attention(draft_config, config.num_layers)
+        self.mlp = _ResidentBf16MTPMoE(draft_config)
+        self.input_layernorm = GemmaRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = GemmaRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        residual = hidden
+        hidden = self.input_layernorm.forward(hidden)
+        hidden = self.self_attn.forward(hidden)
+        hidden, residual = self.post_attention_layernorm.forward_add_residual(
+            hidden, residual
+        )
+        hidden = self.mlp.forward(hidden)
+        return hidden, residual
+
+
+class Qwen3_5MultiTokenPredictor(BaseOP):
+    def __init__(self, config):
+        h = config.hidden_size
+        self.fc = LinearReplicated(2 * h, h, has_bias=False)
+        self.layers = OPList([_MTPDecoderLayer(config)])
+        self.norm = GemmaRMSNorm(h, eps=config.rms_norm_eps)
+        self.pre_fc_norm_embedding = GemmaRMSNorm(h, eps=config.rms_norm_eps)
+        self.pre_fc_norm_hidden = GemmaRMSNorm(h, eps=config.rms_norm_eps)
+
+    def forward(
+        self, token_embeddings: torch.Tensor, target_hidden: torch.Tensor
+    ) -> torch.Tensor:
+        embed = self.pre_fc_norm_embedding.forward(token_embeddings)
+        hidden = self.pre_fc_norm_hidden.forward(target_hidden)
+        hidden = self.fc.forward(torch.cat((embed, hidden), dim=-1))
+        hidden, residual = self.layers.op_list[0].forward(hidden)
+        hidden, _ = self.norm.forward_add_residual(hidden, residual)
+        return hidden
+
+
+__all__ = ["Qwen3_5MultiTokenPredictor"]

--- a/python/sparklab/models/qwen3_5_moe/weight.py
+++ b/python/sparklab/models/qwen3_5_moe/weight.py
@@ -152,6 +152,84 @@ def _is_gemma_norm(name: str) -> bool:
     return name == "model.norm.weight" or name.endswith(_GEMMA_NORM_SUFFIXES)
 
 
+_MTP_FUSIONS: dict[str, tuple[str, ...]] = {
+    ".self_attn.qkv_proj.weight": (
+        ".self_attn.q_proj.weight",
+        ".self_attn.k_proj.weight",
+        ".self_attn.v_proj.weight",
+    ),
+    ".mlp.shared_expert.gate_up_proj.weight": (
+        ".mlp.shared_expert.gate_proj.weight",
+        ".mlp.shared_expert.up_proj.weight",
+    ),
+}
+
+
+def _is_mtp_gemma_norm(name: str) -> bool:
+    return name in {
+        "norm.weight",
+        "pre_fc_norm_embedding.weight",
+        "pre_fc_norm_hidden.weight",
+    } or name.endswith(
+        (
+            ".input_layernorm.weight",
+            ".post_attention_layernorm.weight",
+            ".self_attn.q_norm.weight",
+            ".self_attn.k_norm.weight",
+        )
+    )
+
+
+def iter_speculative_weights(
+    model_path: str, device: torch.device
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Stream the BF16 ``mtp.*`` head under draft-model state-dict names."""
+    reader = ShardReader(model_path, device)
+    pending: dict[str, dict[int, torch.Tensor]] = {}
+    try:
+        raw_names = sorted(name for name in reader.names() if name.startswith("mtp."))
+        for raw_name in raw_names:
+            name = raw_name.removeprefix("mtp.")
+            tensor = reader.get_tensor(raw_name)
+            fused = _try_fuse(name, tensor, pending)
+            # _try_fuse also knows target-only groups. MTP names can only match
+            # qkv, dense gate/up, or the shared-expert group below.
+            if fused is not None:
+                if fused:
+                    out_name, out = fused
+                    if _is_mtp_gemma_norm(out_name):
+                        out = out + 1.0
+                    yield out_name, out
+                continue
+            shared_fused = None
+            for out_suffix, parts in _MTP_FUSIONS.items():
+                if out_suffix == ".self_attn.qkv_proj.weight":
+                    continue  # already handled by _try_fuse
+                for index, suffix in enumerate(parts):
+                    if name.endswith(suffix):
+                        out_name = name[: -len(suffix)] + out_suffix
+                        slots = pending.setdefault(out_name, {})
+                        slots[index] = tensor
+                        if len(slots) == len(parts):
+                            del pending[out_name]
+                            yield out_name, torch.cat(
+                                [slots[i] for i in range(len(parts))], dim=0
+                            )
+                        shared_fused = True
+                        break
+                if shared_fused:
+                    break
+            if shared_fused:
+                continue
+            if _is_mtp_gemma_norm(name):
+                tensor = tensor + 1.0
+            yield name, tensor
+        if pending:
+            raise ValueError(f"incomplete Qwen MTP projection groups: {sorted(pending)}")
+    finally:
+        reader.close()
+
+
 def _try_fuse(
     name: str, tensor: torch.Tensor, buf: dict[str, dict[int, torch.Tensor]]
 ) -> tuple[str, torch.Tensor] | tuple[()] | None:

--- a/python/sparklab/models/qwen4_exp/model.py
+++ b/python/sparklab/models/qwen4_exp/model.py
@@ -179,12 +179,12 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
         draft = torch.argmax(F.linear(sample_hidden, head.weight, self.lm_head.bias), -1)
         drafts = [draft.squeeze(0).to(torch.int32)]
 
-        # A future physical page is not allocated until verification is
-        # scheduled. Stop at the current page boundary; MTP-1 is therefore
-        # always available, while MTP-2/3 shorten one step every 16 tokens.
-        page_size = ctx.page_size
-        page_end = ((req.device_len + page_size - 1) // page_size) * page_size
-        steps = min(self._mtp_steps, 1 + max(0, page_end - req.device_len))
+        # The scheduler reserves the configured lookahead before this forward,
+        # including with page_size=1, so every configured draft step has a
+        # physical KV row.
+        steps = min(
+            self._mtp_steps, max(1, req.max_device_len - req.device_len)
+        )
         for step in range(1, steps):
             position = req.device_len + step - 1
             draft_req = Req(

--- a/python/sparklab/recipes/qwen3.6-35b-a3b.json
+++ b/python/sparklab/recipes/qwen3.6-35b-a3b.json
@@ -1,17 +1,17 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.3.0",
+  "recipe_version": "0.4.0",
   "slug": "qwen3.6-35b-a3b",
   "name": "Qwen3.6 35B A3B",
   "model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
   "parameters": "35B total / 3B active",
   "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
   "source_bytes": 23450872529,
-  "prepared_bytes": 20916176722,
+  "prepared_bytes": 22605468940,
   "runtime_artifact": {
     "repo_id": "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW",
-    "revision": "fecab7acfd0590d2b268d8fb9ea1c88431471111",
-    "bytes": 20916176722,
+    "revision": "4826bc15c0f91ab9de7c57040bda36cfc57b3974",
+    "bytes": 22605468996,
     "fingerprint": "bda7268c3e0afd7b"
   },
   "intended_tier": "fast",
@@ -43,14 +43,16 @@
     "decode_tokens_per_second": 67.7870954092827,
     "warm_ttft_seconds": 0.32882933877408504,
     "evidence": "GB10-QWEN36-FAST-002",
-    "note": "The exact pinned FTW artifact passed the Fast gate with exact 32K recall, complete capability probes, bounded resident memory, and a zero-swap 60-minute endurance run."
+    "note": "The target-only profile passed the Fast gate with exact 32K recall, complete capability probes, bounded resident memory, and a zero-swap 60-minute endurance run. The artifact also includes an experimental native BF16 MTP shard; its measured GB10 profile is opt-in and slower than target-only decode."
   },
   "evidence": [
     "GB10-QWEN36-FAST-001",
-    "GB10-QWEN36-FAST-002"
+    "GB10-QWEN36-FAST-002",
+    "GB10-QWEN36-MTP-003"
   ],
   "limitations": [
     "The fixed five-problem AIME sample scored 0/5 because all five sampled runs exhausted the 2,048-token reasoning budget before emitting a final answer; Fast certification establishes serving correctness and operational behavior, not benchmark-quality certification.",
-    "Certification covers text inference at batch one on one NVIDIA GB10."
+    "Certification covers text inference at batch one on one NVIDIA GB10.",
+    "Native MTP is experimental: width three reproduced the controlled target-only output hash but measured 8.57 tok/s versus 52.63 tok/s without speculation; widths one and two did not reproduce that hash."
   ]
 }

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -280,7 +280,11 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
 
     model_config = config.model_config
     requested = str(getattr(config, "speculative_method", "auto") or "auto")
-    qwen_mtp = getattr(model_config, "qwen4_exp_args", None) is not None
+    qwen4_mtp = getattr(model_config, "qwen4_exp_args", None) is not None
+    qwen35_mtp = int(
+        getattr(model_config, "mtp_num_hidden_layers", 0) or 0
+    ) > 0
+    qwen_mtp = qwen4_mtp or qwen35_mtp
     dsv4_args = getattr(model_config, "dsv4_args", None)
     dsv4_dspark = bool(
         dsv4_args is not None
@@ -334,9 +338,11 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         return
 
     if method != "mtp" or not qwen_mtp:
-        raise ValueError("--speculative-method mtp currently supports Qwen4-Exp only")
+        raise ValueError(
+            "--speculative-method mtp requires a supported Qwen checkpoint-native MTP head"
+        )
     if speculative_tokens > 3:
-        raise ValueError("Qwen4 MTP supports at most 3 speculative tokens")
+        raise ValueError("Qwen MTP supports at most 3 speculative tokens")
     if getattr(config, "draft_sample_method", "greedy") != "greedy":
         raise ValueError("Qwen4 MTP currently supports greedy draft sampling only")
     # The draft layer owns an independent QSA KV/index slot at the first layer
@@ -347,18 +353,20 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
 
     mtp_layer_id = model_config.num_layers
     args = model_config.qwen4_exp_args
-    if mtp_layer_id not in args.qsa_layer_ids:
+    if args is not None and mtp_layer_id not in args.qsa_layer_ids:
         args = replace(args, qsa_layer_ids=(*args.qsa_layer_ids, mtp_layer_id))
     groups = []
     for group in model_config.attention_groups:
         if isinstance(group, FullAttentionGroupConfig) and mtp_layer_id not in group.layer_ids:
-            group = replace(
-                group,
-                layer_ids=(*group.layer_ids, mtp_layer_id),
-                num_index_layers=group.num_index_layers + 1,
-            )
+            changes = {"layer_ids": (*group.layer_ids, mtp_layer_id)}
+            # Qwen4's draft is QSA and owns an index slot. Qwen3.5/3.6 uses
+            # ordinary full attention, so only its KV layer is added.
+            if args is not None:
+                changes["num_index_layers"] = group.num_index_layers + 1
+            group = replace(group, **changes)
         groups.append(group)
-    object.__setattr__(model_config, "qwen4_exp_args", args)
+    if args is not None:
+        object.__setattr__(model_config, "qwen4_exp_args", args)
     object.__setattr__(model_config, "attention_groups", tuple(groups))
     object.__setattr__(model_config, "speculative_method", "mtp")
     object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
@@ -1279,8 +1287,15 @@ class Engine:
         proposer = getattr(self.model, "propose_mtp", None)
         if proposer is None:
             return None
-        with self.ctx.forward_batch(batch):
-            return proposer(batch, next_tokens)
+        # DSpark's fused proposal consumes the active target batch directly.
+        # Qwen MTP switches between the target-shaped first step and synthetic
+        # one-token draft batches, so its model adapter owns those context
+        # manager scopes itself (nesting forward_batch is forbidden).
+        method = getattr(getattr(self, "config", None), "speculative_method", "dspark")
+        if method == "dspark":
+            with self.ctx.forward_batch(batch):
+                return proposer(batch, next_tokens)
+        return proposer(batch, next_tokens)
 
     def _replay_verified_prefix(self, batch: Batch, length: int, start: int) -> None:
         """Rebuild stateful target/draft cache after a partial rejection."""

--- a/python/sparklab/runtime/kvcache/__init__.py
+++ b/python/sparklab/runtime/kvcache/__init__.py
@@ -207,7 +207,13 @@ def create_kvcache_pool(
         num_kv_heads=num_kv_heads,
         num_pages=num_pages,
         page_size=page_size,
-        num_layers=model_config.num_layers,
+        # A checkpoint-native draft may own the first logical KV id after the
+        # target tower. Keep target num_layers unchanged for model construction,
+        # but size the global-id map from the declared cache group.
+        num_layers=max(
+            model_config.num_layers,
+            max((layer for spec in kv_specs for layer in spec.layer_ids), default=-1) + 1,
+        ),
         head_dim=head_dim,
         device=device,
         dtype=dtype,

--- a/python/sparklab/runtime/scheduler/cache.py
+++ b/python/sparklab/runtime/scheduler/cache.py
@@ -396,6 +396,10 @@ class CacheManager:
                 self.unlock(old_handle)
                 self._free(page_indices[free_upto : max(free_upto, prefix_len)])
                 keep_live = not mamba_exist           # tree now owns linear_slot_idx
+                # Speculative proposal can reserve physical rows beyond the
+                # accepted final boundary. The tree owns through cached_len;
+                # return the page-aligned lookahead tail explicitly.
+                self._free(self._padded_tail(req, req.cached_len))
             else:
                 self.unlock(old_handle)
                 self._free(page_indices[free_upto :])

--- a/python/sparklab/runtime/scheduler/scheduler.py
+++ b/python/sparklab/runtime/scheduler/scheduler.py
@@ -822,7 +822,27 @@ class Scheduler(SchedulerIOMixin):
             self.cache_manager.free_swa_out_of_window_extend(batch.reqs)
         # Polymorphic page allocation: DSV4 allocates window pages + cmp/idx blocks into its
         # slot maps; the generic manager allocates KV pages into the page table.
-        self.cache_manager.allocate_paged(batch.reqs)
+        # Native MTP writes its own KV while proposing the next draft block,
+        # after this target forward has returned. Reserve those physical rows
+        # now; verification will fill the corresponding token_pool entries on
+        # the next scheduler iteration. This is required for page_size=1 and
+        # also removes page-boundary-dependent draft widths.
+        lookahead = (
+            int(getattr(self.config, "speculative_tokens", 0) or 0)
+            if getattr(self.config, "speculative_method", "none") == "mtp"
+            else 0
+        )
+        if lookahead:
+            actual_lens = [req.device_len for req in batch.reqs]
+            for req in batch.reqs:
+                req.device_len = min(req.max_device_len, req.device_len + lookahead)
+            try:
+                self.cache_manager.allocate_paged(batch.reqs)
+            finally:
+                for req, actual in zip(batch.reqs, actual_lens):
+                    req.device_len = actual
+        else:
+            self.cache_manager.allocate_paged(batch.reqs)
         if batch.is_prefill:
             self._gather_multimodal(batch)
         batch.positions = _make_positions(batch, self.device)

--- a/tests/models/test_qwen3_5_mtp.py
+++ b/tests/models/test_qwen3_5_mtp.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+
+from sparklab.models.qwen3_5_moe.config import parse_config
+from sparklab.models.qwen3_5_moe.weight import iter_speculative_weights
+
+
+def _config(*, mtp_layers: int = 1):
+    text = SimpleNamespace(
+        num_hidden_layers=8,
+        layer_types=[
+            "linear_attention", "linear_attention", "linear_attention", "full_attention",
+            "linear_attention", "linear_attention", "linear_attention", "full_attention",
+        ],
+        hidden_size=64,
+        vocab_size=256,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=16,
+        max_position_embeddings=4096,
+        rope_parameters={"rope_type": "default", "rope_theta": 10000.0},
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+        tie_word_embeddings=False,
+        num_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        norm_topk_prob=True,
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=4,
+        mtp_num_hidden_layers=mtp_layers,
+    )
+    return SimpleNamespace(
+        model_type="qwen3_5_moe",
+        architectures=["Qwen3_5MoeForConditionalGeneration"],
+        text_config=text,
+    )
+
+
+def test_config_declares_native_mtp_and_engine_adds_full_kv_slot():
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+
+    model_config = parse_config(_config())
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="auto",
+        speculative_tokens=3,
+        draft_sample_method="greedy",
+        max_running_req=8,
+        cache_type="naive",
+        cuda_graph_bs=[1, 2, 4],
+        cuda_graph_max_bs=4,
+    )
+
+    def override(name, value):
+        setattr(config, name, value)
+
+    _adjust_speculative_config(config, override)
+    _adjust_speculative_config(config, override)
+
+    assert model_config.mtp_num_hidden_layers == 1
+    assert model_config.speculative_method == "mtp"
+    full = next(group for group in model_config.attention_groups if group.name == "full")
+    assert full.layer_ids.count(model_config.num_layers) == 1
+    assert full.num_index_layers == 0
+    assert config.max_running_req == 1
+    assert config.cache_type == "radix"
+    assert config.cuda_graph_bs == [] and config.cuda_graph_max_bs == 0
+
+    from sparklab.runtime.kvcache import create_kvcache_pool
+    from sparklab.runtime.distributed import set_tp_info, try_get_tp_info
+
+    if try_get_tp_info() is None:
+        set_tp_info(rank=0, size=1)
+
+    pool = create_kvcache_pool(
+        model_config=model_config,
+        num_pages=2,
+        page_size=1,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+    assert len(pool._layer_map) == model_config.num_layers + 1
+    assert pool._layer_map[model_config.num_layers] >= 0
+
+
+def test_speculative_weight_iterator_fuses_projections_and_bakes_norm(tmp_path):
+    h, q, kv, i, experts = 4, 8, 2, 3, 2
+    tensors = {
+        "mtp.fc.weight": torch.arange(h * 2 * h, dtype=torch.bfloat16).view(h, 2 * h),
+        "mtp.pre_fc_norm_hidden.weight": torch.zeros(h, dtype=torch.bfloat16),
+        "mtp.layers.0.self_attn.q_proj.weight": torch.full((q, h), 1, dtype=torch.bfloat16),
+        "mtp.layers.0.self_attn.k_proj.weight": torch.full((kv, h), 2, dtype=torch.bfloat16),
+        "mtp.layers.0.self_attn.v_proj.weight": torch.full((kv, h), 3, dtype=torch.bfloat16),
+        "mtp.layers.0.mlp.shared_expert.gate_proj.weight": torch.full(
+            (i, h), 4, dtype=torch.bfloat16
+        ),
+        "mtp.layers.0.mlp.shared_expert.up_proj.weight": torch.full(
+            (i, h), 5, dtype=torch.bfloat16
+        ),
+        "mtp.layers.0.mlp.experts.gate_up_proj": torch.zeros(
+            experts, 2 * i, h, dtype=torch.bfloat16
+        ),
+    }
+    save_file(tensors, tmp_path / "model.safetensors")
+
+    loaded = dict(iter_speculative_weights(str(tmp_path), torch.device("cpu")))
+
+    assert loaded["layers.0.self_attn.qkv_proj.weight"].shape == (q + 2 * kv, h)
+    assert loaded["layers.0.self_attn.qkv_proj.weight"][:, 0].tolist() == (
+        [1] * q + [2] * kv + [3] * kv
+    )
+    assert loaded["layers.0.mlp.shared_expert.gate_up_proj.weight"].shape == (2 * i, h)
+    torch.testing.assert_close(
+        loaded["pre_fc_norm_hidden.weight"], torch.ones(h, dtype=torch.bfloat16)
+    )
+    assert "layers.0.mlp.experts.gate_up_proj" in loaded

--- a/tests/runtime/engine/test_speculative_attention_routing.py
+++ b/tests/runtime/engine/test_speculative_attention_routing.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import torch
+
+from sparklab.attention.base import HybridBackend
+from sparklab.core import Batch
+
+
+class _RecordingBackend:
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+
+    def forward(self, *args, **kwargs):
+        self.calls.append(("forward", args, kwargs))
+        return self.name
+
+    def prepare_metadata(self, batch):
+        self.calls.append(("prepare", batch))
+        return self.name
+
+
+def _batch(phase):
+    batch = Batch(reqs=[SimpleNamespace()], phase=phase)
+    batch.padded_reqs = batch.reqs
+    return batch
+
+
+def test_hybrid_attention_routes_verification_through_multitoken_backend():
+    prefill = _RecordingBackend("prefill")
+    decode = _RecordingBackend("decode")
+    backend = HybridBackend(prefill, decode)
+    batch = _batch("verify")
+
+    assert backend.prepare_metadata(batch) == "prefill"
+    assert backend.forward(
+        torch.empty(0), torch.empty(0), torch.empty(0), 0, batch
+    ) == "prefill"
+    assert [call[0] for call in prefill.calls] == ["prepare", "forward"]
+    assert decode.calls == []
+
+
+def test_hybrid_attention_keeps_single_token_decode_on_decode_backend():
+    prefill = _RecordingBackend("prefill")
+    decode = _RecordingBackend("decode")
+    backend = HybridBackend(prefill, decode)
+    batch = _batch("decode")
+
+    assert backend.prepare_metadata(batch) == "decode"
+    assert backend.forward(
+        torch.empty(0), torch.empty(0), torch.empty(0), 0, batch
+    ) == "decode"
+    assert prefill.calls == []
+    assert [call[0] for call in decode.calls] == ["prepare", "forward"]

--- a/tests/runtime/scheduler/test_hybrid_cache_manager.py
+++ b/tests/runtime/scheduler/test_hybrid_cache_manager.py
@@ -110,6 +110,38 @@ def test_hybrid_finish_skips_overadvanced_speculative_state():
     cm.check_integrity()
 
 
+def test_hybrid_finish_reclaims_speculative_lookahead_tail():
+    pool = _pool()
+    page_table = torch.zeros(4, 64, dtype=torch.int32)
+    cm = CacheManager(64, 1, page_table, "hybrid_radix", linear_state_pool=pool)
+    pending = _pend([7, 8, 9, 10, 11])
+    mr = cm.match_req(pending)
+    live, pp = pool.alloc(1)[0], tuple(pool.alloc(2))
+    req = Req(
+        input_ids=pending.input_ids,
+        table_idx=1,
+        cached_len=0,
+        output_len=4,
+        uid=1,
+        sampling_params=SamplingParams(),
+        cache_handle=mr.cuda_handle,
+    )
+    req.linear_slot_idx, req.mamba_ping_pong = live, pp
+    cm.lock(mr.cuda_handle)
+    cm.allocate_paged([req])
+    actual = req.device_len
+    req.device_len += 1
+    cm.allocate_paged([req])
+    req.device_len = actual
+    assert req.allocated_len == 6
+    req.cached_len = 4
+
+    cm.cache_req(req, finished=True)
+
+    assert cm.match_req(pending).cuda_handle.cached_len == 4
+    cm.check_integrity()
+
+
 def test_free_req_slots_idempotent():
     """C2: a finish/abort double-free of the same request must NOT push its GDN slots twice."""
     pool = _pool()

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -129,14 +129,20 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert deepseek.deployment.backend_options["moe_host_cache_gb"] == 0
     assert deepseek.deployment.backend_options["moe_prefill_overlap"] is False
     qwen36 = get_recipe("qwen3.6-35b-a3b")
+    assert qwen36.recipe_version == "0.4.0"
     assert qwen36.status == "certified"
     assert qwen36.runtime_memory == {"total_bytes": 34359738368}
     assert qwen36.performance.decode_tokens_per_second == pytest.approx(67.7870954092827)
     assert qwen36.performance.warm_ttft_seconds == pytest.approx(0.32882933877408504)
-    assert qwen36.evidence == ("GB10-QWEN36-FAST-001", "GB10-QWEN36-FAST-002")
+    assert qwen36.evidence == (
+        "GB10-QWEN36-FAST-001",
+        "GB10-QWEN36-FAST-002",
+        "GB10-QWEN36-MTP-003",
+    )
     assert qwen36.runtime_artifact is not None
     assert qwen36.runtime_artifact.repo_id == "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW"
-    assert qwen36.runtime_artifact.revision == "fecab7acfd0590d2b268d8fb9ea1c88431471111"
+    assert qwen36.runtime_artifact.revision == "4826bc15c0f91ab9de7c57040bda36cfc57b3974"
+    assert qwen36.runtime_artifact.bytes == 22605468996
     assert qwen36.runtime_artifact.fingerprint == "bda7268c3e0afd7b"
     primary = select_recipes(load_catalog(), portfolio_role="primary")
     assert {(item.intended_tier, item.slug) for item in primary} == {

--- a/tests/sparklab/test_planner.py
+++ b/tests/sparklab/test_planner.py
@@ -125,7 +125,7 @@ def test_qwen36_prepare_uses_pinned_prebuilt_runtime(tmp_path, monkeypatch):
 
     assert recipe.runtime_artifact is not None
     assert recipe.runtime_artifact.repo_id == "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW"
-    assert recipe.runtime_artifact.revision == "fecab7acfd0590d2b268d8fb9ea1c88431471111"
+    assert recipe.runtime_artifact.revision == "4826bc15c0f91ab9de7c57040bda36cfc57b3974"
     assert plan.acquisition == "prebuilt-runtime"
     assert plan.ready is True
 


### PR DESCRIPTION
## Summary
- load and execute Qwen3.6's checkpoint-native BF16 MTP layer from safetensors or FTW
- add transactional hybrid-cache verification, lookahead allocation, and multi-token attention routing
- publish and pin the four-shard FTW artifact at Hugging Face revision 4826bc15c0f91ab9de7c57040bda36cfc57b3974
- document the GB10 width sweep and keep MTP experimental/opt-in

## GB10 result
- target only: 52.63 tok/s
- MTP-1: 5.68 tok/s, 28/31 accepted
- MTP-2: 7.02 tok/s, 35/42 accepted
- MTP-3: 8.57 tok/s, 41/50 accepted, target-only output hash preserved

The BF16 draft head costs more than the saved NVFP4 target forwards on GB10, so the certified target-only profile remains the default.

## Validation
- 1333 passed, 197 skipped
- real four-shard FTW validation: 1071 tensors, 16 speculative weights
- real OpenAI-compatible streaming benchmark on NVIDIA GB10

Signed-off-by: lidaiqing <lidaiqing2016@gmail.com>