### PR TITLE
perf: optimize Qwen speculative inference paths

### DIFF
--- a/benchmarks/bench_decode_moe.py
+++ b/benchmarks/bench_decode_moe.py
@@ -474,6 +474,30 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="draft sampling and target verification rule",
     )
     p.add_argument(
+        "--dspark-confidence-threshold", type=float, default=0.0,
+        help="DSpark confidence probability floor; 0 keeps fixed-width verification",
+    )
+    p.add_argument(
+        "--dspark-draft-cache-slots", type=int, default=0,
+        help="aggregate layer-LRU quota for the three DSpark draft layers",
+    )
+    p.add_argument(
+        "--dspark-draft-cache-quotas", default="",
+        help="comma-separated exact per-draft-layer layer-LRU quotas",
+    )
+    p.add_argument(
+        "--dsv4-kv-storage", choices=("bf16", "fp8"), default="bf16",
+        help="physical DSV4 window/compressed KV storage",
+    )
+    p.add_argument(
+        "--dsv4-index-storage", choices=("bf16", "fp4"), default="bf16",
+        help="physical DSV4 Lightning-Indexer key storage",
+    )
+    p.add_argument(
+        "--qwen4-dense-storage", choices=("bf16", "fp8"), default="bf16",
+        help="physical Qwen4-Exp resident projection storage",
+    )
+    p.add_argument(
         "--disable-prefill-overlap", action="store_true",
         help="disable the two-layer prefill staging reservation (permits a one-layer cache)",
     )
@@ -619,6 +643,12 @@ def serve_cmd(args: argparse.Namespace, backend: str, port: int) -> list[str]:
         "--speculative-method", args.speculative_method,
         "--speculative-tokens", str(args.speculative_tokens),
         "--draft-sample-method", args.draft_sample_method,
+        "--dspark-confidence-threshold", str(args.dspark_confidence_threshold),
+        "--dspark-draft-cache-slots", str(args.dspark_draft_cache_slots),
+        "--dspark-draft-cache-quotas", args.dspark_draft_cache_quotas,
+        "--dsv4-kv-storage", args.dsv4_kv_storage,
+        "--dsv4-index-storage", args.dsv4_index_storage,
+        "--qwen4-dense-storage", args.qwen4_dense_storage,
     ]
     if args.num_tokens > 0:
         cmd += ["--num-tokens", str(args.num_tokens)]
@@ -670,13 +700,15 @@ def parse_speculative_summary(log_text: str) -> dict | None:
     """Extract the final measured request's native speculative counters."""
     matches = re.findall(
         r"MTP summary: steps=(\d+), accepted=(\d+)/(\d+) \(([\d.]+)%\), "
-        r"outputs=(\d+), target_forwards=(\d+), outputs/target=([\d.]+)",
+        r"outputs=(\d+), target_forwards=(\d+), outputs/target=([\d.]+)"
+        r"(?:, replays=(\d+)/(\d+), fast_commits=(\d+))?",
         log_text,
     )
     if not matches:
         return None
-    steps, accepted, drafted, rate, outputs, forwards, efficiency = matches[-1]
-    return {
+    (steps, accepted, drafted, rate, outputs, forwards, efficiency,
+     replay_calls, replay_tokens, fast_commits) = matches[-1]
+    result = {
         "steps": int(steps),
         "accepted": int(accepted),
         "drafted": int(drafted),
@@ -685,6 +717,19 @@ def parse_speculative_summary(log_text: str) -> dict | None:
         "target_forwards": int(forwards),
         "outputs_per_target_forward": float(efficiency),
     }
+    if replay_calls:
+        result.update({
+            "replay_calls": int(replay_calls),
+            "replay_tokens": int(replay_tokens),
+            "fast_carry_commits": int(fast_commits),
+        })
+    stats_matches = re.findall(r"DSpark stats: (\{[^\n]+\})", log_text)
+    if stats_matches:
+        try:
+            result.update(json.loads(stats_matches[-1]))
+        except json.JSONDecodeError:
+            pass
+    return result
 
 
 def wait_ready(origin: str, proc: subprocess.Popen, log_path: str, timeout: float) -> None:
@@ -931,6 +976,12 @@ def run_one(args: argparse.Namespace, backend: str) -> dict:
             "speculative_method": args.speculative_method,
             "speculative_tokens": args.speculative_tokens,
             "draft_sample_method": args.draft_sample_method,
+            "dspark_confidence_threshold": args.dspark_confidence_threshold,
+            "dspark_draft_cache_slots": args.dspark_draft_cache_slots,
+            "dspark_draft_cache_quotas": args.dspark_draft_cache_quotas,
+            "dsv4_kv_storage": args.dsv4_kv_storage,
+            "dsv4_index_storage": args.dsv4_index_storage,
+            "qwen4_dense_storage": args.qwen4_dense_storage,
             "cpu_threads": args.cpu_threads,
             "hybrid_fetch": args.hybrid_fetch,
             "disk_read_workers": int(os.getenv("SPARKLAB_DISK_READ_WORKERS", "16")),
@@ -1005,6 +1056,31 @@ def run_one(args: argparse.Namespace, backend: str) -> dict:
             "fetched_per_layer": fetched / calls if calls else 0.0,
             "fetch_rate": fetched / missing if missing else 0.0,
         }
+        before_layers = {item["layer"]: item for item in before_moe.get("per_layer", [])}
+        per_layer = []
+        for item in after_moe.get("per_layer", []):
+            prior = before_layers.get(item["layer"], {})
+            steps = item.get("steps", 0) - prior.get("steps", 0)
+            active = item.get("active", 0) - prior.get("active", 0)
+            missing = item.get("missing", 0) - prior.get("missing", 0)
+            fetched_layer = item.get("fetched", 0) - prior.get("fetched", 0)
+            per_layer.append({
+                "layer": item["layer"],
+                "steps": steps,
+                "active": active,
+                "missing": missing,
+                "fetched": fetched_layer,
+                "active_per_step": active / steps if steps else 0.0,
+                "missing_per_step": missing / steps if steps else 0.0,
+                "miss_rate": missing / active if active else 0.0,
+                "fetched_per_step": fetched_layer / steps if steps else 0.0,
+            })
+        if per_layer:
+            row["moe"]["per_layer"] = per_layer
+        if after_moe.get("routing"):
+            # Routing concentration is a whole-session profile (warmup + measured
+            # request); label it rather than pretending the aggregate is subtractable.
+            row["moe"]["routing_session"] = after_moe["routing"]
         before_disk = before_moe.get("disk") or {}
         after_disk = after_moe.get("disk") or {}
         if after_disk:

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -27,7 +27,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
   performance probe.
 - `results/GB10-QWEN36-MTP-003.json` records the native BF16 MTP sweep. Three drafts
   reproduced the target-only output hash and accepted 41/50 proposals, but measured only
-  8.57 tok/s versus the 52.63 tok/s control, so MTP remains experimental and opt-in.
+  8.57 tok/s versus the 52.63 tok/s control before short-batch kernel optimization.
+- `results/GB10-QWEN36-MTP-004.json` records the optimized native MTP path. Width two
+  reached 74.42 tok/s versus its matched 45.38 tok/s eager control on the 256-token
+  Triton-attention probe, a 64.0% gain and 10.60x the prior width-two implementation.
 - `results/GB10-QWEN38-27B-001.json` records the dense Qwen3.8-27B ModelOpt
   NVFP4 result: 8.83 decode tok/s, 0.144 s warm TTFT, exact 64K recall, and
   passing reasoning, tool-call, and coding-agent probes.

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -4,6 +4,14 @@ This directory contains compact, reviewable summaries for SparkLab model
 recipes. Raw logs and large result streams stay outside the source repository.
 
 - `result.schema.json` defines the versioned summary contract.
+- `results/GB10-QWEN38-FP8-PLE-005.json` measures NVFP4 routed experts with a
+  50%-smaller FP8 external PLE table.
+- `results/GB10-QWEN38-HYBRID-006.json` adds physical FP8 resident projections:
+  22.16 tok/s, 3.36 GiB lower server VRAM, exact 128-token output parity, and a
+  passing 4096-token-cap W1 smoke gate.
+- `results/GB10-DSV4-ADAPTIVE-004.json` records confidence-adaptive DSpark,
+  replay-free first-draft rejection commits, residency profiling, true FP8
+  window/compressed KV, and packed FP4 Lightning-Indexer storage.
 - `results/GB10-BASELINE-001.json` records the measured DeepSeek V4 launch baseline.
 - `results/GB10-DSV4-SPARSE-001.json` records the optimized DeepSeek V4 route-first
   sparse-prefill probe: 10.28 decode tok/s and 0.604 s warm TTFT, with the baseline

--- a/benchmarks/gb10/build_qwen38_hybrid.py
+++ b/benchmarks/gb10/build_qwen38_hybrid.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Build a hard-linked Qwen3.8 NVFP4 + FP8-PLE FTW artifact.
+
+The routed experts and resident tensors remain byte-identical to the source FTW.
+Only the external BF16 PLE table is streamed through an E4M3 cast. Both paths must
+live on the same filesystem so the roughly 78 GB of FTW shards can be hard-linked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+
+from sparklab.models.qwen4_exp.weight import requantize_raw_ngram_artifact
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True, help="source Qwen3.8 FTW")
+    parser.add_argument("--output", type=Path, required=True, help="new hybrid FTW path")
+    parser.add_argument("--chunk-rows", type=int, default=65_536)
+    return parser.parse_args()
+
+
+def _link_tree(source: Path, destination: Path) -> None:
+    destination.mkdir()
+    for entry in source.iterdir():
+        if entry.name in {"qwen4_ngram.bin", "qwen4_ngram.json", "freetoken_weight.json"}:
+            continue
+        target = destination / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, target, copy_function=os.link)
+        elif entry.is_file():
+            os.link(entry, target)
+
+
+def main() -> int:
+    args = _args()
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    if not (source / "freetoken_weight.json").is_file():
+        raise SystemExit(f"not an FTW checkpoint: {source}")
+    if output.exists():
+        raise SystemExit(f"output already exists: {output}")
+    if source.stat().st_dev != output.parent.stat().st_dev:
+        raise SystemExit("source and output must be on the same filesystem for hard links")
+
+    building = output.with_name(f".{output.name}.building-{os.getpid()}")
+    try:
+        _link_tree(source, building)
+        ple = requantize_raw_ngram_artifact(
+            str(source), str(building), chunk_rows=args.chunk_rows
+        )
+        index = json.loads((source / "freetoken_weight.json").read_text(encoding="utf-8"))
+        artifacts = [
+            artifact for artifact in index.get("external_artifacts", [])
+            if artifact.get("kind") != "qwen4_ngram"
+        ]
+        artifacts.append({"kind": "qwen4_ngram", **ple})
+        index["external_artifacts"] = artifacts
+        index["derived_from_fingerprint"] = index.get("fingerprint")
+        index["artifact_variant"] = "nvfp4-experts-fp8-ple"
+        index_path = building / "freetoken_weight.json"
+        index_path.write_text(
+            json.dumps(index, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+        )
+        os.rename(building, output)
+    except BaseException:
+        # Keep an interrupted 51 GB conversion available for diagnosis; its hidden,
+        # PID-qualified name cannot be mistaken for a runnable artifact.
+        if building.exists():
+            print(f"incomplete build retained at {building}")
+        raise
+
+    print(json.dumps({
+        "output": str(output),
+        "variant": "nvfp4-experts-fp8-ple",
+        "ple_dtype": ple["dtype"],
+        "ple_bytes": ple["nbytes"],
+        "hardlinked_ftw_bytes": index["total_bytes"],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/gb10/results/GB10-DSV4-ADAPTIVE-004.json
+++ b/benchmarks/gb10/results/GB10-DSV4-ADAPTIVE-004.json
@@ -21,5 +21,5 @@
   },
   "validation": {"target_reasoning_answer": 70, "dspark_n1_reasoning_answer": 70, "fp8_kv_end_to_end_smoke": true, "packed_fp4_indexer_end_to_end_smoke": true, "packed_cache_output_hash": "16207e79597e", "quality_gate_run": false, "packed_fp4_indexer_implemented": true},
   "conclusion": "N=1 crosses break-even after safe first-draft-rejection carry commits. Confidence threshold 0.5 is promising. Exact draft quotas reduce I/O but not throughput. True FP8 window/compressed KV and packed FP4 indexer storage preserve the short-run target hash and save progressively more cache memory at long context.",
-  "source": {"raw_artifacts": "/home/lidaiqing/results/dsv4-dspark-adaptive/"}
+  "source": {"raw_artifacts": "$HOME/results/dsv4-dspark-adaptive/"}
 }

--- a/benchmarks/gb10/results/GB10-DSV4-ADAPTIVE-004.json
+++ b/benchmarks/gb10/results/GB10-DSV4-ADAPTIVE-004.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.0", "result_id": "GB10-DSV4-ADAPTIVE-004",
+  "status": "measured", "date": "2026-09-02",
+  "platform": {"device": "NVIDIA GB10", "memory_gib": 128, "cuda": "13.0"},
+  "model": {"repository": "deepseek-ai/DeepSeek-V4-Flash-0731", "checkpoint_format": "ftw-ds-fp4", "target_layers": 43, "draft_layers": 3},
+  "workload": {"name": "AIME-25 problem 0", "batch_size": 1, "sampling": "greedy", "expert_cache_slots": 5250, "cuda_graph": false},
+  "metrics": {
+    "target_256_tok_s": 7.8509, "dspark_n1_fast_commit_256_tok_s": 8.4993,
+    "dspark_n1_relative_to_target_percent": 8.26,
+    "dspark_n1_accepted": 87, "dspark_n1_drafted": 127,
+    "dspark_n1_fast_carry_commits": 40, "dspark_n1_replay_calls": 0,
+    "fixed_n5_128_tok_s": 7.3877, "adaptive_n5_threshold_0_5_128_tok_s": 8.6663,
+    "adaptive_n5_speedup_percent": 17.31, "adaptive_n5_acceptance": 0.713,
+    "fp8_kv_smoke_32_tok_s": 10.5587,
+    "fp4_index_smoke_32_tok_s": 10.4940,
+    "fp8_kv_fp4_index_smoke_32_tok_s": 10.5632,
+    "bf16_kv_2k_cache_gib": 0.29, "fp8_window_compressed_kv_2k_cache_gib": 0.23,
+    "packed_cache_savings_64k_gib": 0.4856,
+    "packed_cache_savings_256k_gib": 1.9332,
+    "packed_cache_savings_1m_gib": 7.5413
+  },
+  "validation": {"target_reasoning_answer": 70, "dspark_n1_reasoning_answer": 70, "fp8_kv_end_to_end_smoke": true, "packed_fp4_indexer_end_to_end_smoke": true, "packed_cache_output_hash": "16207e79597e", "quality_gate_run": false, "packed_fp4_indexer_implemented": true},
+  "conclusion": "N=1 crosses break-even after safe first-draft-rejection carry commits. Confidence threshold 0.5 is promising. Exact draft quotas reduce I/O but not throughput. True FP8 window/compressed KV and packed FP4 indexer storage preserve the short-run target hash and save progressively more cache memory at long context.",
+  "source": {"raw_artifacts": "/home/lidaiqing/results/dsv4-dspark-adaptive/"}
+}

--- a/benchmarks/gb10/results/GB10-QWEN36-MTP-004.json
+++ b/benchmarks/gb10/results/GB10-QWEN36-MTP-004.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN36-MTP-004",
+  "status": "measured",
+  "recipe": {
+    "slug": "qwen3.6-35b-a3b",
+    "recipe_version": "0.4.0",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "08b959c302417d698a221967c1e521c23e6da445",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "repository": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+    "format": "ftw-nvfp4 + native BF16 MTP shard",
+    "quantization": "nvfp4 target + bf16 MTP",
+    "fingerprint": "bda7268c3e0afd7b",
+    "ftw_bytes": 22580867072,
+    "mtp_shard_bytes": 1689288704,
+    "mtp_payload_bytes": 1689281536
+  },
+  "workload": {
+    "single_stream": "greedy AIME25 problem 0, 54 prompt tokens",
+    "client_path": "OpenAI-compatible streaming HTTP API",
+    "warmup_requests": 1,
+    "measured_trials": 1,
+    "short_sweep_completion_tokens": 64,
+    "confirmation_completion_tokens": 256,
+    "prefix_reuse": "fresh prompt per measured server process"
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "expert_storage": "ram",
+    "expert_cache": "all 40 x 256 routed experts resident",
+    "attention_backend": "triton",
+    "cache_type": "hybrid_radix",
+    "page_size": 1,
+    "kv_tokens": 4096,
+    "max_running_requests": 1,
+    "cuda_graphs": false,
+    "selected_speculative_tokens": 2
+  },
+  "metrics": {
+    "matched_fi_64_target_only_decode_tokens_per_second": 49.067,
+    "matched_fi_64_mtp1_decode_tokens_per_second": 63.45830546461273,
+    "matched_fi_64_mtp2_decode_tokens_per_second": 66.31211075806793,
+    "matched_fi_64_mtp3_decode_tokens_per_second": 53.64,
+    "matched_fi_mtp2_relative_percent": 35.146,
+    "triton_64_mtp2_decode_tokens_per_second": 68.89,
+    "triton_256_target_only_decode_tokens_per_second": 45.382597260123,
+    "triton_256_mtp2_decode_tokens_per_second": 74.42385418992012,
+    "triton_256_mtp2_relative_percent": 63.992,
+    "triton_256_target_only_warm_ttft_seconds": 0.38921682399814017,
+    "triton_256_mtp2_warm_ttft_seconds": 0.36765717799426056,
+    "triton_256_target_only_vram_gib": 20.171875,
+    "triton_256_mtp2_vram_gib": 21.75390625,
+    "triton_256_mtp2_accepted_drafts": "153/173 (88.4%)",
+    "triton_256_mtp2_outputs_per_target_forward": 2.49,
+    "triton_256_mtp2_replay_calls": 15,
+    "triton_256_mtp2_replay_tokens": 25,
+    "prior_mtp2_decode_tokens_per_second": 7.019028706134907,
+    "mtp2_speedup_over_prior": 10.603
+  },
+  "validation": {
+    "checkpoint_checksum_verified": true,
+    "complete_checkpoint_loaded": true,
+    "native_mtp_weights_loaded": true,
+    "transactional_rejection_rollback": true,
+    "short_replay_uses_verification_gdn_and_decode_moe_kernels": true,
+    "speculative_page_reclamation": true,
+    "triton_256_target_only_output_sha1": "dc94b09666a6",
+    "triton_256_mtp2_output_sha1": "ec3dcb059017",
+    "selected_width_matches_target_only": false,
+    "api_stream_completed": true,
+    "oom_count": 0,
+    "service_restarts": 0,
+    "focused_unit_tests": "41 passed"
+  },
+  "admission": {
+    "tier": "fast",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "Width-two MTP reached 74.42 tok/s versus its matched 45.38 tok/s eager control on the 256-token Triton-attention probe.",
+      "The optimized path is 10.60x faster than the prior 7.02 tok/s width-two implementation because verification and rejection replay no longer use padded prompt MoE and chunk-GDN kernels.",
+      "This dirty-worktree performance result does not replace the clean-revision capability, context, quality, and endurance certification of the target-only recipe."
+    ]
+  },
+  "source": {
+    "target_only_artifact": "/tmp/qwen36-target-triton-attn-256.jsonl",
+    "mtp2_artifact": "/tmp/qwen36-mtp2-triton-attn-256.jsonl",
+    "short_sweep_artifacts": "/tmp/qwen36-mtp{0,1,2,3}-optimized.jsonl",
+    "prior_evidence": "GB10-QWEN36-MTP-003"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "Each configuration has one measured trial and covers batch-one greedy generation only.",
+    "The multi-token verification path selected a different close greedy continuation than single-token eager decoding; sampled distribution and broader quality gates were not evaluated.",
+    "The existing 32K context, capability, coding-agent, and endurance gates were not rerun for this optional path."
+  ]
+}

--- a/benchmarks/gb10/results/GB10-QWEN38-FP8-PLE-005.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-FP8-PLE-005.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0", "result_id": "GB10-QWEN38-FP8-PLE-005",
+  "status": "measured", "date": "2026-09-02",
+  "platform": {"device": "NVIDIA GB10", "memory_gib": 128, "cuda": "13.0"},
+  "model": {"repository": "Inferact/Qwen3.8-Flash-Next-NVFP4", "routed_experts": "NVFP4", "ple_storage": "float8_e4m3fn"},
+  "workload": {"batch_size": 1, "sampling": "greedy", "completion_tokens": 128, "mtp_tokens": 2},
+  "metrics": {
+    "bf16_ple_sync_tok_s": 21.2654, "bf16_ple_async_tok_s": 21.2951,
+    "fp8_ple_sync_tok_s": 21.8234, "fp8_ple_async_tok_s": 21.7931,
+    "fp8_sync_speedup_percent": 2.62,
+    "bf16_ple_bytes": 102400491520, "fp8_ple_bytes": 51200245760,
+    "ple_storage_reduction_percent": 50.0
+  },
+  "validation": {"sampled_rows_match_bf16_to_fp8_to_bf16": true, "bf16_output_hash": "9ce352b0edd6", "fp8_output_hash": "37a7098d6fbc", "quality_gate_run": false},
+  "conclusion": "FP8 halves PLE storage and improves this matched probe by 2.62%. Async staging is neutral with the current single early PLE layer and remains opt-in.",
+  "source": {"raw_artifacts": "/home/lidaiqing/results/qwen3.8-fp8-ple/"}
+}

--- a/benchmarks/gb10/results/GB10-QWEN38-FP8-PLE-005.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-FP8-PLE-005.json
@@ -13,5 +13,5 @@
   },
   "validation": {"sampled_rows_match_bf16_to_fp8_to_bf16": true, "bf16_output_hash": "9ce352b0edd6", "fp8_output_hash": "37a7098d6fbc", "quality_gate_run": false},
   "conclusion": "FP8 halves PLE storage and improves this matched probe by 2.62%. Async staging is neutral with the current single early PLE layer and remains opt-in.",
-  "source": {"raw_artifacts": "/home/lidaiqing/results/qwen3.8-fp8-ple/"}
+  "source": {"raw_artifacts": "$HOME/results/qwen3.8-fp8-ple/"}
 }

--- a/benchmarks/gb10/results/GB10-QWEN38-HYBRID-006.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-HYBRID-006.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0", "result_id": "GB10-QWEN38-HYBRID-006",
+  "status": "measured", "date": "2026-09-02",
+  "platform": {"device": "NVIDIA GB10", "memory_gib": 128, "cuda": "13.0"},
+  "model": {"repository": "Inferact/Qwen3.8-Flash-Next-NVFP4", "routed_experts": "NVFP4", "ple_storage": "float8_e4m3fn", "resident_projections": "float8_e4m3fn-per-output-row"},
+  "workload": {"batch_size": 1, "sampling": "greedy", "completion_tokens": 128, "mtp_tokens": 2},
+  "metrics": {
+    "bf16_dense_fp8_ple_tok_s": 21.8234,
+    "fp8_dense_fp8_ple_tok_s": 22.1641,
+    "speedup_percent": 1.56,
+    "bf16_dense_server_vram_gib": 78.9688,
+    "fp8_dense_server_vram_gib": 75.6113,
+    "server_vram_saved_gib": 3.3575,
+    "w1_smoke_decode_tok_s": 22.1202,
+    "w1_smoke_completion_tokens": 705
+  },
+  "validation": {"bf16_dense_output_hash": "37a7098d6fbc", "fp8_dense_output_hash": "37a7098d6fbc", "w1_smoke_expected_answer": "70", "w1_smoke_extracted_answer": "70", "w1_smoke_passed": true, "full_w1_run": false},
+  "conclusion": "Load-time streaming FP8 resident projection conversion saves 3.36 GiB and improves the matched decode probe by 1.56% without changing its 128-token output. The 4096-token-cap W1 smoke passes; the deliberately truncated 512-token diagnostic is retained separately and is not a quality result.",
+  "source": {"raw_artifacts": "/home/lidaiqing/results/qwen3.8-fp8-dense/", "quality_result": "benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-4096-20260902.json"}
+}

--- a/benchmarks/gb10/results/GB10-QWEN38-HYBRID-006.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-HYBRID-006.json
@@ -16,5 +16,5 @@
   },
   "validation": {"bf16_dense_output_hash": "37a7098d6fbc", "fp8_dense_output_hash": "37a7098d6fbc", "w1_smoke_expected_answer": "70", "w1_smoke_extracted_answer": "70", "w1_smoke_passed": true, "full_w1_run": false},
   "conclusion": "Load-time streaming FP8 resident projection conversion saves 3.36 GiB and improves the matched decode probe by 1.56% without changing its 128-token output. The 4096-token-cap W1 smoke passes; the deliberately truncated 512-token diagnostic is retained separately and is not a quality result.",
-  "source": {"raw_artifacts": "/home/lidaiqing/results/qwen3.8-fp8-dense/", "quality_result": "benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-4096-20260902.json"}
+  "source": {"raw_artifacts": "$HOME/results/qwen3.8-fp8-dense/", "quality_result": "benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-4096-20260902.json"}
 }

--- a/benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-20260902.json
+++ b/benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-20260902.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0",
+  "paper": "arXiv:2608.16157v1",
+  "workload": "W1",
+  "model": "qwen3.8-flash-next-hybrid",
+  "served_model": "qwen3.8-flash-next-hybrid",
+  "weight_format": "NVFP4+FP8",
+  "mode": "smoke",
+  "base_url": "http://127.0.0.1:18081",
+  "provenance": {
+    "timestamp_utc": "2026-09-02T16:14:05.439971+00:00",
+    "git_revision": "08b959c302417d698a221967c1e521c23e6da445",
+    "python": "3.11.15",
+    "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+    "server": {
+      "status": "ok",
+      "model": "qwen3.8-flash-next-hybrid",
+      "instance_id": "ad6093b2-85ec-4f6a-833b-256309e5cb69",
+      "uptime_s": 43,
+      "maintenance": "serving",
+      "version": "0.1.1"
+    },
+    "model_registry": null
+  },
+  "quality": {
+    "passed": false,
+    "correct": 0,
+    "total": 1,
+    "accuracy": 0,
+    "gate": "final extracted answer equals the AIME reference answer"
+  },
+  "metrics": {
+    "request_count": 1,
+    "mean_decode_tokens_per_second": 20.237321249289923,
+    "mean_ttft_seconds": 1.7841881469939835,
+    "max_ttft_seconds": 1.7841881469939835
+  },
+  "requests": [
+    {
+      "problem": 0,
+      "expected": "70",
+      "answer": null,
+      "correct": false,
+      "prompt_tokens": 91,
+      "completion_tokens": 512,
+      "ttft_seconds": 1.7841881469939835,
+      "duration_seconds": 27.03503084098338,
+      "decode_seconds": 25.250377443997422,
+      "decode_tokens_per_second": 20.237321249289923,
+      "finish_reason": "length",
+      "output_sha256": "8f62cad3399dc40a4b40da8fca5edd0af75b61899584ed470b31a614d182ff1e",
+      "reasoning_output": "We need solve problem. Need provide final boxed. Let's analyze thoroughly.\n\nProblem: Find sum of all integer bases b>9 for which 17_b is a divisor of 97_b.\n\nInterpretation: In base b, digits 1,7 and 9,7. Since b>9, digits valid. 17_b = b+7. 97_b = 9b+7. Need b+7 divides 9b+7. Integer bases b>9. Find sum of all such b.\n\nCompute divisibility: b+7 | 9b+7. Express 9b+7 = 9(b+7) - 56. Since 9(b+7)=9b+63, subtract 56 gives 9b+7. Thus b+7 divides 56. Since b>9, b+7 >16. Positive divisors of 56 greater than 16: 28,56? Also 56 divisors: 1,2,4,7,8,14,28,56. >16: 28,56. Then b=21,49. Sum=70. Check: b=21: 17_21=28, 97_21=196? 9*21+7=196, 196/28=7. b=49: 56 divides 448? 9*49+7=448, /56=8. Sum 70.\n\nNeed final answer with explanation. Ensure no missing negative? b>9 positive. Divisor positive. Good.\n\nNeed maybe consider base b integer >9, digits 9 and 7 valid. Yes.\n\nFinal boxed 70.\n",
+      "output": "\n\nIn base \\(b\\),\n\n\\[\n17_b = b+7\n\\]\n\nand\n\n\\[\n97_b = 9b+7.\n\\]\n\nWe need \\(b+7\\) to divide \\(9b+7\\). Rewrite:\n\n\\[\n9b+7 = 9(b+7)-56.\n\\]\n\nSo \\(b+7\\) must divide \\(56\\). Since \\(b>9\\), we have \\(b+7>16\\)."
+    }
+  ],
+  "configuration": {
+    "dataset": "math-ai/aime25/test.jsonl",
+    "problems": "0",
+    "max_tokens": 512,
+    "temperature": 0.0,
+    "top_p": null,
+    "seed": null
+  }
+}

--- a/benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-4096-20260902.json
+++ b/benchmarks/quality/results/qwen3.8-flash-next-hybrid-w1-smoke-4096-20260902.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0",
+  "paper": "arXiv:2608.16157v1",
+  "workload": "W1",
+  "model": "qwen3.8-flash-next-hybrid",
+  "served_model": "qwen3.8-flash-next-hybrid",
+  "weight_format": "NVFP4+FP8",
+  "mode": "smoke",
+  "base_url": "http://127.0.0.1:18081",
+  "provenance": {
+    "timestamp_utc": "2026-09-02T16:15:05.835484+00:00",
+    "git_revision": "08b959c302417d698a221967c1e521c23e6da445",
+    "python": "3.11.15",
+    "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+    "server": {
+      "status": "ok",
+      "model": "qwen3.8-flash-next-hybrid",
+      "instance_id": "ad6093b2-85ec-4f6a-833b-256309e5cb69",
+      "uptime_s": 104,
+      "maintenance": "serving",
+      "version": "0.1.1"
+    },
+    "model_registry": null
+  },
+  "quality": {
+    "passed": true,
+    "correct": 1,
+    "total": 1,
+    "accuracy": 1,
+    "gate": "final extracted answer equals the AIME reference answer"
+  },
+  "metrics": {
+    "request_count": 1,
+    "mean_decode_tokens_per_second": 22.12023895524451,
+    "mean_ttft_seconds": 0.28146086900960654,
+    "max_ttft_seconds": 0.28146086900960654
+  },
+  "requests": [
+    {
+      "problem": 0,
+      "expected": "70",
+      "answer": "70",
+      "correct": true,
+      "prompt_tokens": 91,
+      "completion_tokens": 705,
+      "ttft_seconds": 0.28146086900960654,
+      "duration_seconds": 32.10779035001178,
+      "decode_seconds": 31.82605763999163,
+      "decode_tokens_per_second": 22.12023895524451,
+      "finish_reason": "stop",
+      "output_sha256": "24612d65450fe6e0f131db741dbeed6a5d2216bcbab4e6b12400dceefa078b94",
+      "reasoning_output": "We need solve problem. Need provide final boxed. Let's analyze thoroughly.\n\nProblem: Find sum of all integer bases b>9 for which 17_b is a divisor of 97_b.\n\nInterpretation: In base b, digits 1,7 and 9,7. Since b>9, digits valid. 17_b = 1*b + 7 = b+7. 97_b = 9*b + 7 = 9b+7. Need b+7 divides 9b+7. Integer bases b>9.\n\nCompute divisibility: 9b+7 = 9(b+7) - 56? 9b+63 -56 = 9b+7. So b+7 | 56. Since b>9, b+7 >16. Positive divisors of 56 greater than 16: 28,56? Also 56 divisors: 1,2,4,7,8,14,28,56. >16: 28,56. Then b = 21,49. Sum =70. Check b>9 yes. Need ensure divisor means positive? yes.\n\nBut let's consider if base b integer >9, 17_b divisor of 97_b. Could be negative? no. Sum 70.\n\nNeed final with explanation. Ensure no hidden issue: 17_b = b+7, 97_b=9b+7. Divisibility: (9b+7)/(b+7) = 9 - 56/(b+7). Need integer. b+7 divides 56. b+7 >16. Divisors 28,56. b=21,49. Sum 70.\n\nNeed final boxed. Could mention b=21: 17_21=28, 97_21=196? 9*21+7=196, 196/28=7. b=49: 56, 448? 9*49+7=448, /56=8. Good.\n\nFinal concise.\n",
+      "output": "\n\nIn base \\(b\\),\n\n\\[\n17_b = b+7,\\qquad 97_b = 9b+7.\n\\]\n\nWe need \\(b+7 \\mid 9b+7\\). Since\n\n\\[\n9b+7 = 9(b+7)-56,\n\\]\n\nthis is equivalent to\n\n\\[\nb+7 \\mid 56.\n\\]\n\nBecause \\(b>9\\), we have \\(b+7>16\\). The positive divisors of \\(56\\) greater than \\(16\\) are \\(28\\) and \\(56\\). Thus\n\n\\[\nb+7=28 \\implies b=21,\n\\]\n\\[\nb+7=56 \\implies b=49.\n\\]\n\nThe sum of all such bases is\n\n\\[\n21+49=70.\n\\]\n\n\\[\n\\boxed{70}\n\\]"
+    }
+  ],
+  "configuration": {
+    "dataset": "math-ai/aime25/test.jsonl",
+    "problems": "0",
+    "max_tokens": 4096,
+    "temperature": 0.0,
+    "top_p": null,
+    "seed": null
+  }
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -31,7 +31,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | Model | Parameter | Quantization | Recipe | Status | tok/s | TTFT(s) |
 |---|---|---|---|---|---:|---:|
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
-| [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP3 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
+| [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW | `qwen3.8-27b` | Experimental | 8.83 | 0.144 |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP2 | `qwen3.8-flash-next` | Experimental | 20.31 | 0.212 |
@@ -53,14 +53,15 @@ The Qwen3.8-Flash-Next row reports its selected two-draft MTP profile. It is opt
 the default profile remains available for concurrent or sampled traffic.
 
 Qwen3.6's published FTW artifact includes its native BF16 MTP weights, but the portfolio
-row continues to report the certified target-only profile. The measured three-draft path
-was 83.7% slower on GB10 and remains experimental.
+row continues to report the certified target-only profile. The optimized two-draft path
+measured 74.42 tok/s on a matched 256-token GB10 probe versus 45.38 tok/s target-only;
+it remains opt-in pending the full certification suite.
 
 ## Evidence and caveats
 
 | Model | Current result | Evidence |
 |---|---|---|
-| Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Native MTP3 is available but measured 8.57 tok/s versus its 52.63 tok/s control, so it remains opt-in. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json) |
+| Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Optimized native MTP2 reached 74.42 tok/s versus its 45.38 tok/s eager control; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json) |
 | Qwen3.8-27B | Passes Frontier speed, exact 64K recall, reasoning/tool parsing, and the coding-agent probe; the clean-revision 60-minute endurance gate remains outstanding. | [GB10-QWEN38-27B-001](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json) |
 | Qwen3.8-Flash-Next | The opt-in two-draft MTP profile measured 20.31 tok/s with exact eager-output parity; the default concurrent profile remains 16.84 single-stream tok/s. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-NVFP4-OPT-004](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json) |
 | DeepSeek V4 Flash | GPU-first expert residency reaches 8.67 tok/s. Native DSpark remains opt-in because N=1 still trails target-only decoding with disk-backed experts on one GB10. | [GB10-DSV4-RESIDENCY-003](../benchmarks/gb10/results/GB10-DSV4-RESIDENCY-003.json) |

--- a/docs/models/qwen3.6-35b-a3b.md
+++ b/docs/models/qwen3.6-35b-a3b.md
@@ -1,7 +1,7 @@
 # Run Qwen3.6-35B-A3B
 
 Qwen3.6-35B-A3B is SparkLab's Fast-tier NVFP4 recipe. It uses a pinned, prebuilt FTW
-artifact and runs resident on one NVIDIA DGX Spark. Recipe 0.3.0 is Fast-certified on
+artifact and runs resident on one NVIDIA DGX Spark. Recipe 0.4.0 is Fast-certified on
 one NVIDIA GB10: 67.79 decode tok/s, 0.329 s warm TTFT, exact 32K recall, and a stable
 60-minute zero-swap run. See the
 [versioned evidence](../../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json).
@@ -44,25 +44,32 @@ the complete FTW repack locally from NVIDIA's pinned source checkpoint.
 sparklab run qwen3.6-35b-a3b --root /path/to/models
 ```
 
-## Experimental speculative decoding
+## Optional speculative decoding
 
 SparkLab can load Qwen3.6's native MTP layer, verify its draft tokens with the target,
 and commit or roll back paged KV and GDN recurrent state at the accepted boundary. The
-[upstream vLLM profile](https://recipes.vllm.ai/Qwen/Qwen3.6-35B-A3B) uses three drafts:
+[upstream vLLM profile](https://recipes.vllm.ai/Qwen/Qwen3.6-35B-A3B) uses three drafts.
+On GB10, SparkLab's measured optimum is currently two drafts with Triton attention:
 
 ```bash
 sparklab run qwen3.6-35b-a3b --root /path/to/models -- \
   --speculative-method mtp \
-  --speculative-tokens 3
+  --speculative-tokens 2 \
+  --attention-backend triton
 ```
 
-This path is available for experimentation, not recommended for production on GB10. In
-a controlled 64-token greedy sweep, target-only decode reached 52.63 tok/s. Draft widths
-one, two, and three reached 5.68, 7.02, and 8.57 tok/s respectively. Width three accepted
-41/50 drafts and reduced the run to 23 target forwards, but the resident BF16 draft layer
-cost more than the saved NVFP4 target work. It was also the only measured width that
-reproduced the target-only output hash. Keep the default target-only recipe for normal
-chat and agent use. See [GB10-QWEN36-MTP-003](../../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json).
+The optimized path sends verification and short rejection repairs through decode-sized
+MoE and recurrent kernels instead of padded prompt kernels. In the controlled 64-token
+FlashInfer sweep, target-only decode reached 49.07 tok/s and widths one, two, and three
+reached 63.46, 66.31, and 53.64 tok/s. A longer matched Triton-attention probe reached
+74.42 tok/s with width two versus 45.38 tok/s target-only: a 64.0% gain, 88.4% draft
+acceptance, and 2.49 output tokens per target forward.
+
+Keep this profile opt-in for now. It covers one greedy request, and the multi-token
+numerical path selected a different close greedy continuation than single-token eager
+decode. The complete context, quality, agent, and endurance certification suite has not
+been rerun. See [the original sweep](../../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json)
+and [the optimized result](../../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json).
 
 MTP currently applies to one running greedy request. Sampled requests fall back to target
 decoding, and target verification runs eagerly.

--- a/python/sparklab/attention/dsv4_compress.py
+++ b/python/sparklab/attention/dsv4_compress.py
@@ -21,6 +21,8 @@ import os
 
 import torch
 
+from sparklab.core import get_global_ctx
+
 
 class CompressorBackendMixin:
     # DSV4_RING_CHECK=1 -> assert the ring read-back equals what was written. Off by default.
@@ -68,7 +70,14 @@ class CompressorBackendMixin:
         self, layer_id: int, tier: str, rows: torch.Tensor, kv: torch.Tensor
     ) -> None:
         pool = self.compress_pool(layer_id, tier)
-        pool.index_copy_(0, rows, kv.to(pool.dtype))
+        if tier == "idx" and pool.dtype == torch.uint8:
+            self.pool.store_indexer(kv, layer_id, rows)
+            return
+        value = kv.to(pool.dtype)
+        if pool.dtype == torch.float8_e4m3fn:
+            pool.view(torch.uint8).index_copy_(0, rows, value.view(torch.uint8))
+        else:
+            pool.index_copy_(0, rows, value)
 
     # ----- compress-state ring ---------------------------------------------------------
     def carry_state_loc(self, window_slot: int, ring_size: int) -> torch.Tensor:
@@ -116,7 +125,11 @@ class CompressorBackendMixin:
         blocks: torch.Tensor,
     ) -> None:
         ring = self.compress_state_ring(layer_id, tier)
-        ring.set_blocks(self.ring_page_base(window_slots, ring_size), blocks)
+        page_base = self.ring_page_base(window_slots, ring_size)
+        batch = getattr(get_global_ctx(), "batch", None)
+        if batch is not None and batch.is_verify:
+            self.pool.capture_first_speculative_carry(ring, page_base, blocks)
+        ring.set_blocks(page_base, blocks)
 
     def write_boundary_carries(
         self, *, layer_id: int, tier: str, ratio: int, overlap: bool, ring_size: int,

--- a/python/sparklab/attention/dsv4_indexer.py
+++ b/python/sparklab/attention/dsv4_indexer.py
@@ -29,9 +29,17 @@ class IndexerBackendMixin:
         """
         block_starts = torch.arange(0, n_blocks * ratio, ratio, device=self.device)
         rows = self.compress_rows_of(ti, block_starts, ratio)
-        return self.compress_pool(layer_id, "idx").index_select(0, rows).unsqueeze(0).expand(
-            bsz, -1, -1
-        )
+        pool = self.compress_pool(layer_id, "idx")
+        if pool.dtype == torch.uint8:
+            from sparklab.kernels.triton.dsv4.fp4_cache import unpack_fp4_rows
+
+            keys = unpack_fp4_rows(
+                pool, self.pool.idx_scale_pool[layer_id], rows,
+                self.pool.index_head_dim,
+            )
+        else:
+            keys = pool.index_select(0, rows)
+        return keys.unsqueeze(0).expand(bsz, -1, -1)
 
     def indexer_prefill_logits(
         self, q: torch.Tensor, keys: torch.Tensor, weights: torch.Tensor
@@ -50,9 +58,10 @@ class IndexerBackendMixin:
         memory (so a captured graph tracks the position, not the staged width)."""
         from sparklab.kernels.triton.dsv4.indexer import indexer_decode_logits
 
+        pool = self.compress_pool(layer_id, "idx")
         return indexer_decode_logits(
-            q, weights, self.compress_pool(layer_id, "idx"), self.snapshot(),
-            valid, n_stage, ratio,
+            q, weights, pool, self.snapshot(), valid, n_stage, ratio,
+            fp4_scales=self.pool.idx_scale_pool[layer_id],
         )
 
     def indexer_select_prefill(

--- a/python/sparklab/checkpoint/__main__.py
+++ b/python/sparklab/checkpoint/__main__.py
@@ -45,6 +45,12 @@ def main(argv: list[str] | None = None, prog: str = "sparklab.checkpoint") -> in
         default=None,
         help="store supported KDA main projections in the selected FTW format",
     )
+    p.add_argument(
+        "--qwen4-ngram-dtype",
+        choices=("preserve", "float8_e4m3fn"),
+        default="preserve",
+        help="storage dtype for Qwen3.8 PLE rows (default: preserve source)",
+    )
     p.add_argument("--shard-gib", type=float, default=8.0, help="max shard size in GiB")
     p.add_argument("--device", default=None, help="CUDA device for repack (default cuda:0)")
     ns = p.parse_args(argv)
@@ -57,6 +63,7 @@ def main(argv: list[str] | None = None, prog: str = "sparklab.checkpoint") -> in
         moe_backend=ns.moe_backend, nvfp4_backend=ns.nvfp4_backend,
         expert_quantization=ns.expert_quantization,
         kda_quantization=ns.kda_quantization,
+        qwen4_ngram_dtype=ns.qwen4_ngram_dtype,
         shard_limit=shard_limit, device=ns.device,
     )
     dt = time.perf_counter() - t

--- a/python/sparklab/checkpoint/convert.py
+++ b/python/sparklab/checkpoint/convert.py
@@ -292,6 +292,7 @@ def _convert_checkpoint(
     moe_backend: str = "offload",
     nvfp4_backend: str = "triton",
     expert_quantization: str | None = None,
+    qwen4_ngram_dtype: str = "preserve",
     shard_limit: int = DEFAULT_SHARD_LIMIT,
     device: str | None = None,
 ) -> dict:
@@ -471,9 +472,14 @@ def _convert_checkpoint(
         external_hook = _load_attr(spec.module, "copy_external_artifacts")
     except AttributeError:
         external_hook = None
-    external_artifacts = (
-        external_hook(model_path, out_dir, mc) if external_hook is not None else []
-    )
+    external_artifacts = []
+    if external_hook is not None:
+        external_artifacts = external_hook(
+            model_path,
+            out_dir,
+            mc,
+            ngram_dtype=qwen4_ngram_dtype,
+        )
 
     try:
         fingerprint = _source_fingerprint(
@@ -520,12 +526,17 @@ def convert_checkpoint(
     nvfp4_backend: str = "triton",
     expert_quantization: str | None = None,
     kda_quantization: str | None = None,
+    qwen4_ngram_dtype: str = "preserve",
     shard_limit: int = DEFAULT_SHARD_LIMIT,
     device: str | None = None,
 ) -> dict:
     """Write a self-contained FTW checkpoint, including requested format transforms."""
     if kda_quantization not in {None, "fp8_pertensor"}:
         raise ValueError(f"unsupported KDA quantization: {kda_quantization!r}")
+    if qwen4_ngram_dtype not in {"preserve", "float8_e4m3fn"}:
+        raise ValueError(
+            f"unsupported Qwen4 n-gram target dtype: {qwen4_ngram_dtype!r}"
+        )
     previous = os.environ.get(_GLM_KDA_QUANT_ENV)
     try:
         if kda_quantization is None:
@@ -539,6 +550,7 @@ def convert_checkpoint(
             moe_backend=moe_backend,
             nvfp4_backend=nvfp4_backend,
             expert_quantization=expert_quantization,
+            qwen4_ngram_dtype=qwen4_ngram_dtype,
             shard_limit=shard_limit,
             device=device,
         )

--- a/python/sparklab/core.py
+++ b/python/sparklab/core.py
@@ -171,6 +171,10 @@ class Batch:
     # is a multi-token continuation and therefore uses the varlen kernels.
     return_all_logits: bool = field(default=False, init=False)
     disable_state_tracking: bool = field(default=False, init=False)
+    # A short sequential repair after speculative rejection. Attention still needs
+    # prefill/varlen semantics, while token-local MoE and recurrent mixers should use
+    # their low-latency verification kernels instead of padded prompt kernels.
+    is_speculative_replay: bool = field(default=False, init=False)
     verify_cached_lens: Tuple[int, ...] = field(default_factory=tuple, init=False)
 
     @property

--- a/python/sparklab/kernels/triton/dsv4/fp4_cache.py
+++ b/python/sparklab/kernels/triton/dsv4/fp4_cache.py
@@ -1,0 +1,146 @@
+"""Packed E2M1 cache rows for the DSV4 Lightning Indexer."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from .fp8_linear import _log2_ceil, _round_fp4
+
+
+@triton.jit
+def decode_e2m1(code):
+    mag = code & 7
+    value = tl.where(
+        mag == 0, 0.0,
+        tl.where(mag == 1, 0.5,
+        tl.where(mag == 2, 1.0,
+        tl.where(mag == 3, 1.5,
+        tl.where(mag == 4, 2.0,
+        tl.where(mag == 5, 3.0,
+        tl.where(mag == 6, 4.0, 6.0)))))))
+    return tl.where((code & 8) != 0, -value, value)
+
+
+@triton.jit
+def _encode_e2m1(value):
+    value = _round_fp4(value)
+    a = tl.abs(value)
+    mag = tl.where(
+        a == 0.0, 0,
+        tl.where(a == 0.5, 1,
+        tl.where(a == 1.0, 2,
+        tl.where(a == 1.5, 3,
+        tl.where(a == 2.0, 4,
+        tl.where(a == 3.0, 5,
+        tl.where(a == 4.0, 6, 7)))))))
+    return mag | tl.where(value < 0, 8, 0)
+
+
+@triton.jit
+def _pack_fp4_rows_kernel(
+    x_ptr, rows_ptr, packed_ptr, scales_ptr,
+    M: tl.constexpr, D: tl.constexpr,
+    stride_xm, stride_xd, stride_pr, stride_pb, stride_sr, stride_sb,
+    BLOCK: tl.constexpr,
+):
+    m = tl.program_id(0)
+    b = tl.program_id(1)
+    offs = b * BLOCK + tl.arange(0, BLOCK)
+    x = tl.load(x_ptr + m * stride_xm + offs * stride_xd).to(tl.float32)
+    amax = tl.maximum(tl.max(tl.abs(x), axis=0), 6.0 * (2.0 ** -126))
+    exponent = _log2_ceil(amax / 6.0)
+    scale = tl.exp2(exponent.to(tl.float32))
+    pairs = tl.arange(0, BLOCK // 2)
+    even = tl.load(
+        x_ptr + m * stride_xm + (b * BLOCK + pairs * 2) * stride_xd
+    ).to(tl.float32)
+    odd = tl.load(
+        x_ptr + m * stride_xm + (b * BLOCK + pairs * 2 + 1) * stride_xd
+    ).to(tl.float32)
+    lo = _encode_e2m1(tl.clamp(even / scale, -6.0, 6.0)).to(tl.uint8)
+    hi = _encode_e2m1(tl.clamp(odd / scale, -6.0, 6.0)).to(tl.uint8)
+    byte = lo | (hi << 4)
+    row = tl.load(rows_ptr + m)
+    tl.store(packed_ptr + row * stride_pr + (b * (BLOCK // 2) + pairs) * stride_pb, byte)
+    tl.store(scales_ptr + row * stride_sr + b * stride_sb, scale)
+
+
+def pack_fp4_rows(
+    x: torch.Tensor,
+    rows: torch.Tensor,
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+) -> None:
+    """Quantize ``x[M,D]`` into selected packed-pool rows, block size 32."""
+    x = x.reshape(-1, x.shape[-1]).contiguous()
+    rows = rows.reshape(-1).to(torch.int64)
+    M, D = x.shape
+    assert rows.numel() == M and D % 32 == 0
+    assert packed.dtype == torch.uint8 and packed.shape[1] == D // 2
+    assert scales.dtype == torch.float32 and scales.shape[1] == D // 32
+    if x.device.type == "cpu":
+        blocks = x.float().view(M, D // 32, 32)
+        amax = blocks.abs().amax(-1).clamp_min(6.0 * 2.0**-126)
+        scale = torch.pow(2.0, torch.ceil(torch.log2(amax / 6.0)))
+        q = blocks / scale.unsqueeze(-1)
+        lut = torch.tensor(
+            [0, .5, 1, 1.5, 2, 3, 4, 6], dtype=torch.float32, device=x.device
+        )
+        distance = (q.abs().unsqueeze(-1) - lut).abs()
+        code = distance.argmin(-1).to(torch.uint8) | ((q < 0).to(torch.uint8) << 3)
+        code = code.view(M, D)
+        bytes_ = code[:, 0::2] | (code[:, 1::2] << 4)
+        packed.index_copy_(0, rows, bytes_)
+        scales.index_copy_(0, rows, scale)
+        return
+    _pack_fp4_rows_kernel[(M, D // 32)](
+        x, rows, packed, scales, M=M, D=D,
+        stride_xm=x.stride(0), stride_xd=x.stride(1),
+        stride_pr=packed.stride(0), stride_pb=packed.stride(1),
+        stride_sr=scales.stride(0), stride_sb=scales.stride(1), BLOCK=32,
+    )
+
+
+@triton.jit
+def _unpack_fp4_rows_kernel(
+    packed_ptr, scales_ptr, rows_ptr, out_ptr,
+    M: tl.constexpr, D: tl.constexpr,
+    stride_pr, stride_pb, stride_sr, stride_sb, stride_om, stride_od,
+    BLOCK: tl.constexpr,
+):
+    m = tl.program_id(0)
+    b = tl.program_id(1)
+    offs = b * BLOCK + tl.arange(0, BLOCK)
+    row = tl.load(rows_ptr + m)
+    byte = tl.load(packed_ptr + row * stride_pr + (offs // 2) * stride_pb)
+    code = tl.where((offs & 1) == 0, byte & 15, byte >> 4)
+    scale = tl.load(scales_ptr + row * stride_sr + b * stride_sb)
+    value = decode_e2m1(code) * scale
+    tl.store(out_ptr + m * stride_om + offs * stride_od, value)
+
+
+def unpack_fp4_rows(
+    packed: torch.Tensor, scales: torch.Tensor, rows: torch.Tensor, D: int
+) -> torch.Tensor:
+    """Gather/dequantize selected cache rows into BF16."""
+    rows = rows.reshape(-1).to(torch.int64)
+    out = torch.empty((rows.numel(), D), dtype=torch.bfloat16, device=packed.device)
+    if packed.device.type == "cpu":
+        byte = packed.index_select(0, rows)
+        code = torch.empty((rows.numel(), D), dtype=torch.uint8)
+        code[:, 0::2], code[:, 1::2] = byte & 15, byte >> 4
+        lut = torch.tensor([0, .5, 1, 1.5, 2, 3, 4, 6], dtype=torch.float32)
+        value = lut[(code & 7).long()] * torch.where(code & 8 != 0, -1.0, 1.0)
+        return (value.view(-1, D // 32, 32) * scales.index_select(0, rows).unsqueeze(-1)).view(-1, D).to(torch.bfloat16)
+    _unpack_fp4_rows_kernel[(rows.numel(), D // 32)](
+        packed, scales, rows, out, M=rows.numel(), D=D,
+        stride_pr=packed.stride(0), stride_pb=packed.stride(1),
+        stride_sr=scales.stride(0), stride_sb=scales.stride(1),
+        stride_om=out.stride(0), stride_od=out.stride(1), BLOCK=32,
+    )
+    return out
+
+
+__all__ = ["decode_e2m1", "pack_fp4_rows", "unpack_fp4_rows"]

--- a/python/sparklab/kernels/triton/dsv4/indexer.py
+++ b/python/sparklab/kernels/triton/dsv4/indexer.py
@@ -23,6 +23,8 @@ import torch
 import triton
 import triton.language as tl
 
+from .fp4_cache import decode_e2m1
+
 
 @triton.jit
 def _indexer_logits_kernel(
@@ -117,17 +119,19 @@ def indexer_logits(
 
 @triton.jit
 def _indexer_decode_logits_kernel(
-    q_ptr, w_ptr, pool_ptr, snap_ptr, valid_ptr, out_ptr,
+    q_ptr, w_ptr, pool_ptr, scale_ptr, snap_ptr, valid_ptr, out_ptr,
     N_STAGE, RATIO,
     stride_qb, stride_qh, stride_qd,
     stride_wb, stride_wh,
     stride_pr, stride_pd,
+    stride_sr, stride_ss,
     stride_sb, stride_sw,
     stride_ob, stride_ot,
     H: tl.constexpr,
     D: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_T: tl.constexpr,
+    FP4: tl.constexpr,
 ):
     """One decode query per row, gathering its own compressed keys.
 
@@ -161,8 +165,20 @@ def _indexer_decode_logits_kernel(
                    mask=t_mask, other=0)
     rows = tl.maximum(snap, 0) // RATIO
 
-    k = tl.load(pool_ptr + rows[:, None] * stride_pr + offs_d[None, :] * stride_pd,
-                mask=t_mask[:, None], other=0.0)
+    if FP4:
+        byte = tl.load(
+            pool_ptr + rows[:, None] * stride_pr + (offs_d[None, :] // 2) * stride_pd,
+            mask=t_mask[:, None], other=0,
+        )
+        code = tl.where((offs_d[None, :] & 1) == 0, byte & 15, byte >> 4)
+        scale = tl.load(
+            scale_ptr + rows[:, None] * stride_sr + (offs_d[None, :] // 32) * stride_ss,
+            mask=t_mask[:, None], other=0.0,
+        )
+        k = (decode_e2m1(code) * scale).to(tl.bfloat16)
+    else:
+        k = tl.load(pool_ptr + rows[:, None] * stride_pr + offs_d[None, :] * stride_pd,
+                    mask=t_mask[:, None], other=0.0)
     q = tl.load(q_ptr + pid_b * stride_qb + offs_h[:, None] * stride_qh + offs_d[None, :] * stride_qd,
                 mask=h_mask[:, None], other=0.0)
     w = tl.load(w_ptr + pid_b * stride_wb + offs_h * stride_wh, mask=h_mask, other=0.0).to(tl.float32)
@@ -184,6 +200,7 @@ def indexer_decode_logits(
     n_stage: int,             # static staged width (the buffer the top-k scans)
     ratio: int,
     out: torch.Tensor | None = None,
+    fp4_scales: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Head-reduced Lightning-Indexer logits ``[B, n_stage]`` for a decode step.
 
@@ -199,25 +216,34 @@ def indexer_decode_logits(
     """
     B, H, D = q.shape
     assert weights.shape == (B, H), (weights.shape, (B, H))
-    assert idx_pool.shape[1] == D, (idx_pool.shape, D)
+    packed_fp4 = fp4_scales is not None
+    assert idx_pool.shape[1] == D // (2 if packed_fp4 else 1), (idx_pool.shape, D)
+    if packed_fp4:
+        assert idx_pool.dtype == torch.uint8
+        assert fp4_scales.dtype == torch.float32
+        assert fp4_scales.shape == (idx_pool.shape[0], D // 32)
     assert D == triton.next_power_of_2(D), f"index_head_dim must be pow2, got {D}"
 
     if out is None:
-        out = torch.empty((B, n_stage), dtype=idx_pool.dtype, device=q.device)
+        out = torch.empty((B, n_stage), dtype=torch.bfloat16, device=q.device)
     if n_stage == 0:
         return out
 
     BLOCK_T = 64
     _indexer_decode_logits_kernel[(B, triton.cdiv(n_stage, BLOCK_T))](
-        q, weights, idx_pool, full_snap, valid, out,
+        q, weights, idx_pool, fp4_scales if packed_fp4 else idx_pool,
+        full_snap, valid, out,
         n_stage, ratio,
         q.stride(0), q.stride(1), q.stride(2),
         weights.stride(0), weights.stride(1),
         idx_pool.stride(0), idx_pool.stride(1),
+        (fp4_scales.stride(0) if packed_fp4 else 0),
+        (fp4_scales.stride(1) if packed_fp4 else 0),
         full_snap.stride(0), full_snap.stride(1),
         out.stride(0), out.stride(1),
         H=H, D=D,
         BLOCK_H=triton.next_power_of_2(H), BLOCK_T=BLOCK_T,
+        FP4=packed_fp4,
         num_warps=4, num_stages=2,
     )
     return out

--- a/python/sparklab/layers/moe.py
+++ b/python/sparklab/layers/moe.py
@@ -229,7 +229,15 @@ class OffloadMoELayer(MoELayer):
         router_logits: torch.Tensor | None = None,
     ):
         ctx = get_global_ctx()
-        if ctx.batch.uses_prefill_kernels:
+        # Speculative verification advances several consecutive positions, so its
+        # attention and recurrent-state mixers need prefill semantics. Its MoE is
+        # still a tiny decode-sized matrix (normally 2--4 rows), however. Sending
+        # those rows through the grouped prefill kernel pads every active expert to
+        # a full M block and makes verification more expensive than the target
+        # forwards it replaces. The routed decode kernel accepts M > 1 and keeps
+        # exactly the same token-local MoE computation without that padding.
+        short_replay = getattr(ctx.batch, "is_speculative_replay", False)
+        if ctx.batch.uses_prefill_kernels and not (ctx.batch.is_verify or short_replay):
             final_hidden_states = self.prefill_forward(hidden_states, router_logits)
         else:
             final_hidden_states = self.decode_forward(hidden_states, router_logits)
@@ -249,7 +257,8 @@ class OffloadMoELayer(MoELayer):
         rewrites expert ids into cache slot ids); pass a fresh tensor or a clone.
         """
         ctx = get_global_ctx()
-        if ctx.batch.uses_prefill_kernels:
+        short_replay = getattr(ctx.batch, "is_speculative_replay", False)
+        if ctx.batch.uses_prefill_kernels and not (ctx.batch.is_verify or short_replay):
             out = self._prefill_routed(hidden_states, topk_weights, topk_ids)
         else:
             out = self._decode_routed(hidden_states, topk_weights, topk_ids)

--- a/python/sparklab/models/blocks.py
+++ b/python/sparklab/models/blocks.py
@@ -27,6 +27,15 @@ class BaseLLMModel(ABC, BaseOP):
         """Stage model-specific inputs that must remain outside graph capture/replay."""
         return None
 
+    def begin_external_inputs(self, batch) -> None:
+        """Start asynchronous model inputs whose values depend only on the batch.
+
+        Engines call this before target-state bookkeeping and transformer execution.
+        Models may finish the work lazily at the layer that consumes it, or from
+        ``prepare_cuda_graph_inputs`` immediately before graph replay.
+        """
+        return None
+
 
 class GatedMLP(BaseOP):
     def __init__(self, config: ModelConfig):

--- a/python/sparklab/models/config.py
+++ b/python/sparklab/models/config.py
@@ -326,6 +326,7 @@ class ModelConfig:
     speculative_method: str = "none"
     speculative_tokens: int = 0
     draft_sample_method: str = "greedy"
+    dspark_confidence_threshold: float = 0.0
     # Generic execution-path capability flags (set by a model's parse_config) so the engine and
     # factories stay model-agnostic instead of branching on dsv4_args:
     single_stream_only: bool = False  # model runs one sequence at a time -> force bs=1

--- a/python/sparklab/models/deepseek_v4/args.py
+++ b/python/sparklab/models/deepseek_v4/args.py
@@ -23,6 +23,10 @@ class DeepseekV4Args:
     scale_fmt: Literal[None, "ue8m0"] = "ue8m0"
     expert_dtype: Literal[None, "fp4"] = "fp4"
     scale_dtype: Literal["fp32", "fp8"] = "fp8"
+    # Runtime cache representation. FP8 is true one-byte storage; BF16 keeps
+    # the historical quantize-then-dequantize representation.
+    kv_storage_dtype: Literal["bf16", "fp8"] = "bf16"
+    index_storage_dtype: Literal["bf16", "fp4"] = "bf16"
 
     # ----- shape -----
     vocab_size: int = 129280

--- a/python/sparklab/models/deepseek_v4/dspark.py
+++ b/python/sparklab/models/deepseek_v4/dspark.py
@@ -7,6 +7,8 @@ of anchor/noise queries is then refined by a sequential low-rank Markov bias.
 
 from __future__ import annotations
 
+import os
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -30,12 +32,31 @@ def draft_query_geometry(
     return anchor_pos, min(max_steps, page_end - anchor_pos)
 
 
+def confidence_prefix_length(
+    confidence_probs: torch.Tensor, threshold: float
+) -> int:
+    """Return the contiguous confident prefix, keeping at least one draft."""
+    if confidence_probs.numel() == 0:
+        return 0
+    if threshold <= 0:
+        return int(confidence_probs.numel())
+    below = torch.nonzero(confidence_probs < threshold, as_tuple=False)
+    return (
+        int(confidence_probs.numel())
+        if not below.numel()
+        else max(1, int(below[0, 0].item()))
+    )
+
+
 class DSparkDraft(nn.Module):
     def __init__(self, args: DeepseekV4Args, steps: int, sample_method: str):
         super().__init__()
         self.args = args
         self.steps = int(steps)
         self.sample_method = sample_method
+        self.confidence_threshold = float(
+            getattr(args, "confidence_threshold", 0.0)
+        )
         self.hc_mult = args.hc_mult
         self.norm_eps = args.norm_eps
         self.hc_eps = args.hc_eps
@@ -71,6 +92,44 @@ class DSparkDraft(nn.Module):
         )
         self._bound = False
         self.last_draft_probs: torch.Tensor | None = None
+        self.last_confidence_probs: torch.Tensor | None = None
+        self.profile_confidence = os.getenv(
+            "SPARKLAB_DSPARK_PROFILE_CONFIDENCE", "0"
+        ).strip().lower() in {"1", "true", "yes", "on"}
+        # Plain lazy tensors, not registered buffers: the model is constructed on
+        # ``meta`` and weights are assigned afterward, while these diagnostics need
+        # to be created directly on the confidence output's real CUDA device.
+        self._confidence_sum: torch.Tensor | None = None
+        self._confidence_min: torch.Tensor | None = None
+        self._confidence_max: torch.Tensor | None = None
+        self._confidence_count: torch.Tensor | None = None
+
+    def reset_confidence_stats(self) -> None:
+        if self._confidence_sum is None:
+            return
+        self._confidence_sum.zero_()
+        self._confidence_min.fill_(float("inf"))
+        self._confidence_max.fill_(float("-inf"))
+        self._confidence_count.zero_()
+
+    def confidence_stats(self) -> list[dict]:
+        if self._confidence_count is None:
+            return []
+        counts = self._confidence_count.tolist()
+        sums = self._confidence_sum.tolist()
+        mins = self._confidence_min.tolist()
+        maxs = self._confidence_max.tolist()
+        return [
+            {
+                "position": index + 1,
+                "count": count,
+                "mean": sums[index] / count,
+                "min": mins[index],
+                "max": maxs[index],
+            }
+            for index, count in enumerate(counts)
+            if count
+        ]
 
     def bind(self, pool, device: torch.device) -> None:
         if self._bound:
@@ -139,6 +198,7 @@ class DSparkDraft(nn.Module):
         self.bind(pool, pool.device)
         req = batch.reqs[0]
         self.last_draft_probs = None
+        self.last_confidence_probs = None
         if self.sample_method == "greedy" and not req.sampling_params.is_greedy:
             return None
         # ``next_token`` is the just-sampled anchor at device_len - 1.  Draft
@@ -190,8 +250,10 @@ class DSparkDraft(nn.Module):
         previous = anchor
         drafts = []
         draft_probs = []
+        markov_embeds = []
         for row in range(n_query):
             markov = F.embedding(previous, self.markov_w1)
+            markov_embeds.append(markov.squeeze(0))
             logits = base_logits[row : row + 1] + F.linear(markov, self.markov_w2)
             if req.sampling_params.is_greedy:
                 token = torch.argmax(logits, dim=-1)
@@ -205,7 +267,45 @@ class DSparkDraft(nn.Module):
             previous = token
         if draft_probs:
             self.last_draft_probs = torch.stack(draft_probs)
-        return torch.stack(drafts)
+        result = torch.stack(drafts)
+        threshold = self.confidence_threshold
+        if threshold > 0 or self.profile_confidence:
+            features = torch.cat(
+                (head_hidden[0].float(), torch.stack(markov_embeds).float()), dim=-1
+            )
+            confidence = torch.sigmoid(F.linear(features, self.confidence_weight)).squeeze(-1)
+            self.last_confidence_probs = confidence
+            if self._confidence_sum is None:
+                self._confidence_sum = torch.zeros(
+                    self.steps, dtype=torch.float32, device=confidence.device
+                )
+                self._confidence_min = torch.full(
+                    (self.steps,), float("inf"), device=confidence.device
+                )
+                self._confidence_max = torch.full(
+                    (self.steps,), float("-inf"), device=confidence.device
+                )
+                self._confidence_count = torch.zeros(
+                    self.steps, dtype=torch.int64, device=confidence.device
+                )
+            n_confidence = confidence.numel()
+            self._confidence_sum[:n_confidence].add_(confidence)
+            self._confidence_min[:n_confidence].copy_(
+                torch.minimum(self._confidence_min[:n_confidence], confidence)
+            )
+            self._confidence_max[:n_confidence].copy_(
+                torch.maximum(self._confidence_max[:n_confidence], confidence)
+            )
+            self._confidence_count[:n_confidence].add_(1)
+            # Verification must remain a contiguous prefix. Always keep one draft:
+            # the full parallel draft has already run, and an empty block would only
+            # add scheduler overhead without reducing target work below one token.
+            length = confidence_prefix_length(confidence, threshold)
+            if length < result.numel():
+                result = result[:length]
+                if self.last_draft_probs is not None:
+                    self.last_draft_probs = self.last_draft_probs[: result.numel()]
+        return result
 
 
-__all__ = ["DSparkDraft"]
+__all__ = ["DSparkDraft", "confidence_prefix_length", "draft_query_geometry"]

--- a/python/sparklab/models/deepseek_v4/model.py
+++ b/python/sparklab/models/deepseek_v4/model.py
@@ -267,6 +267,9 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
                 config.speculative_tokens,
                 getattr(config, "draft_sample_method", "greedy"),
             )
+            self._dspark.confidence_threshold = float(
+                getattr(config, "dspark_confidence_threshold", 0.0) or 0.0
+            )
         self._bound = False
 
     def _ensure_bound(self) -> None:
@@ -400,6 +403,16 @@ class DeepseekV4ForCausalLM(BaseLLMModel):
         probs = self._dspark.last_draft_probs
         self._dspark.last_draft_probs = None
         return probs
+
+    def reset_speculative_stats(self) -> None:
+        if self._dspark is not None:
+            self._dspark.reset_confidence_stats()
+
+    def speculative_stats(self) -> dict:
+        if self._dspark is None:
+            return {}
+        confidence = self._dspark.confidence_stats()
+        return {"confidence": confidence} if confidence else {}
 
 
 __all__ = ["Transformer", "DeepseekV4ForCausalLM"]

--- a/python/sparklab/models/qwen3_5_moe/gdn.py
+++ b/python/sparklab/models/qwen3_5_moe/gdn.py
@@ -178,7 +178,40 @@ class Qwen3_5GatedDeltaNet(BaseOP):
         z = z.reshape(total, self.num_v_heads, self.head_v_dim)
         li = pool.local_index(self.layer_id)
 
-        if not batch.uses_prefill_kernels:
+        if batch.is_verify or batch.is_speculative_replay:
+            # Verification and rejection replay are short continuations (normally
+            # 1--4 tokens), not prompt chunks. Keep the varlen convolution so consecutive
+            # tokens update one request's convolution state, then use the fused
+            # recurrent update kernel's native target-verify mode. The generic
+            # chunk GDN path launches the full WY/chunk pipeline and dominates
+            # latency at these tiny sequence lengths.
+            mixed = self._conv_prefill(
+                conv_in,
+                pool,
+                fla.cu_seqlens,
+                fla.cache_indices,
+                fla.has_initial_state,
+            )
+            qf, kf, vf = torch.split(
+                mixed, [self.key_dim, self.key_dim, self.value_dim], dim=-1
+            )
+            q = qf.reshape(1, total, self.num_k_heads, self.head_k_dim).to(dtype)
+            k = kf.reshape(1, total, self.num_k_heads, self.head_k_dim).to(dtype)
+            v = vf.reshape(1, total, self.num_v_heads, self.head_v_dim).to(dtype)
+            core_out = gdn_decode_fla(
+                q,
+                k,
+                v,
+                a,
+                b,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                state_source=pool.recurrent_states[li],
+                indices=fla.cache_indices,
+                cu_seqlens=fla.cu_seqlens,
+                scale=self.head_k_dim ** -0.5,
+            )
+        elif not batch.uses_prefill_kernels:
             # Fused fla decode kernel: gating + in-kernel l2norm + recurrent update +
             # per-request state read/write-by-index, all in one kernel (no gather/scatter,
             # no clone, no external l2norm). q/k stay at num_k_heads (kernel handles GQA).

--- a/python/sparklab/models/qwen3_5_moe/gdn_kernels.py
+++ b/python/sparklab/models/qwen3_5_moe/gdn_kernels.py
@@ -42,22 +42,24 @@ def gdn_prefill_chunk_fla(
 
 
 def gdn_decode_fla(
-    q: torch.Tensor,        # [1, B, num_k_heads, head_k_dim] bf16 (NOT GQA-expanded)
-    k: torch.Tensor,        # [1, B, num_k_heads, head_k_dim] bf16
-    v: torch.Tensor,        # [1, B, num_v_heads, head_v_dim] bf16
-    a: torch.Tensor,        # [B, num_v_heads] raw
-    b: torch.Tensor,        # [B, num_v_heads] raw
+    q: torch.Tensor,        # [1, total, num_k_heads, head_k_dim] bf16 (NOT GQA-expanded)
+    k: torch.Tensor,        # [1, total, num_k_heads, head_k_dim] bf16
+    v: torch.Tensor,        # [1, total, num_v_heads, head_v_dim] bf16
+    a: torch.Tensor,        # [total, num_v_heads] raw
+    b: torch.Tensor,        # [total, num_v_heads] raw
     *,
     A_log: torch.Tensor,        # [num_v_heads]
     dt_bias: torch.Tensor,      # [num_v_heads]
     state_source: torch.Tensor,  # [num_slots, num_v_heads, head_k_dim, head_v_dim] fp32 (in place)
-    indices: torch.Tensor,      # [B] int32 slot id per request
-    cu_seqlens: torch.Tensor,   # [B+1] query indptr (arange) from FLAMetadata
+    indices: torch.Tensor,      # [num_seqs] int32 slot id per request
+    cu_seqlens: torch.Tensor,   # [num_seqs+1] query indptr from FLAMetadata
     scale: float,
 ) -> torch.Tensor:
     """Fused sigmoid-gating gated-delta-rule decode (vendored fla triton kernel): gating +
     in-kernel l2norm + recurrent update + state read/write-by-index in one kernel, with no
-    external gating or gather/scatter/clone glue. Returns [B, num_v, V]."""
+    external gating or gather/scatter/clone glue. Supports one token per
+    sequence for ordinary decode and a short multi-token sequence for target
+    verification. Returns [total, num_v, V]."""
     from sparklab.kernels.fla import fused_sigmoid_gating_delta_rule_update
 
     o = fused_sigmoid_gating_delta_rule_update(
@@ -68,8 +70,8 @@ def gdn_decode_fla(
         initial_state_indices=indices,  # already int32 (built int32 in the scheduler)
         scale=scale, use_qk_l2norm_in_kernel=True, cu_seqlens=cu_seqlens,
     )
-    # kernel returns o = [NK, *v.shape] then squeeze(NK) -> [1, B, num_v, V].
-    # o[0] -> [B, num_v, V] (all B decode tokens; o[0,0] would drop B>1).
+    # kernel returns o = [NK, *v.shape] then squeeze(NK) ->
+    # [1, total, num_v, V]. o[0] retains every packed token.
     return o[0]
 
 

--- a/python/sparklab/models/qwen3_5_moe/moe.py
+++ b/python/sparklab/models/qwen3_5_moe/moe.py
@@ -30,6 +30,18 @@ class _SharedExpert(BaseOP):
                 hidden_size, [intermediate_size, intermediate_size], has_bias=False
             )
             self.down_proj = Fp8BlockLinear(intermediate_size, hidden_size, has_bias=False)
+        elif shared_quant == "fp8_pertensor":
+            from sparklab.kernels.triton.fp8_pertensor_linear import (
+                Fp8PerTensorColMerged,
+                Fp8PerTensorLinear,
+            )
+
+            self.gate_up_proj = Fp8PerTensorColMerged(
+                hidden_size, [intermediate_size, intermediate_size], has_bias=False
+            )
+            self.down_proj = Fp8PerTensorLinear(
+                intermediate_size, hidden_size, has_bias=False
+            )
         elif shared_quant == "nvfp4" or getattr(config, "dense_quant", "none") == "nvfp4":
             # NVFP4 checkpoint: keep the shared expert's NVFP4 weights native (W4A16).
             from sparklab.kernels.triton.nvfp4_linear import Nvfp4DenseColMerged, Nvfp4DenseLinear

--- a/python/sparklab/models/qwen3_5_moe/mtp.py
+++ b/python/sparklab/models/qwen3_5_moe/mtp.py
@@ -12,6 +12,7 @@ from dataclasses import replace
 
 import torch
 
+from sparklab.core import get_global_ctx
 from sparklab.layers import (
     BaseOP,
     GemmaRMSNorm,
@@ -65,17 +66,35 @@ class _ResidentBf16MTPMoE(BaseOP):
 
     def forward(self, hidden: torch.Tensor) -> torch.Tensor:
         router_logits = self.gate.forward(hidden)
-        # The resident grouped GEMM may reuse its input storage.
-        shared_input = hidden.clone()
-        shared = self.shared_expert.forward(shared_input)
-        shared.mul_(torch.sigmoid(self.shared_expert_gate.forward(shared_input)))
+        # The shared branch finishes on the same stream before routed expert
+        # computation can reuse the input storage, so it does not need a clone.
+        shared = self.shared_expert.forward(hidden)
+        shared.mul_(torch.sigmoid(self.shared_expert_gate.forward(hidden)))
         weights, ids = fused_topk(
             hidden_states=hidden,
             gating_output=router_logits,
             topk=self.top_k,
             renormalize=True,
         )
-        return self.experts.routed_forward(hidden, weights, ids) + shared
+        batch = get_global_ctx().batch
+        if batch.uses_prefill_kernels and not batch.is_verify:
+            routed = self.experts.routed_forward(hidden, weights, ids)
+        else:
+            # MTP proposal rows are normally M=1 (and verification feedback is
+            # at most four rows). The generic grouped kernel pads every selected
+            # expert to BLOCK_SIZE_M=16; the decode kernel computes just the
+            # routed rows and allocates its output instead of overwriting input.
+            from sparklab.moe.fused import fused_experts_decode_impl
+
+            routed = fused_experts_decode_impl(
+                hidden,
+                self.experts.gate_up_proj,
+                self.experts.down_proj,
+                weights,
+                ids,
+            )
+            routed = self.experts._maybe_all_reduce(routed)
+        return routed + shared
 
 
 class _MTPDecoderLayer(BaseOP):

--- a/python/sparklab/models/qwen4_exp/__init__.py
+++ b/python/sparklab/models/qwen4_exp/__init__.py
@@ -6,10 +6,13 @@ from .weight import (
     load_nvfp4_expert_sources,
     load_nvfp4_expert_sources_parallel,
     setup_offload_expert_banks,
+    transform_ftw_weights,
+    transform_runtime_weights,
 )
 
 __all__ = [
     "Qwen4ExpForCausalLM", "copy_external_artifacts", "parse_config", "iter_weights",
     "load_nvfp4_expert_sources", "load_nvfp4_expert_sources_parallel",
     "setup_offload_expert_banks",
+    "transform_ftw_weights", "transform_runtime_weights",
 ]

--- a/python/sparklab/models/qwen4_exp/attention.py
+++ b/python/sparklab/models/qwen4_exp/attention.py
@@ -9,10 +9,9 @@ from sparklab.runtime.distributed import get_tp_info
 from sparklab.layers import (
     BaseOP,
     GemmaPlusOneRMSNorm,
-    LinearColParallelMerged,
-    LinearReplicated,
 )
 from sparklab.layers.rotary import get_rope
+from sparklab.models.quant_linear import make_col_merged_quant, make_replicated_quant
 from sparklab.utils import nvtx_annotate
 
 if TYPE_CHECKING:
@@ -33,17 +32,26 @@ class Qwen4ExpAttention(BaseOP):
         self.q_dim = self.num_q * self.head_dim
         self.kv_dim = self.num_kv * self.head_dim
         self._split = [2 * self.q_dim, self.kv_dim, self.kv_dim]
-        self.qkv_proj = LinearColParallelMerged(config.hidden_size, self._split, has_bias=False)
+        # Qwen4 checkpoint quantization describes routed experts independently
+        # from the publisher's BF16 dense tower. Never let expert_quant select a
+        # dense projection kernel here.
+        self.qkv_proj = make_col_merged_quant(
+            "none", config.attn_quant, config.hidden_size, self._split, has_bias=False
+        )
         self.q_norm = GemmaPlusOneRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = GemmaPlusOneRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.o_proj = LinearReplicated(self.q_dim, config.hidden_size, has_bias=False)
+        self.o_proj = make_replicated_quant(
+            "none", config.attn_quant, self.q_dim, config.hidden_size, has_bias=False
+        )
 
         self.index_n_heads = args.index_n_heads
         self.index_dim = args.index_head_dim
         self.index_q_dim = self.index_n_heads * self.index_dim
-        self.index_qk_proj = LinearReplicated(
-            config.hidden_size, self.index_q_dim + self.index_dim, has_bias=False
+        self.index_qk_proj = make_replicated_quant(
+            "none", config.attn_quant, config.hidden_size,
+            self.index_q_dim + self.index_dim, has_bias=False
         )
+        self._pertensor_fp8 = config.attn_quant == "fp8_pertensor"
         self.index_q_norm = GemmaPlusOneRMSNorm(self.index_dim, eps=config.rms_norm_eps)
         self.index_k_norm = GemmaPlusOneRMSNorm(self.index_dim, eps=config.rms_norm_eps)
         self.rotary = get_rope(
@@ -93,7 +101,20 @@ class Qwen4ExpAttention(BaseOP):
             # Dense-budget selection ignores index queries. Retain only the raw key
             # projection so a request that later crosses the sparse threshold still
             # has the complete index-key history available.
-            raw_ik = F.linear(x, self.index_qk_proj.weight[-self.index_dim:]).contiguous()
+            if self._pertensor_fp8:
+                from sparklab.kernels.triton.fp8_pertensor_linear import (
+                    fp8_pertensor_linear,
+                )
+
+                raw_ik = fp8_pertensor_linear(
+                    x,
+                    self.index_qk_proj.weight[-self.index_dim:].contiguous(),
+                    self.index_qk_proj.weight_scale[-self.index_dim:].contiguous(),
+                ).contiguous()
+            else:
+                raw_ik = F.linear(
+                    x, self.index_qk_proj.weight[-self.index_dim:]
+                ).contiguous()
             index_q = None
         out = ctx.attn_backend.qsa_forward(
             q_flat.view(-1, self.num_q, self.head_dim),

--- a/python/sparklab/models/qwen4_exp/hyper.py
+++ b/python/sparklab/models/qwen4_exp/hyper.py
@@ -4,7 +4,8 @@ import os
 
 import torch
 import torch.nn.functional as F
-from sparklab.layers import BaseOP, LinearReplicated
+from sparklab.layers import BaseOP
+from sparklab.models.quant_linear import make_replicated_quant
 
 
 class GroupedPlusOneRMSNorm(BaseOP):
@@ -46,19 +47,22 @@ class Qwen4GatedResidual(BaseOP):
         eps: float,
         *,
         use_combine: bool = True,
+        quant: str = "none",
     ):
         self.hidden_size = hidden_size
         self.hc_count = hc_count
         self.width = hidden_size * hc_count
         self.hc_norm = GroupedPlusOneRMSNorm(self.width, hidden_size, eps)
-        self.input_mix_weight_down = LinearReplicated(
-            self.width, hc_lowrank, has_bias=False
+        self.input_mix_weight_down = make_replicated_quant(
+            "none", quant, self.width, hc_lowrank, has_bias=False
         )
-        self.input_mix_weight_up = LinearReplicated(
-            hc_lowrank, self.width, has_bias=False
+        self.input_mix_weight_up = make_replicated_quant(
+            "none", quant, hc_lowrank, self.width, has_bias=False
         )
         self.block_inject_weight = (
-            LinearReplicated(self.width, hc_count, has_bias=False) if use_combine else None
+            make_replicated_quant(
+                "none", quant, self.width, hc_count, has_bias=False
+            ) if use_combine else None
         )
         self._fused = os.getenv(
             "SPARKLAB_DISABLE_QWEN4_HYPER_FUSION", "0"

--- a/python/sparklab/models/qwen4_exp/model.py
+++ b/python/sparklab/models/qwen4_exp/model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import torch
@@ -35,6 +37,7 @@ class Qwen4ExpDecoderLayer(BaseOP):
                 conv_kernel_size=group.conv_kernel_dim,
                 rms_norm_eps=config.rms_norm_eps,
                 layer_id=layer_id,
+                attn_quant=config.attn_quant,
                 output_gate_activation=args.output_gate_activation,
             )
         else:
@@ -45,10 +48,12 @@ class Qwen4ExpDecoderLayer(BaseOP):
             if layer_id in args.ple_layer_ids else None
         )
         self.attn_hyper_connection = Qwen4GatedResidual(
-            config.hidden_size, args.hc_count, args.hc_lowrank, config.rms_norm_eps
+            config.hidden_size, args.hc_count, args.hc_lowrank, config.rms_norm_eps,
+            quant=config.attn_quant,
         )
         self.mlp_hyper_connection = Qwen4GatedResidual(
-            config.hidden_size, args.hc_count, args.hc_lowrank, config.rms_norm_eps
+            config.hidden_size, args.hc_count, args.hc_lowrank, config.rms_norm_eps,
+            quant=config.attn_quant,
         )
 
     @nvtx_annotate("Layer_{}", layer_id_field="_layer_id")
@@ -75,7 +80,7 @@ class Qwen4ExpModel(BaseOP):
         ])
         self.hyper_connection_mixer = Qwen4GatedResidual(
             config.hidden_size, args.hc_count, args.hc_lowrank,
-            config.rms_norm_eps, use_combine=False,
+            config.rms_norm_eps, use_combine=False, quant=config.attn_quant,
         )
         self._hc_count = args.hc_count
 
@@ -99,8 +104,17 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
         )
         # Private so BaseOP's strict target state dict remains unchanged. The
         # standalone sidecar is loaded explicitly after the target + expert cache.
+        # The standalone MTP sidecar has its own native expert representation and
+        # BF16 dense tensors. Keep that independent from target-only runtime
+        # requantization until the sidecar ships corresponding scale metadata.
+        mtp_config = replace(
+            config,
+            attn_quant="none",
+            dense_quant="none",
+            shared_expert_quant="none",
+        )
         self._mtp = (
-            Qwen4ExpMultiTokenPredictor(config)
+            Qwen4ExpMultiTokenPredictor(mtp_config)
             if int(getattr(config, "speculative_tokens", 0) or 0) else None
         )
         self._mtp_steps = int(getattr(config, "speculative_tokens", 0) or 0)
@@ -127,6 +141,16 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
             if self._mtp_path is None:
                 raise RuntimeError("Qwen4 MTP sidecar path was not prepared")
             self._mtp.load_sidecar(self._mtp_path, self.model.embed_tokens.weight.device)
+
+    def begin_external_inputs(self, batch) -> None:
+        # Opt in until a checkpoint with multiple/later PLE layers provides enough
+        # transformer work to hide the thread handoff. The current Qwen3.8 artifact
+        # has one early PLE layer and its controlled GB10 result was neutral.
+        if os.getenv("SPARKLAB_QWEN4_ASYNC_PLE", "0") != "1":
+            return
+        for layer in self.model.layers.op_list:
+            if layer.ple is not None:
+                layer.ple.begin_external_input(batch)
 
     def prepare_cuda_graph_inputs(self, batch) -> None:
         for layer in self.model.layers.op_list:

--- a/python/sparklab/models/qwen4_exp/ple.py
+++ b/python/sparklab/models/qwen4_exp/ple.py
@@ -6,13 +6,14 @@ import os
 import re
 import struct
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 
 import torch
 import torch.nn.functional as F
 from sparklab.core import get_global_ctx
-from sparklab.layers import BaseOP, LinearReplicated
+from sparklab.layers import BaseOP
+from sparklab.models.quant_linear import make_replicated_quant
 
 from .hyper import GroupedPlusOneRMSNorm
 
@@ -69,6 +70,11 @@ class _ZeroNGramStore:
 
     def lookup(self, ids: torch.Tensor) -> torch.Tensor:
         return torch.zeros((*ids.shape, self.dim), dtype=torch.bfloat16)
+
+    def lookup_async(self, ids: torch.Tensor) -> Future[torch.Tensor]:
+        future: Future[torch.Tensor] = Future()
+        future.set_result(self.lookup(ids))
+        return future
 
 
 class _CachedRowStore:
@@ -134,6 +140,10 @@ class _CachedRowStore:
             table = table.to(torch.bfloat16)
         return table.index_select(0, inverse).view(*ids.shape, self.dim)
 
+    def lookup_async(self, ids: torch.Tensor) -> Future[torch.Tensor]:
+        """Schedule one complete lookup while preserving per-store row parallelism."""
+        return self._async_executor.submit(self._lookup, ids)
+
 
 class SafetensorNGramStore(_CachedRowStore):
     """Random-row reader over the split n-gram tensors without mmap page retention."""
@@ -187,9 +197,11 @@ class SafetensorNGramStore(_CachedRowStore):
             total += rows
         self.total_rows = total
         self._executor = ThreadPoolExecutor(max_workers=min(16, expected_parts))
+        self._async_executor = ThreadPoolExecutor(max_workers=1)
         self._init_row_cache()
 
     def close(self) -> None:
+        self._async_executor.shutdown(wait=True)
         self._executor.shutdown(wait=True)
         for fd in self._fds:
             os.close(fd)
@@ -230,9 +242,11 @@ class RawNGramStore(_CachedRowStore):
             raise ValueError(f"invalid Qwen4 FTW n-gram manifest: {manifest}")
         self._fd = os.open(Path(model_path) / manifest["file"], os.O_RDONLY)
         self._executor = ThreadPoolExecutor(max_workers=16)
+        self._async_executor = ThreadPoolExecutor(max_workers=1)
         self._init_row_cache()
 
     def close(self) -> None:
+        self._async_executor.shutdown(wait=True)
         self._executor.shutdown(wait=True)
         os.close(self._fd)
         self._row_cache.clear()
@@ -403,7 +417,7 @@ class DiskNGramEmbedding(BaseOP):
             blocks.append(torch.remainder(mixed[:, None], sizes) + offsets)
         return torch.cat(blocks, -1)
 
-    def forward(self, batch) -> torch.Tensor:
+    def _row_ids(self, batch) -> torch.Tensor:
         if self._store is None:
             raise RuntimeError("Qwen4 disk n-gram embedding was not bound before weight load")
         all_ids, offset = [], 0
@@ -414,7 +428,18 @@ class DiskNGramEmbedding(BaseOP):
                 req.input_ids, req.cached_len, req.device_len, current
             ))
             offset += length
-        rows = self._store.lookup(torch.cat(all_ids, 0))
+        return torch.cat(all_ids, 0)
+
+    def begin(self, batch) -> Future[torch.Tensor]:
+        """Compute history hashes now and issue disk reads without waiting for them."""
+        return self._store.lookup_async(self._row_ids(batch))
+
+    @staticmethod
+    def finish(future: Future[torch.Tensor]) -> torch.Tensor:
+        return future.result().flatten(-2)
+
+    def forward(self, batch) -> torch.Tensor:
+        rows = self._store.lookup(self._row_ids(batch))
         return rows.flatten(-2)
 
 
@@ -432,8 +457,13 @@ class Qwen4PLE(BaseOP):
         self.hc_count = args.hc_count
         self.width = self.hidden_size * self.hc_count
         self.embedding = DiskNGramEmbedding(args, config.vocab_size, ple_index)
-        self.key_proj = LinearReplicated(args.ple_embed_dim, self.width, has_bias=False)
-        self.value_proj = LinearReplicated(args.ple_embed_dim, self.hidden_size, has_bias=False)
+        self.key_proj = make_replicated_quant(
+            "none", config.attn_quant, args.ple_embed_dim, self.width, has_bias=False
+        )
+        self.value_proj = make_replicated_quant(
+            "none", config.attn_quant, args.ple_embed_dim,
+            self.hidden_size, has_bias=False
+        )
         self.norm_key = GroupedPlusOneRMSNorm(self.width, self.hidden_size, config.rms_norm_eps)
         self.norm_query = GroupedPlusOneRMSNorm(self.width, self.hidden_size, config.rms_norm_eps)
         self.norm_conv = GroupedPlusOneRMSNorm(self.width, self.hidden_size, config.rms_norm_eps)
@@ -441,27 +471,57 @@ class Qwen4PLE(BaseOP):
         self.dilation = args.ngram_size
         self.state_len = (args.ple_conv_kernel_size - 1) * self.dilation
         self._capture_embed: torch.Tensor | None = None
+        self._capture_host: torch.Tensor | None = None
+        self._pending_embed: Future[torch.Tensor] | None = None
 
     def bind(self, model_path: str, *, dummy: bool = False) -> None:
         self.embedding.bind(model_path, dummy=dummy)
 
-    def prepare_cuda_graph_inputs(self, batch) -> None:
-        """Resolve disk-backed PLE rows before graph replay into a stable GPU buffer."""
-        embed = self.embedding.forward(batch)
+    def begin_external_input(self, batch) -> None:
+        if getattr(self, "_pending_embed", None) is not None:
+            raise RuntimeError("Qwen4 PLE external input was begun twice without consumption")
+        self._pending_embed = self.embedding.begin(batch)
+
+    def _finish_external_input(self, batch) -> torch.Tensor:
+        pending = getattr(self, "_pending_embed", None)
+        if pending is None:
+            return self.embedding.forward(batch)
+        self._pending_embed = None
+        return self.embedding.finish(pending)
+
+    def _copy_to_stable_device(self, embed: torch.Tensor) -> torch.Tensor:
+        """Copy a completed lookup through stable host/device graph buffers."""
         weight = self.key_proj.weight
-        if self._capture_embed is None:
+        capture = getattr(self, "_capture_embed", None)
+        if capture is None:
+            # This is an activation buffer, not a weight buffer. Resident FP8
+            # projection weights still consume BF16 PLE rows through W8A16.
             self._capture_embed = torch.empty(
-                embed.shape, dtype=weight.dtype, device=weight.device
+                embed.shape, dtype=torch.bfloat16, device=weight.device
             )
-        if (
-            embed.shape[-1] != self._capture_embed.shape[-1]
-            or embed.shape[0] > self._capture_embed.shape[0]
-        ):
+            capture = self._capture_embed
+        if embed.shape[-1] != capture.shape[-1] or embed.shape[0] > capture.shape[0]:
             raise RuntimeError(
                 "Qwen4 PLE CUDA graph input exceeds its stable buffer: "
-                f"got={tuple(embed.shape)}, capacity={tuple(self._capture_embed.shape)}"
+                f"got={tuple(embed.shape)}, capacity={tuple(capture.shape)}"
             )
-        self._capture_embed[: embed.shape[0]].copy_(embed)
+
+        if capture.device.type == "cuda":
+            host = getattr(self, "_capture_host", None)
+            if host is None:
+                self._capture_host = torch.empty(
+                    capture.shape, dtype=capture.dtype, device="cpu", pin_memory=True
+                )
+                host = self._capture_host
+            host[: embed.shape[0]].copy_(embed)
+            capture[: embed.shape[0]].copy_(host[: embed.shape[0]], non_blocking=True)
+        else:
+            capture[: embed.shape[0]].copy_(embed)
+        return capture[: embed.shape[0]]
+
+    def prepare_cuda_graph_inputs(self, batch) -> None:
+        """Resolve disk-backed PLE rows before graph replay into a stable GPU buffer."""
+        self._copy_to_stable_device(self._finish_external_input(batch))
 
     def _conv(self, x: torch.Tensor, batch) -> torch.Tensor:
         pool = get_global_ctx().linear_state_pool
@@ -521,7 +581,13 @@ class Qwen4PLE(BaseOP):
             # backing allocation.  Each graph reads only its static row prefix.
             embed = self._capture_embed[: hidden.shape[0]]
         else:
-            embed = self.embedding.forward(batch).to(hidden.device, dtype=hidden.dtype)
+            embed = self._finish_external_input(batch)
+            if hidden.device.type == "cuda":
+                # Stable pinned/device buffers also make eager host transfers
+                # non-blocking once the disk lookup completes.
+                embed = self._copy_to_stable_device(embed)
+            else:
+                embed = embed.to(hidden.device, dtype=hidden.dtype)
         key = self.norm_key.forward(self.key_proj.forward(embed)).view(
             -1, self.hc_count, self.hidden_size
         )

--- a/python/sparklab/models/qwen4_exp/weight.py
+++ b/python/sparklab/models/qwen4_exp/weight.py
@@ -38,6 +38,12 @@ _EXPERT_LAYER = re.compile(
 )
 _SHARD_RE = re.compile(r"ngram_embedding\.shard_(\d+)\.weight$")
 _MTP_FILE = "nvfp4_experts_mtp.safetensors"
+_NGRAM_MANIFEST = "qwen4_ngram.json"
+_NGRAM_PAYLOAD = "qwen4_ngram.bin"
+_NGRAM_DTYPES = {
+    "bfloat16": (torch.bfloat16, 2),
+    "float8_e4m3fn": (torch.float8_e4m3fn, 1),
+}
 _SKIP = (
     "model.visual.", "visual.", "mtp.",
 )
@@ -50,6 +56,81 @@ _FUSIONS = {
         ".linear_attn.in_proj_b.weight", ".linear_attn.in_proj_a.weight",
     ),
 }
+_FP8_MAX = 448.0
+_FP8_PROJECTION_SUFFIXES = (
+    ".self_attn.qkv_proj.weight",
+    ".self_attn.o_proj.weight",
+    ".self_attn.index_qk_proj.weight",
+    ".linear_attn.in_proj_qkvz.weight",
+    ".linear_attn.out_proj.weight",
+    ".mlp.shared_expert.gate_up_proj.weight",
+    ".mlp.shared_expert.down_proj.weight",
+    ".ple.key_proj.weight",
+    ".ple.value_proj.weight",
+)
+
+
+def _quant_fp8_per_row(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Stream one BF16 projection into the W8A16 resident representation."""
+    values = weight.float()
+    scale = (values.abs().amax(dim=1) / _FP8_MAX).clamp(min=1e-12)
+    quantized = (values / scale[:, None]).clamp(
+        -_FP8_MAX, _FP8_MAX
+    ).to(torch.float8_e4m3fn)
+    return quantized, scale.to(torch.float32)
+
+
+def _is_fp8_resident_projection(name: str, weight: torch.Tensor) -> bool:
+    if weight.ndim != 2 or not name.endswith(".weight"):
+        return False
+    return name.endswith(_FP8_PROJECTION_SUFFIXES) or "hyper_connection" in name
+
+
+def _transform_resident_weights(weights, config):
+    if getattr(config, "attn_quant", "none") != "fp8_pertensor":
+        yield from weights
+        return
+    linear = config.linear_attention_group()
+    qkvz_rows = None
+    if linear is not None:
+        key_dim = linear.num_key_heads * linear.key_head_dim
+        value_dim = linear.num_value_heads * linear.value_head_dim
+        qkvz_rows = 2 * key_dim + 2 * value_dim
+
+    for name, weight in weights:
+        if name.endswith(".linear_attn.in_proj.weight"):
+            if qkvz_rows is None or qkvz_rows >= weight.shape[0]:
+                raise ValueError(
+                    f"invalid Qwen4 GDN fusion {name}: shape={tuple(weight.shape)} "
+                    f"qkvz_rows={qkvz_rows}"
+                )
+            base = name.removesuffix("in_proj.weight")
+            qkvz, ba = weight[:qkvz_rows], weight[qkvz_rows:]
+            quantized, scale = _quant_fp8_per_row(qkvz)
+            yield base + "in_proj_qkvz.weight", quantized
+            yield base + "in_proj_qkvz.weight_scale", scale
+            yield base + "in_proj_ba.weight", ba
+            continue
+        if _is_fp8_resident_projection(name, weight):
+            if weight.dtype == torch.float8_e4m3fn:
+                # Idempotent for a future FTW conversion that stores native FP8.
+                yield name, weight
+            else:
+                quantized, scale = _quant_fp8_per_row(weight)
+                yield name, quantized
+                yield name.removesuffix(".weight") + ".weight_scale", scale
+            continue
+        yield name, weight
+
+
+def transform_runtime_weights(weights, config):
+    """Adapt legacy Qwen4 source/FTW tensors to the selected resident format."""
+    yield from _transform_resident_weights(weights, config)
+
+
+def transform_ftw_weights(weights, config):
+    """FTW counterpart used by the generic checkpoint replay path."""
+    yield from _transform_resident_weights(weights, config)
 
 
 def _rename(raw: str) -> str | None:
@@ -289,7 +370,140 @@ def _copy_file_atomic(source: str, destination: str) -> int:
     return size
 
 
-def copy_external_artifacts(model_path: str, out_dir: str, model_config) -> list[dict]:
+def _write_bf16_as_fp8(
+    src_fd: int,
+    dst_fd: int,
+    *,
+    source_offset: int,
+    rows: int,
+    dim: int,
+    chunk_rows: int,
+) -> int:
+    """Stream one contiguous BF16 matrix into an E4M3 payload."""
+    if chunk_rows <= 0:
+        raise ValueError("chunk_rows must be positive")
+    input_row_bytes = dim * 2
+    output_bytes = 0
+    for row_start in range(0, rows, chunk_rows):
+        count = min(chunk_rows, rows - row_start)
+        length = count * input_row_bytes
+        payload = os.pread(
+            src_fd,
+            length,
+            source_offset + row_start * input_row_bytes,
+        )
+        if len(payload) != length:
+            raise OSError(f"short Qwen4 n-gram read: {len(payload)}/{length}")
+        source = torch.frombuffer(bytearray(payload), dtype=torch.bfloat16)
+        quantized = source.to(torch.float8_e4m3fn).view(torch.uint8)
+        data = quantized.numpy().tobytes()
+        offset = 0
+        while offset < len(data):
+            written = os.write(dst_fd, data[offset:])
+            if written <= 0:
+                raise OSError(f"short Qwen4 n-gram write: {offset}/{len(data)}")
+            offset += written
+        output_bytes += offset
+        try:
+            os.posix_fadvise(
+                src_fd,
+                source_offset + row_start * input_row_bytes,
+                length,
+                os.POSIX_FADV_DONTNEED,
+            )
+        except OSError:
+            pass
+    return output_bytes
+
+
+def requantize_raw_ngram_artifact(
+    model_path: str,
+    out_dir: str,
+    *,
+    storage_dtype: str = "float8_e4m3fn",
+    chunk_rows: int = 65_536,
+) -> dict:
+    """Build a precision-reduced PLE overlay from an existing FTW side artifact.
+
+    The target directory contains only the replacement manifest and payload. It can
+    be copied over a hard-linked FTW clone without rewriting the model shards.
+    """
+    if storage_dtype not in _NGRAM_DTYPES:
+        raise ValueError(f"unsupported Qwen4 n-gram target dtype: {storage_dtype!r}")
+    source_dir = os.path.realpath(model_path)
+    destination = os.path.realpath(out_dir)
+    os.makedirs(destination, exist_ok=True)
+    manifest_path = os.path.join(source_dir, _NGRAM_MANIFEST)
+    with open(manifest_path, encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    source_dtype = str(manifest.get("dtype", ""))
+    if source_dtype not in _NGRAM_DTYPES:
+        raise ValueError(f"unsupported Qwen4 n-gram source dtype: {source_dtype!r}")
+    rows, dim = int(manifest["rows"]), int(manifest["dim"])
+    source_item_size = _NGRAM_DTYPES[source_dtype][1]
+    expected = rows * dim * source_item_size
+    if int(manifest.get("nbytes", -1)) != expected:
+        raise ValueError(f"invalid Qwen4 n-gram manifest: {manifest}")
+    source_file = os.path.join(source_dir, str(manifest["file"]))
+    if os.path.getsize(source_file) != expected:
+        raise ValueError(
+            f"Qwen4 n-gram payload size mismatch: {os.path.getsize(source_file)}/{expected}"
+        )
+
+    final_path = os.path.join(destination, _NGRAM_PAYLOAD)
+    temporary = final_path + ".tmp"
+    if source_dtype == storage_dtype:
+        _copy_file_atomic(source_file, final_path)
+        output_bytes = expected
+    elif source_dtype == "bfloat16" and storage_dtype == "float8_e4m3fn":
+        src_fd = os.open(source_file, os.O_RDONLY)
+        try:
+            with open(temporary, "wb", buffering=0) as out:
+                output_bytes = _write_bf16_as_fp8(
+                    src_fd,
+                    out.fileno(),
+                    source_offset=0,
+                    rows=rows,
+                    dim=dim,
+                    chunk_rows=chunk_rows,
+                )
+                os.fsync(out.fileno())
+                try:
+                    os.posix_fadvise(
+                        out.fileno(), 0, output_bytes, os.POSIX_FADV_DONTNEED
+                    )
+                except OSError:
+                    pass
+        finally:
+            os.close(src_fd)
+        os.replace(temporary, final_path)
+    else:
+        raise ValueError(
+            f"unsupported Qwen4 n-gram conversion: {source_dtype} -> {storage_dtype}"
+        )
+
+    result = {
+        **manifest,
+        "file": _NGRAM_PAYLOAD,
+        "dtype": storage_dtype,
+        "nbytes": output_bytes,
+        "source_dtype": source_dtype,
+        "quantization": "cast_rne" if source_dtype != storage_dtype else "preserve",
+    }
+    temp_manifest = os.path.join(destination, _NGRAM_MANIFEST + ".tmp")
+    with open(temp_manifest, "w", encoding="utf-8") as handle:
+        json.dump(result, handle, sort_keys=True)
+    os.replace(temp_manifest, os.path.join(destination, _NGRAM_MANIFEST))
+    return result
+
+
+def copy_external_artifacts(
+    model_path: str,
+    out_dir: str,
+    model_config,
+    *,
+    ngram_dtype: str = "preserve",
+) -> list[dict]:
     """Extract the PLE table into one precision-preserving random-read file.
 
     This streams exact safetensors data ranges in kernel space: no tensor is
@@ -309,7 +523,9 @@ def copy_external_artifacts(model_path: str, out_dir: str, model_config) -> list
     if [p[0] for p in parts] != list(range(args.split_ngram_parts)):
         raise ValueError("Qwen4 external artifact is missing split n-gram tensors")
 
-    final_path = os.path.join(out_dir, "qwen4_ngram.bin")
+    if ngram_dtype not in {"preserve", "float8_e4m3fn"}:
+        raise ValueError(f"unsupported Qwen4 n-gram target dtype: {ngram_dtype!r}")
+    final_path = os.path.join(out_dir, _NGRAM_PAYLOAD)
     temporary = final_path + ".tmp"
     total_rows = total_bytes = 0
     storage_dtype = None
@@ -324,7 +540,11 @@ def copy_external_artifacts(model_path: str, out_dir: str, model_config) -> list
                 meta = header[name]
                 if meta["dtype"] not in dtype_bytes or len(meta["shape"]) != 2:
                     raise ValueError(f"unexpected Qwen4 n-gram tensor {name}: {meta}")
-                manifest_dtype, item_size = dtype_bytes[meta["dtype"]]
+                source_dtype, item_size = dtype_bytes[meta["dtype"]]
+                manifest_dtype = (
+                    "float8_e4m3fn" if ngram_dtype == "float8_e4m3fn"
+                    else source_dtype
+                )
                 if storage_dtype is None:
                     storage_dtype = manifest_dtype
                 elif storage_dtype != manifest_dtype:
@@ -334,19 +554,37 @@ def copy_external_artifacts(model_path: str, out_dir: str, model_config) -> list
                 expected = int(meta["shape"][0]) * int(meta["shape"][1]) * item_size
                 if length != expected:
                     raise ValueError(f"invalid Qwen4 n-gram byte length for {name}")
-                _copy_range(fd, out.fileno(), 8 + header_size + begin, length)
+                rows = int(meta["shape"][0])
+                dim = int(meta["shape"][1])
+                if source_dtype == manifest_dtype:
+                    _copy_range(fd, out.fileno(), 8 + header_size + begin, length)
+                    written = length
+                elif source_dtype == "bfloat16" and manifest_dtype == "float8_e4m3fn":
+                    written = _write_bf16_as_fp8(
+                        fd,
+                        out.fileno(),
+                        source_offset=8 + header_size + begin,
+                        rows=rows,
+                        dim=dim,
+                        chunk_rows=65_536,
+                    )
+                else:
+                    raise ValueError(
+                        f"unsupported Qwen4 n-gram conversion: "
+                        f"{source_dtype} -> {manifest_dtype}"
+                    )
                 # Keep the destination from becoming dirty page-cache pressure on unified
                 # memory. Commit and evict each part before copying the next one; source
                 # pages are evicted below.
                 os.fdatasync(out.fileno())
                 try:
                     os.posix_fadvise(
-                        out.fileno(), total_bytes, length, os.POSIX_FADV_DONTNEED
+                        out.fileno(), total_bytes, written, os.POSIX_FADV_DONTNEED
                     )
                 except OSError:
                     pass
-                total_rows += int(meta["shape"][0])
-                total_bytes += length
+                total_rows += rows
+                total_bytes += written
                 try:
                     os.posix_fadvise(fd, 8 + header_size + begin, length, os.POSIX_FADV_DONTNEED)
                 except OSError:
@@ -364,7 +602,7 @@ def copy_external_artifacts(model_path: str, out_dir: str, model_config) -> list
         "nbytes": total_bytes,
         "parts": args.split_ngram_parts,
     }
-    manifest_path = os.path.join(out_dir, "qwen4_ngram.json")
+    manifest_path = os.path.join(out_dir, _NGRAM_MANIFEST)
     temp_manifest = manifest_path + ".tmp"
     with open(temp_manifest, "w", encoding="utf-8") as handle:
         json.dump(manifest, handle, sort_keys=True)
@@ -389,5 +627,6 @@ __all__ = [
     "iter_weights",
     "load_nvfp4_expert_sources",
     "load_nvfp4_expert_sources_parallel",
+    "requantize_raw_ngram_artifact",
     "setup_offload_expert_banks",
 ]

--- a/python/sparklab/models/weight.py
+++ b/python/sparklab/models/weight.py
@@ -225,6 +225,7 @@ def load_weight(
     device: torch.device,
     *,
     include_moe_experts: bool = True,
+    model_config=None,
 ) -> Iterator[Tuple[str, torch.Tensor]]:
     # FTW checkpoint: dense weights are stored post-iter_weights, so we replay them
     # model-agnostically instead of re-running the per-model reader. Which tensors exist is
@@ -239,7 +240,8 @@ def load_weight(
         # stack. Vision is opt-in (default OFF, see vision_load_enabled): when it is off the
         # model never builds the tower, so replaying those tensors would trip load_state_dict's
         # strict unexpected-key check. Skip them here to match the model the engine built.
-        config, spec = _spec_for_model_path(model_path)
+        parsed_config, spec = _spec_for_model_path(model_path)
+        config = model_config if model_config is not None else parsed_config
         weights = iter_ftw_weights(model_path)
         transform = _model_override(spec, "transform_ftw_weights")
         if transform is not None:
@@ -256,14 +258,19 @@ def load_weight(
             yield name, tensor
         return
 
-    _config, spec = _spec_for_model_path(model_path)
+    parsed_config, spec = _spec_for_model_path(model_path)
+    config = model_config if model_config is not None else parsed_config
     iter_weights = _load_attr(spec.module, spec.iter_weights)
-    yield from iter_weights(
+    weights = iter_weights(
         model_path,
         device,
         include_moe_experts=include_moe_experts,
         include_non_moe=True,
     )
+    transform = _model_override(spec, "transform_runtime_weights")
+    if transform is not None:
+        weights = transform(weights, config)
+    yield from weights
 
 
 def load_moe_expert_sources(

--- a/python/sparklab/moe/offload_cache.py
+++ b/python/sparklab/moe/offload_cache.py
@@ -179,6 +179,8 @@ class OffloadMoeCache:
         self.layer_counts = torch.zeros(
             (self.num_layers,), dtype=torch.int32, device=self.device
         )
+        self._reserved_layer_quotas: dict[int, int] = {}
+        self.layer_quotas = self._equal_layer_quotas(self.cache_size)
         self.active_mask = torch.zeros((self.num_experts,), dtype=torch.int32, device=self.device)
         self.evict_slots = torch.empty((self.num_experts,), dtype=torch.int32, device=self.device)
         self.src_indices = torch.empty((self.num_experts,), dtype=torch.int32, device=self.device)
@@ -492,6 +494,7 @@ class OffloadMoeCache:
         self.sparse_prefill_fallback_layers = 0
         self.shared_expert_overlap_calls = 0
         self._hit_d2d_fallback_logged = False  # geometry changed; re-log if still unusable
+        self.layer_quotas = self._layer_quotas_for_size(cache_size)
         # 5. Re-evaluate prefill overlap against the new size.
         if self.prefill_overlap and cache_size < 2 * self.num_experts:
             logger.warning(
@@ -501,6 +504,73 @@ class OffloadMoeCache:
             self.prefill_overlap = False
         if self.prefill_overlap:
             self._init_prefill_overlap_buffers()
+
+    def _equal_layer_quotas(self, cache_size: int) -> torch.Tensor:
+        base, extra = divmod(cache_size, self.num_layers)
+        values = [base + (layer < extra) for layer in range(self.num_layers)]
+        return torch.tensor(values, dtype=torch.int32, device=self.device)
+
+    def _layer_quotas_for_size(self, cache_size: int) -> torch.Tensor:
+        if not self._reserved_layer_quotas:
+            return self._equal_layer_quotas(cache_size)
+        reserved = sum(self._reserved_layer_quotas.values())
+        regular_ids = [
+            layer for layer in range(self.num_layers)
+            if layer not in self._reserved_layer_quotas
+        ]
+        if reserved + len(regular_ids) > cache_size:
+            raise ValueError(
+                "reserved layer quotas leave fewer than one slot for each other layer: "
+                f"reserved={reserved}, cache_size={cache_size}, other_layers={len(regular_ids)}"
+            )
+        values = [0] * self.num_layers
+        if regular_ids:
+            base, extra = divmod(cache_size - reserved, len(regular_ids))
+            for index, layer in enumerate(regular_ids):
+                values[layer] = base + (index < extra)
+        for layer, quota in self._reserved_layer_quotas.items():
+            values[layer] = quota
+        if any(value > self.num_experts for value in values):
+            raise ValueError(
+                "layer cache quota exceeds the number of experts in one layer: "
+                f"max={max(values)}, experts={self.num_experts}"
+            )
+        return torch.tensor(values, dtype=torch.int32, device=self.device)
+
+    def reserve_layer_slots(self, layer_ids: tuple[int, ...], slots: int) -> None:
+        """Give selected layers an aggregate protected layer-LRU quota."""
+        if self.cache_policy != "layer_lru":
+            raise ValueError("layer slot reservations require cache_policy='layer_lru'")
+        ids = tuple(sorted(set(int(layer) for layer in layer_ids)))
+        if not ids or any(layer < 0 or layer >= self.num_layers for layer in ids):
+            raise ValueError(f"invalid reserved layer ids: {ids}")
+        if slots <= 0:
+            raise ValueError("reserved layer slots must be positive")
+        base, extra = divmod(int(slots), len(ids))
+        self.reserve_layer_quotas({
+            layer: base + (index < extra) for index, layer in enumerate(ids)
+        })
+
+    def reserve_layer_quotas(self, quotas: dict[int, int]) -> None:
+        """Set exact protected layer-LRU quotas for selected layers."""
+        if self.cache_policy != "layer_lru":
+            raise ValueError("layer slot reservations require cache_policy='layer_lru'")
+        normalized = {int(layer): int(quota) for layer, quota in quotas.items() if quota}
+        if not normalized or any(
+            layer < 0 or layer >= self.num_layers for layer in normalized
+        ):
+            raise ValueError(f"invalid reserved layer quotas: {normalized}")
+        if any(quota <= 0 or quota > self.num_experts for quota in normalized.values()):
+            raise ValueError(
+                f"layer quotas must be in [1, {self.num_experts}]: {normalized}"
+            )
+        self._reserved_layer_quotas = normalized
+        self.layer_quotas = self._layer_quotas_for_size(self.cache_size)
+        logger.info_rank0(
+            f"Reserved exact MoE cache quotas {normalized}; "
+            f"other-layer quota range="
+            f"{min(self.layer_quotas.tolist())}-{max(self.layer_quotas.tolist())}"
+        )
 
     def set_alphas(
         self, gate_up_alpha: torch.Tensor | None, down_alpha: torch.Tensor | None
@@ -1059,6 +1129,9 @@ class OffloadMoeCache:
             per_layer.append({
                 "layer": L,
                 "steps": s,
+                "active": a,
+                "missing": m,
+                "fetched": f,
                 "active_per_step": (a / s) if s else 0.0,
                 "missing_per_step": (m / s) if s else 0.0,
                 "miss_rate": (m / a) if a else 0.0,

--- a/python/sparklab/moe/offload_kernels.py
+++ b/python/sparklab/moe/offload_kernels.py
@@ -66,6 +66,7 @@ def layer_lru_ensure(cache, layer_id: int, expert_ids: torch.Tensor, *, stats=No
         cache.usage,
         cache.step,
         cache.layer_counts,
+        cache.layer_quotas,
         expert_ids,
         cache.src_indices,
         cache.evict_slots,
@@ -99,10 +100,7 @@ def _layer_lru_ensure_cpu(cache, layer_id: int, expert_ids: torch.Tensor, *, sta
         else:
             missing.append(expert)
     cache.num_indices.fill_(len(missing))
-    quotas = [
-        cache.cache_size // cache.num_layers + (lid < cache.cache_size % cache.num_layers)
-        for lid in range(cache.num_layers)
-    ]
+    quotas = cache.layer_quotas.tolist()
     for index, expert in enumerate(sorted(missing)):
         counts = cache.layer_counts.tolist()
         over = {lid for lid, count in enumerate(counts) if count > quotas[lid]}
@@ -143,6 +141,7 @@ def _layer_lru_ensure_kernel(
     usage_ptr,
     step_ptr,
     layer_counts_ptr,
+    layer_quotas_ptr,
     out_ptr,
     src_ptr,
     dst_ptr,
@@ -195,15 +194,13 @@ def _layer_lru_ensure_kernel(
         lids = tl.arange(0, BLOCK_L)
         lmask = lids < num_layers
         counts = tl.load(layer_counts_ptr + lids, mask=lmask, other=0)
-        quota_base: tl.constexpr = cache_size // num_layers
-        quota_extra: tl.constexpr = cache_size % num_layers
-        quotas = quota_base + (lids < quota_extra).to(tl.int32)
+        quotas = tl.load(layer_quotas_ptr + lids, mask=lmask, other=0)
 
         for i in tl.range(num_missing):
             owner = owners // num_experts
             owner_valid = cmask & (owners >= 0)
             owner_count = tl.load(layer_counts_ptr + owner, mask=owner_valid, other=0)
-            owner_quota = quota_base + (owner < quota_extra).to(tl.int32)
+            owner_quota = tl.load(layer_quotas_ptr + owner, mask=owner_valid, other=0)
             any_over = tl.sum((lmask & (counts > quotas)).to(tl.int32)) > 0
             eligible = (
                 cmask

--- a/python/sparklab/recipes/qwen3.6-35b-a3b.json
+++ b/python/sparklab/recipes/qwen3.6-35b-a3b.json
@@ -43,16 +43,17 @@
     "decode_tokens_per_second": 67.7870954092827,
     "warm_ttft_seconds": 0.32882933877408504,
     "evidence": "GB10-QWEN36-FAST-002",
-    "note": "The target-only profile passed the Fast gate with exact 32K recall, complete capability probes, bounded resident memory, and a zero-swap 60-minute endurance run. The artifact also includes an experimental native BF16 MTP shard; its measured GB10 profile is opt-in and slower than target-only decode."
+    "note": "The target-only profile passed the Fast gate with exact 32K recall, complete capability probes, bounded resident memory, and a zero-swap 60-minute endurance run. The artifact also includes an opt-in native BF16 MTP shard; the optimized width-two GB10 profile measured 74.42 tok/s on a 256-token probe, but has not repeated the full certification suite."
   },
   "evidence": [
     "GB10-QWEN36-FAST-001",
     "GB10-QWEN36-FAST-002",
-    "GB10-QWEN36-MTP-003"
+    "GB10-QWEN36-MTP-003",
+    "GB10-QWEN36-MTP-004"
   ],
   "limitations": [
     "The fixed five-problem AIME sample scored 0/5 because all five sampled runs exhausted the 2,048-token reasoning budget before emitting a final answer; Fast certification establishes serving correctness and operational behavior, not benchmark-quality certification.",
     "Certification covers text inference at batch one on one NVIDIA GB10.",
-    "Native MTP is experimental: width three reproduced the controlled target-only output hash but measured 8.57 tok/s versus 52.63 tok/s without speculation; widths one and two did not reproduce that hash."
+    "Native MTP remains opt-in: optimized width two measured 74.42 tok/s versus its 45.38 tok/s eager control, but its multi-token numerical path did not reproduce the single-token greedy output hash and the full certification suite has not been rerun."
   ]
 }

--- a/python/sparklab/runtime/engine/config.py
+++ b/python/sparklab/runtime/engine/config.py
@@ -100,6 +100,20 @@ class EngineConfig:
     speculative_method: str = "auto"
     speculative_tokens: int = 0
     draft_sample_method: str = "greedy"
+    # DSpark confidence-head probability floor. Zero keeps fixed-width verification.
+    dspark_confidence_threshold: float = 0.0
+    # Aggregate layer-LRU quota for DSpark's draft MoE layers. Zero keeps equal quotas.
+    dspark_draft_cache_slots: int = 0
+    # Optional comma-separated exact quotas for the DSpark draft layers. This is useful
+    # after a routing profile shows that only some draft layers need extra residency.
+    dspark_draft_cache_quotas: str = ""
+    # DeepSeek-V4 window and compressed KV pool representation.
+    dsv4_kv_storage: str = "bf16"
+    # DeepSeek-V4 Lightning-Indexer key representation.
+    dsv4_index_storage: str = "bf16"
+    # Qwen4-Exp resident projection representation. Routed experts and the PLE
+    # table retain their independently selected formats.
+    qwen4_dense_storage: str = "bf16"
 
     @cached_property
     def hf_config(self):

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -310,6 +310,35 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
             "greedy", "probabilistic"
         }:
             raise ValueError("unsupported --draft-sample-method")
+        confidence_threshold = float(
+            getattr(config, "dspark_confidence_threshold", 0.0) or 0.0
+        )
+        if not 0.0 <= confidence_threshold < 1.0:
+            raise ValueError("--dspark-confidence-threshold must be in [0, 1)")
+        draft_cache_slots = int(
+            getattr(config, "dspark_draft_cache_slots", 0) or 0
+        )
+        draft_cache_quotas = str(
+            getattr(config, "dspark_draft_cache_quotas", "") or ""
+        ).strip()
+        if draft_cache_slots < 0:
+            raise ValueError("--dspark-draft-cache-slots must be non-negative")
+        if (draft_cache_slots or draft_cache_quotas) and config.moe_cache_policy != "layer_lru":
+            raise ValueError(
+                "DSpark draft cache reservations require --moe-cache-policy layer_lru"
+            )
+        if draft_cache_quotas:
+            try:
+                quotas = tuple(int(value) for value in draft_cache_quotas.split(","))
+            except ValueError as exc:
+                raise ValueError(
+                    "--dspark-draft-cache-quotas must be comma-separated integers"
+                ) from exc
+            if len(quotas) != dsv4_args.n_mtp_layers or any(value < 0 for value in quotas):
+                raise ValueError(
+                    "--dspark-draft-cache-quotas must contain one non-negative quota "
+                    f"per draft layer ({dsv4_args.n_mtp_layers} values)"
+                )
         from sparklab.models.config import DSV4AttentionGroupConfig
 
         args = replace(dsv4_args, dspark_enabled=True)
@@ -327,6 +356,9 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
         object.__setattr__(
             model_config, "draft_sample_method", config.draft_sample_method
+        )
+        object.__setattr__(
+            model_config, "dspark_confidence_threshold", confidence_threshold
         )
         override("speculative_method", "dspark")
         # Correctness-first verification is eager and batch one. The DSpark
@@ -504,7 +536,8 @@ class Engine:
         self.config = config  # retained for runtime cache rebuild (rebuild_runtime_cache)
         self.mtp_stats = {
             "target_forwards": 0, "drafted": 0, "accepted": 0,
-            "outputs": 0,
+            "outputs": 0, "replay_calls": 0, "replay_tokens": 0,
+            "fast_carry_commits": 0,
         }
         # KV pool family fixed at construction from the model config: its classmethods own the
         # page-token geometry and cost arithmetic the engine needs BEFORE the pool exists
@@ -685,6 +718,7 @@ class Engine:
                 config.model_path,
                 self.device,
                 include_moe_experts=not is_offload_moe_backend(config.moe_backend),
+                model_config=config.model_config,
             ),
             device=self.device,
         )
@@ -876,6 +910,19 @@ class Engine:
             cache.set_bank_sources(banks.sources, layer_residency=banks.layer_residency)
             cache.set_alphas(banks.gate_up_alpha, banks.down_alpha)
             cache.disk_source = disk_source
+            if config.speculative_method == "dspark" and (
+                config.dspark_draft_cache_slots > 0 or config.dspark_draft_cache_quotas
+            ):
+                first = config.model_config.num_layers
+                count = config.model_config.dsv4_args.n_mtp_layers
+                draft_ids = tuple(range(first, first + count))
+                if config.dspark_draft_cache_quotas:
+                    values = tuple(
+                        int(value) for value in config.dspark_draft_cache_quotas.split(",")
+                    )
+                    cache.reserve_layer_quotas(dict(zip(draft_ids, values)))
+                else:
+                    cache.reserve_layer_slots(draft_ids, config.dspark_draft_cache_slots)
             if config.moe_preload_all:
                 cache.preload_all_from_disk()
         else:
@@ -888,6 +935,10 @@ class Engine:
         # Must be set before CUDA graph capture so the (device-side) accumulation ops are
         # captured and re-run on every decode replay.
         cache.collect_stats = config.moe_collect_stats
+        cache.collect_decode_freq = bool(
+            config.moe_collect_stats
+            and os.getenv("SPARKLAB_MOE_ROUTING_STATS", "0") == "1"
+        )
         # attach_offload_moe_cache walks for OffloadMoELayers, or defers to a model's
         # _iter_offload_moe_layers() hook when its MoE blocks are bespoke nn.Modules (DSV4).
         layers = attach_offload_moe_cache(self.model, cache)
@@ -1172,11 +1223,19 @@ class Engine:
 
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
         assert torch.cuda.current_stream() == self.stream
+        # Launch history-only external inputs as early as possible. Qwen4 uses
+        # this window to read all PLE layers concurrently while target-state
+        # snapshots and the first transformer layers execute.
+        self.model.begin_external_inputs(batch)
         if self.config.speculative_tokens and batch.is_prefill:
             self.mtp_stats = {
                 "target_forwards": 0, "drafted": 0, "accepted": 0,
-                "outputs": 0,
+                "outputs": 0, "replay_calls": 0, "replay_tokens": 0,
+                "fast_carry_commits": 0,
             }
+            reset_speculative_stats = getattr(self.model, "reset_speculative_stats", None)
+            if reset_speculative_stats is not None:
+                reset_speculative_stats()
         if self.config.speculative_tokens:
             self.mtp_stats["target_forwards"] += 1
         state_snapshots: list[tuple[int, int]] = []
@@ -1189,6 +1248,7 @@ class Engine:
                 kv_snapshot = self.kv_cache.snapshot_speculative(
                     batch.reqs[0].table_idx, start, start + batch.input_ids.numel()
                 )
+                self.kv_cache.begin_speculative_carry_capture()
             else:
                 pool = self.linear_state_pool
                 if pool is None:
@@ -1225,11 +1285,18 @@ class Engine:
             self.mtp_stats["accepted"] += accepted
             if accepted < drafts.numel():
                 if self.config.speculative_method == "dspark":
-                    self.kv_cache.restore_speculative(kv_snapshot)
+                    if accepted == 0:
+                        self.kv_cache.commit_first_speculative_carry(kv_snapshot)
+                        self.mtp_stats["fast_carry_commits"] += 1
+                    else:
+                        self.kv_cache.restore_speculative(kv_snapshot)
                 else:
                     live, scratch = state_snapshots[0]
                     self.linear_state_pool.copy_from(scratch, live)
-                self._replay_verified_prefix(batch, accepted + 1, start)
+                if self.config.speculative_method != "dspark" or accepted > 0:
+                    self._replay_verified_prefix(batch, accepted + 1, start)
+                    self.mtp_stats["replay_calls"] += 1
+                    self.mtp_stats["replay_tokens"] += accepted + 1
                 req.speculative_drafts = None
                 req.speculative_draft_probs = None
             else:
@@ -1319,6 +1386,7 @@ class Engine:
         replay = Batch(reqs=[replay_req], phase="prefill")
         replay.padded_reqs = replay.reqs
         replay.disable_state_tracking = True
+        replay.is_speculative_replay = True
         replay.input_ids = query
         replay.positions = batch.positions[:length]
         replay.out_loc = batch.out_loc[:length]
@@ -1553,10 +1621,43 @@ def _adjust_config(config: EngineConfig):
     model_config = config.model_config
     single_stream_only = getattr(model_config, "single_stream_only", False)
     is_dsv4 = getattr(model_config, "dsv4_args", None) is not None
+    is_qwen4 = getattr(model_config, "qwen4_exp_args", None) is not None
     has_swa_attention = getattr(model_config, "has_swa_attention", False)
     has_linear_attention = getattr(model_config, "has_linear_attention", False)
     is_moe = getattr(model_config, "is_moe", False)
     expert_quant = getattr(model_config, "expert_quant", "none")
+
+    if is_dsv4:
+        storage = str(getattr(config, "dsv4_kv_storage", "bf16"))
+        index_storage = str(getattr(config, "dsv4_index_storage", "bf16"))
+        if storage not in {"bf16", "fp8"}:
+            raise ValueError("--dsv4-kv-storage must be bf16 or fp8")
+        if index_storage not in {"bf16", "fp4"}:
+            raise ValueError("--dsv4-index-storage must be bf16 or fp4")
+        dsv4_args = model_config.dsv4_args
+        if hasattr(dsv4_args, "__dataclass_fields__"):
+            dsv4_args = replace(
+                dsv4_args,
+                kv_storage_dtype=storage,
+                index_storage_dtype=index_storage,
+            )
+            object.__setattr__(model_config, "dsv4_args", dsv4_args)
+        else:
+            # Lightweight config doubles in engine tests intentionally use a
+            # SimpleNamespace rather than the checkpoint dataclass.
+            setattr(dsv4_args, "kv_storage_dtype", storage)
+            setattr(dsv4_args, "index_storage_dtype", index_storage)
+
+    if is_qwen4:
+        dense_storage = str(getattr(config, "qwen4_dense_storage", "bf16"))
+        if dense_storage not in {"bf16", "fp8"}:
+            raise ValueError("--qwen4-dense-storage must be bf16 or fp8")
+        if dense_storage == "fp8":
+            # Select physical W8A16 modules. The runtime loader streams legacy
+            # BF16 FTW tensors into matching FP8 weights plus row scales.
+            object.__setattr__(model_config, "attn_quant", "fp8_pertensor")
+            object.__setattr__(model_config, "dense_quant", "fp8_pertensor")
+            object.__setattr__(model_config, "shared_expert_quant", "fp8_pertensor")
 
     _adjust_speculative_config(config, override)
 

--- a/python/sparklab/runtime/kvcache/dsv4_cost_model.py
+++ b/python/sparklab/runtime/kvcache/dsv4_cost_model.py
@@ -55,10 +55,14 @@ def ring_size_for_ratio(ratio: int) -> int:
 
 
 def _kv_bytes(args) -> int:
-    return args.head_dim * _BF16_BYTES
+    width = 1 if getattr(args, "kv_storage_dtype", "bf16") == "fp8" else _BF16_BYTES
+    return args.head_dim * width
 
 
 def _index_bytes(args) -> int:
+    if getattr(args, "index_storage_dtype", "bf16") == "fp4":
+        # Two E2M1 codes per byte plus one fp32 scale per 32-value block.
+        return args.index_head_dim // 2 + args.index_head_dim // 32 * _FP32_BYTES
     return args.index_head_dim * _BF16_BYTES
 
 

--- a/python/sparklab/runtime/kvcache/dsv4_paged_pool.py
+++ b/python/sparklab/runtime/kvcache/dsv4_paged_pool.py
@@ -161,11 +161,20 @@ class DSV4PagedKVCache(BaseKVCachePool):
         P: int = 128,
         n_scratch: int = 1,
     ) -> None:
-        assert dtype == torch.bfloat16, "KV pools are bf16 (fp4/fp8 is an in-place round-trip)"
+        assert dtype == torch.bfloat16, "DSV4 compute dtype must be bf16"
         self.args = args
         self.sizes = sizes
         self._device = device
         self._dtype = dtype
+        storage = getattr(args, "kv_storage_dtype", "bf16")
+        if storage not in {"bf16", "fp8"}:
+            raise ValueError(f"unsupported DSV4 KV storage: {storage}")
+        self._kv_storage_dtype = (
+            torch.float8_e4m3fn if storage == "fp8" else torch.bfloat16
+        )
+        self._index_storage_dtype = getattr(args, "index_storage_dtype", "bf16")
+        if self._index_storage_dtype not in {"bf16", "fp4"}:
+            raise ValueError(f"unsupported DSV4 index storage: {self._index_storage_dtype}")
         self.P = P
         self._n_layers = args.runtime_n_layers
         self.head_dim = args.head_dim
@@ -178,6 +187,11 @@ class DSV4PagedKVCache(BaseKVCachePool):
         # write), so the masked per-row scatter is graph-safe (no host sync, no -1 index, no
         # cross-row collision). One per running request row.
         self.n_scratch = int(n_scratch)
+        # The verified anchor's carry can be committed directly on a first-draft
+        # rejection, avoiding a full transformer replay.
+        self._speculative_first_carries: list[
+            tuple[CompressStateRing, torch.Tensor, torch.Tensor]
+        ] = []
 
         # Logical full-loc currency: ONE mapping from the virtual full-token index space to window
         # slots; cmp/idx rows derive arithmetically (full_loc // ratio), the state ring off the
@@ -193,7 +207,8 @@ class DSV4PagedKVCache(BaseKVCachePool):
         """(Re)allocate every physical buffer for the CURRENT ``self.sizes``. Shared by __init__
         and the in-place ``rebuild`` (identity-preserving, like HybridSWAKVCache.rebuild -- the
         CacheManager/engine/ctx all hold THIS object)."""
-        sizes, device, dtype = self.sizes, self._device, self._dtype
+        sizes, device = self.sizes, self._device
+        kv_dtype = self._kv_storage_dtype
         self.cmp_scratch_base = []
         self.idx_scratch_base = []
         self.full_to_window = torch.full(
@@ -207,7 +222,7 @@ class DSV4PagedKVCache(BaseKVCachePool):
 
         # Window KV: every layer.
         self.window_pool: list[torch.Tensor] = [
-            torch.zeros(sizes.n_win_slots, self.head_dim, device=device, dtype=dtype)
+            torch.zeros(sizes.n_win_slots, self.head_dim, device=device, dtype=kv_dtype)
             for _ in range(self._n_layers)
         ]
 
@@ -217,6 +232,7 @@ class DSV4PagedKVCache(BaseKVCachePool):
         # the indexer's own compressor -- a separate pool, no collision.
         self.cmp_pool: list[torch.Tensor | None] = []
         self.idx_pool: list[torch.Tensor | None] = []
+        self.idx_scale_pool: list[torch.Tensor | None] = []
         self.state_ring: list[CompressStateRing | None] = []
         self.indexer_state_ring: list[CompressStateRing | None] = []
         for L in range(self._n_layers):
@@ -224,6 +240,7 @@ class DSV4PagedKVCache(BaseKVCachePool):
             if ratio == 0:
                 self.cmp_pool.append(None)
                 self.idx_pool.append(None)
+                self.idx_scale_pool.append(None)
                 self.state_ring.append(None)
                 self.indexer_state_ring.append(None)
                 self.cmp_scratch_base.append(None)
@@ -233,7 +250,8 @@ class DSV4PagedKVCache(BaseKVCachePool):
             self.cmp_scratch_base.append(sizes.cmp_blocks[L])
             self.cmp_pool.append(
                 torch.zeros(
-                    sizes.cmp_blocks[L] + self.n_scratch, self.head_dim, device=device, dtype=dtype
+                    sizes.cmp_blocks[L] + self.n_scratch, self.head_dim,
+                    device=device, dtype=kv_dtype
                 )
             )
             if ratio == 4:
@@ -241,10 +259,23 @@ class DSV4PagedKVCache(BaseKVCachePool):
                 self.idx_pool.append(
                     torch.zeros(
                         sizes.idx_blocks[L] + self.n_scratch,
-                        self.index_head_dim,
+                        self.index_head_dim // (2 if self._index_storage_dtype == "fp4" else 1),
                         device=device,
-                        dtype=dtype,
+                        dtype=(
+                            torch.uint8
+                            if self._index_storage_dtype == "fp4"
+                            else torch.bfloat16
+                        ),
                     )
+                )
+                self.idx_scale_pool.append(
+                    torch.zeros(
+                        sizes.idx_blocks[L] + self.n_scratch,
+                        self.index_head_dim // 32,
+                        device=device,
+                        dtype=torch.float32,
+                    )
+                    if self._index_storage_dtype == "fp4" else None
                 )
                 # Indexer compressor ring: index_head_dim, overlap, ring_size=8.
                 self.indexer_state_ring.append(
@@ -258,6 +289,7 @@ class DSV4PagedKVCache(BaseKVCachePool):
                 )
             else:
                 self.idx_pool.append(None)
+                self.idx_scale_pool.append(None)
                 self.indexer_state_ring.append(None)
                 self.idx_scratch_base.append(None)
 
@@ -447,7 +479,7 @@ class DSV4PagedKVCache(BaseKVCachePool):
 
         assert self._paged_params is not None, "rebuild before _init_paged_state"
         self.sizes = sizes
-        self.window_pool = self.cmp_pool = self.idx_pool = None
+        self.window_pool = self.cmp_pool = self.idx_pool = self.idx_scale_pool = None
         self.state_ring = self.indexer_state_ring = None
         self.full_to_window = None
         gc.collect()
@@ -555,17 +587,32 @@ class DSV4PagedKVCache(BaseKVCachePool):
 
     # ----- specialized writes -----
     def store_window(self, k: torch.Tensor, layer_id: int, window_slot: torch.Tensor) -> None:
-        self.window_pool[layer_id].index_copy_(0, window_slot, k.to(self._dtype))
+        pool = self.window_pool[layer_id]
+        value = k.to(pool.dtype)
+        if pool.dtype == torch.float8_e4m3fn:
+            pool.view(torch.uint8).index_copy_(0, window_slot, value.view(torch.uint8))
+        else:
+            pool.index_copy_(0, window_slot, value)
 
     def store_compressed(self, kv: torch.Tensor, layer_id: int, cmp_slot: torch.Tensor) -> None:
         pool = self.cmp_pool[layer_id]
         assert pool is not None, f"layer {layer_id} (ratio 0) has no compressed pool"
-        pool.index_copy_(0, cmp_slot, kv.to(self._dtype))
+        value = kv.to(pool.dtype)
+        if pool.dtype == torch.float8_e4m3fn:
+            pool.view(torch.uint8).index_copy_(0, cmp_slot, value.view(torch.uint8))
+        else:
+            pool.index_copy_(0, cmp_slot, value)
 
     def store_indexer(self, k: torch.Tensor, layer_id: int, idx_slot: torch.Tensor) -> None:
         pool = self.idx_pool[layer_id]
         assert pool is not None, f"layer {layer_id} has no indexer pool (only ratio-4)"
-        pool.index_copy_(0, idx_slot, k.to(self._dtype))
+        scales = self.idx_scale_pool[layer_id]
+        if scales is not None:
+            from sparklab.kernels.triton.dsv4.fp4_cache import pack_fp4_rows
+
+            pack_fp4_rows(k, idx_slot, pool, scales)
+        else:
+            pool.index_copy_(0, idx_slot, k.to(self._dtype))
 
     def snapshot_speculative(self, table_idx: int, start: int, end: int):
         """Snapshot only compressor carry blocks touched by speculative verification."""
@@ -604,6 +651,31 @@ class DSV4PagedKVCache(BaseKVCachePool):
                 )
         return snapshots
 
+    def begin_speculative_carry_capture(self) -> None:
+        self._speculative_first_carries.clear()
+
+    def capture_first_speculative_carry(
+        self,
+        ring: CompressStateRing,
+        page_base: torch.Tensor,
+        block: torch.Tensor,
+    ) -> None:
+        if page_base.numel() and block.numel():
+            rows = page_base[:1, None] + torch.arange(
+                ring.ring_size, device=self._device
+            )[None, :]
+            self._speculative_first_carries.append(
+                (ring, rows.flatten(), block[0].clone())
+            )
+
+    def commit_first_speculative_carry(self, snapshots) -> None:
+        """Restore old rings, then commit the already-computed anchor carry."""
+        self.restore_speculative(snapshots)
+        for ring, rows, values in self._speculative_first_carries:
+            ring.buffer.index_copy_(0, rows, values)
+            ring._clear_scratch()
+        self._speculative_first_carries.clear()
+
     @staticmethod
     def restore_speculative(snapshots) -> None:
         for ring, rows, values in snapshots:
@@ -615,6 +687,9 @@ class DSV4PagedKVCache(BaseKVCachePool):
         n += sum(t.numel() * t.element_size() for t in self.window_pool)
         n += sum(t.numel() * t.element_size() for t in self.cmp_pool if t is not None)
         n += sum(t.numel() * t.element_size() for t in self.idx_pool if t is not None)
+        n += sum(
+            t.numel() * t.element_size() for t in self.idx_scale_pool if t is not None
+        )
         n += sum(
             r.buffer.numel() * r.buffer.element_size()
             for r in self.state_ring

--- a/python/sparklab/runtime/scheduler/scheduler.py
+++ b/python/sparklab/runtime/scheduler/scheduler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from typing import TYPE_CHECKING, List, NamedTuple, NoReturn, Set, Tuple, TypeAlias
 
 import torch
@@ -415,12 +417,20 @@ class Scheduler(SchedulerIOMixin):
             rate = stats["accepted"] / drafted if drafted else 0.0
             logger.info_rank0(
                 "MTP summary: steps=%d, accepted=%d/%d (%.1f%%), "
-                "outputs=%d, target_forwards=%d, outputs/target=%.2f",
+                "outputs=%d, target_forwards=%d, outputs/target=%.2f, "
+                "replays=%d/%d, fast_commits=%d",
                 speculative_tokens,
                 stats["accepted"], drafted, 100.0 * rate,
                 stats["outputs"], stats["target_forwards"],
                 stats["outputs"] / max(stats["target_forwards"], 1),
+                stats.get("replay_calls", 0), stats.get("replay_tokens", 0),
+                stats.get("fast_carry_commits", 0),
             )
+            speculative_stats = getattr(self.engine.model, "speculative_stats", None)
+            if speculative_stats is not None and (details := speculative_stats()):
+                logger.info_rank0(
+                    "DSpark stats: " + json.dumps(details, separators=(",", ":"))
+                )
         # Stamp each reply with the post-batch KV page occupancy so the frontend (shell
         # status bar) can show live KV usage without a separate query.
         used, total = self._kv_usage_pages()
@@ -436,6 +446,10 @@ class Scheduler(SchedulerIOMixin):
             moe_cache = getattr(engine, "moe_offload_cache", None)
             if moe_cache is not None and moe_cache.collect_stats and any(m.finished for m in reply):
                 moe_stats = moe_cache.decode_miss_stats()
+                moe_stats["per_layer"] = moe_cache.decode_miss_stats_per_layer()["per_layer"]
+                routing = moe_cache.decode_routing_stats()
+                if routing:
+                    moe_stats["routing"] = routing
                 if moe_cache.disk_source is not None:
                     moe_stats["disk"] = moe_cache.disk_source.stats()
             mamba_used, mamba_total = mamba_slots or (0, 0)

--- a/python/sparklab/serving/args.py
+++ b/python/sparklab/serving/args.py
@@ -339,6 +339,50 @@ def parse_args(
         default=ServerArgs.draft_sample_method,
         help="Draft sampling/verification rule for speculative decoding.",
     )
+    parser.add_argument(
+        "--dspark-confidence-threshold",
+        type=float,
+        default=ServerArgs.dspark_confidence_threshold,
+        help=(
+            "Truncate DSpark verification at the first draft whose confidence "
+            "probability falls below this value; 0 disables adaptive truncation."
+        ),
+    )
+    parser.add_argument(
+        "--dspark-draft-cache-slots",
+        type=int,
+        default=ServerArgs.dspark_draft_cache_slots,
+        help=(
+            "Aggregate layer-LRU quota reserved for DSpark draft layers; 0 uses "
+            "equal per-layer quotas (requires --moe-cache-policy layer_lru)."
+        ),
+    )
+    parser.add_argument(
+        "--dspark-draft-cache-quotas",
+        default=ServerArgs.dspark_draft_cache_quotas,
+        help=(
+            "Comma-separated exact layer-LRU quotas for the DSpark draft layers "
+            "(for example 160,115,115); overrides --dspark-draft-cache-slots."
+        ),
+    )
+    parser.add_argument(
+        "--dsv4-kv-storage",
+        choices=("bf16", "fp8"),
+        default=ServerArgs.dsv4_kv_storage,
+        help="Physical storage for DeepSeek-V4 window/compressed KV pools.",
+    )
+    parser.add_argument(
+        "--dsv4-index-storage",
+        choices=("bf16", "fp4"),
+        default=ServerArgs.dsv4_index_storage,
+        help="Physical storage for DeepSeek-V4 Lightning-Indexer keys.",
+    )
+    parser.add_argument(
+        "--qwen4-dense-storage",
+        choices=("bf16", "fp8"),
+        default=ServerArgs.qwen4_dense_storage,
+        help="Physical storage for Qwen4-Exp resident projection weights.",
+    )
 
     parser.add_argument(
         "--num-tokenizer",

--- a/tests/kernels/test_dsv4_indexer_decode.py
+++ b/tests/kernels/test_dsv4_indexer_decode.py
@@ -98,6 +98,33 @@ def test_per_row_valid(pool):
         assert torch.isinf(got[i, v:]).all()
 
 
+def test_packed_fp4_reader_matches_explicit_dequantized_cache():
+    from sparklab.kernels.triton.dsv4.fp4_cache import (
+        pack_fp4_rows,
+        unpack_fp4_rows,
+    )
+
+    rows = 256
+    g = torch.Generator(device="cuda").manual_seed(17)
+    source = torch.randn(rows, D, device="cuda", dtype=torch.bfloat16, generator=g)
+    packed = torch.empty(rows, D // 2, device="cuda", dtype=torch.uint8)
+    scales = torch.empty(rows, D // 32, device="cuda", dtype=torch.float32)
+    row_ids = torch.arange(rows, device="cuda", dtype=torch.int64)
+    pack_fp4_rows(source, row_ids, packed, scales)
+    dequantized = unpack_fp4_rows(packed, scales, row_ids, D)
+
+    n_stage = 64
+    q, w, snap, valid = _build([n_stage * RATIO - 1], n_stage, seed=19)
+    snap.random_(0, rows * RATIO, generator=g)
+    reference = indexer_decode_logits(
+        q, w, dequantized, snap, valid, n_stage, RATIO
+    )
+    fused = indexer_decode_logits(
+        q, w, packed, snap, valid, n_stage, RATIO, fp4_scales=scales
+    )
+    torch.testing.assert_close(fused, reference, rtol=0, atol=0)
+
+
 def test_cuda_graph_follows_valid(pool):
     """A captured graph must read the bound from device memory, not from capture time."""
     n_stage = 2048

--- a/tests/models/test_dsv4_dspark.py
+++ b/tests/models/test_dsv4_dspark.py
@@ -11,7 +11,10 @@ from sparklab.models.deepseek_v4.args import DeepseekV4Args
 from sparklab.models.deepseek_v4.config import parse_config
 from sparklab.models.deepseek_v4 import weight as dsv4_weight
 from sparklab.models.deepseek_v4.compress import Compressor
-from sparklab.models.deepseek_v4.dspark import draft_query_geometry
+from sparklab.models.deepseek_v4.dspark import (
+    confidence_prefix_length,
+    draft_query_geometry,
+)
 from sparklab.core import Context, SamplingParams
 from sparklab.runtime.distributed import set_tp_info, try_get_tp_info
 from sparklab.runtime.engine.engine import (
@@ -172,6 +175,14 @@ def test_dspark_query_block_starts_at_sampled_anchor_and_stays_in_page():
     assert draft_query_geometry(device_len=127, page_size=128, max_steps=7) == (126, 2)
     assert draft_query_geometry(device_len=128, page_size=128, max_steps=7) == (127, 1)
     assert draft_query_geometry(device_len=129, page_size=128, max_steps=7) == (128, 7)
+
+
+def test_dspark_confidence_truncates_to_contiguous_prefix_with_one_token_floor():
+    confidence = torch.tensor([0.91, 0.72, 0.19, 0.81])
+    assert confidence_prefix_length(confidence, 0.0) == 4
+    assert confidence_prefix_length(confidence, 0.5) == 2
+    assert confidence_prefix_length(confidence, 0.95) == 1
+    assert confidence_prefix_length(torch.empty(0), 0.5) == 0
 
 
 def test_speculative_verification_uses_unaligned_compressor_continuation(monkeypatch):

--- a/tests/models/test_qwen4_exp.py
+++ b/tests/models/test_qwen4_exp.py
@@ -13,7 +13,11 @@ from sparklab.attention.qsa import QSAAttnBackend, QSACaptureData, QSAMetadata
 from sparklab.models.qwen4_exp.config import parse_config
 from sparklab.models.qwen4_exp.hyper import GroupedPlusOneRMSNorm, Qwen4GatedResidual
 from sparklab.models.qwen4_exp.ple import DiskNGramEmbedding, Qwen4PLE, RawNGramStore
-from sparklab.models.qwen4_exp.weight import copy_external_artifacts
+from sparklab.models.qwen4_exp.weight import (
+    copy_external_artifacts,
+    requantize_raw_ngram_artifact,
+    transform_runtime_weights,
+)
 from sparklab.models.qwen4_exp.weight import _iter_experts_layer_order
 from sparklab.models.qwen4_exp.weight import iter_weights
 
@@ -217,6 +221,88 @@ def test_config_detects_inferact_modelopt_nvfp4_experts():
     assert config.expert_quant == "nvfp4"
     assert config.weight_block_size is None
     assert config.shared_expert_quant == "none"
+
+
+def test_runtime_fp8_transform_splits_gdn_and_quantizes_resident_projections():
+    config = parse_config(_config())
+    object.__setattr__(config, "attn_quant", "fp8_pertensor")
+    object.__setattr__(config, "dense_quant", "fp8_pertensor")
+    object.__setattr__(config, "shared_expert_quant", "fp8_pertensor")
+    linear = config.linear_attention_group()
+    key_dim = linear.num_key_heads * linear.key_head_dim
+    value_dim = linear.num_value_heads * linear.value_head_dim
+    qkvz_rows = 2 * key_dim + 2 * value_dim
+    total_rows = qkvz_rows + 2 * linear.num_value_heads
+    gdn = torch.linspace(-2, 2, total_rows * config.hidden_size).reshape(
+        total_rows, config.hidden_size
+    ).to(torch.bfloat16)
+    shared = torch.randn(32, config.hidden_size, dtype=torch.bfloat16)
+
+    transformed = dict(transform_runtime_weights(iter([
+        ("model.layers.0.linear_attn.in_proj.weight", gdn),
+        ("model.layers.0.mlp.shared_expert.gate_up_proj.weight", shared),
+        ("model.layers.0.mlp.gate.weight", torch.randn(8, 64)),
+    ]), config))
+
+    q = transformed["model.layers.0.linear_attn.in_proj_qkvz.weight"]
+    s = transformed["model.layers.0.linear_attn.in_proj_qkvz.weight_scale"]
+    assert q.dtype == torch.float8_e4m3fn and s.dtype == torch.float32
+    assert transformed["model.layers.0.linear_attn.in_proj_ba.weight"].shape[0] == 8
+    torch.testing.assert_close(
+        q.float() * s[:, None], gdn[:qkvz_rows].float(), rtol=0.07, atol=0.02
+    )
+    assert transformed[
+        "model.layers.0.mlp.shared_expert.gate_up_proj.weight"
+    ].dtype == torch.float8_e4m3fn
+    assert "model.layers.0.mlp.shared_expert.gate_up_proj.weight_scale" in transformed
+    # Routers remain BF16/FP32; they are small and numerically sensitive.
+    assert transformed["model.layers.0.mlp.gate.weight"].dtype == torch.float32
+
+
+def test_qwen4_fp8_config_builds_physical_fp8_projection_modules(monkeypatch):
+    from sparklab.kernels.triton.fp8_pertensor_linear import Fp8PerTensorLinear
+    from sparklab.layers import LinearColParallelMerged
+    from sparklab.models.qwen4_exp.attention import Qwen4ExpAttention
+    from sparklab.models.qwen4_exp.hyper import Qwen4GatedResidual
+
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.attention.get_tp_info",
+        lambda: SimpleNamespace(size=1),
+    )
+    monkeypatch.setattr(
+        "sparklab.layers.linear.get_tp_info", lambda: SimpleNamespace(size=1)
+    )
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.attention.get_rope",
+        lambda **_kwargs: object(),
+    )
+    config = parse_config(_config())
+    object.__setattr__(config, "attn_quant", "fp8_pertensor")
+    attention = Qwen4ExpAttention(config, 3)
+    hyper = Qwen4GatedResidual(64, 4, 8, 1e-6, quant="fp8_pertensor")
+    assert isinstance(attention.o_proj, Fp8PerTensorLinear)
+    assert attention.o_proj.weight.dtype == torch.float8_e4m3fn
+    assert isinstance(hyper.input_mix_weight_down, Fp8PerTensorLinear)
+
+    # Official block-FP8 metadata applies only to routed experts; without the
+    # explicit resident switch the publisher's dense attention remains BF16.
+    source = _config()
+    source.quantization_config = {
+        "quant_method": "fp8", "weight_block_size": [128, 128]
+    }
+    official = Qwen4ExpAttention(parse_config(source), 3)
+    assert isinstance(official.qkv_proj, LinearColParallelMerged)
+
+
+def test_fp8_ple_projection_keeps_external_activation_buffer_bf16():
+    ple = object.__new__(Qwen4PLE)
+    ple.key_proj = SimpleNamespace(
+        weight=torch.empty(4, 4, dtype=torch.float8_e4m3fn)
+    )
+    ple._capture_embed = None
+    ple._capture_host = None
+    output = ple._copy_to_stable_device(torch.randn(3, 4, dtype=torch.bfloat16))
+    assert output.dtype == torch.bfloat16
 
 
 def test_expert_wrapper_receives_conversion_streaming_controls(monkeypatch):
@@ -475,6 +561,68 @@ def test_external_ngram_artifact_streams_exact_rows(tmp_path):
     assert reads == 3
 
 
+def test_external_ngram_artifact_can_stream_bf16_as_fp8(tmp_path):
+    source, out = tmp_path / "source", tmp_path / "out"
+    source.mkdir()
+    out.mkdir()
+    values = torch.tensor([
+        [-3.25, -0.2, 0.0, 1.75],
+        [2.5, 4.25, 17.0, 31.0],
+    ], dtype=torch.bfloat16)
+    name = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.shard_0.weight"
+    save_file({name: values}, source / "model.safetensors")
+    (source / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {name: "model.safetensors"}}), encoding="utf-8"
+    )
+    args = SimpleNamespace(
+        split_ngram_parts=1, ple_embed_dim=64, ngram_size=3, heads_per_ngram=8
+    )
+
+    artifacts = copy_external_artifacts(
+        str(source), str(out), SimpleNamespace(qwen4_exp_args=args),
+        ngram_dtype="float8_e4m3fn",
+    )
+
+    manifest = json.loads((out / "qwen4_ngram.json").read_text(encoding="utf-8"))
+    assert artifacts[0]["dtype"] == "float8_e4m3fn"
+    assert manifest["nbytes"] == values.numel()
+    store = RawNGramStore(str(out), manifest, dim=4)
+    try:
+        got = store.lookup(torch.tensor([0, 1]))
+    finally:
+        store.close()
+    expected = values.to(torch.float8_e4m3fn).to(torch.bfloat16)
+    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+
+def test_requantize_existing_raw_ngram_artifact(tmp_path):
+    source, out = tmp_path / "source", tmp_path / "out"
+    source.mkdir()
+    values = torch.arange(24, dtype=torch.bfloat16).view(6, 4)
+    (source / "qwen4_ngram.bin").write_bytes(values.view(torch.uint8).numpy().tobytes())
+    (source / "qwen4_ngram.json").write_text(json.dumps({
+        "schema_version": "1.0", "file": "qwen4_ngram.bin",
+        "dtype": "bfloat16", "rows": 6, "dim": 4,
+        "nbytes": values.numel() * 2, "parts": 1,
+    }), encoding="utf-8")
+
+    manifest = requantize_raw_ngram_artifact(
+        str(source), str(out), chunk_rows=2
+    )
+
+    assert manifest["source_dtype"] == "bfloat16"
+    assert manifest["dtype"] == "float8_e4m3fn"
+    assert manifest["nbytes"] == values.numel()
+    store = RawNGramStore(str(out), manifest, dim=4)
+    try:
+        got = store.lookup(torch.arange(6))
+    finally:
+        store.close()
+    torch.testing.assert_close(
+        got, values.to(torch.float8_e4m3fn).to(torch.bfloat16), rtol=0, atol=0
+    )
+
+
 def test_external_artifacts_copy_optional_mtp_sidecar(tmp_path):
     source, out = tmp_path / "source", tmp_path / "out"
     source.mkdir()
@@ -713,6 +861,41 @@ def test_ple_stages_disk_row_into_stable_graph_input():
     ple.prepare_cuda_graph_inputs(SimpleNamespace())
     assert ple._capture_embed.data_ptr() == pointer
     torch.testing.assert_close(ple._capture_embed, replacement)
+
+
+def test_ple_consumes_prelaunched_lookup_without_sync_fallback():
+    ple = Qwen4PLE.__new__(Qwen4PLE)
+    rows = torch.arange(8, dtype=torch.bfloat16).view(1, 8)
+    calls = []
+
+    class Embedding:
+        def begin(self, batch):
+            from concurrent.futures import Future
+            calls.append(("begin", batch))
+            future = Future()
+            future.set_result(rows.view(1, 2, 4))
+            return future
+
+        def finish(self, future):
+            calls.append(("finish", future))
+            return future.result().flatten(-2)
+
+        def forward(self, _batch):
+            raise AssertionError("synchronous fallback must not run")
+
+    ple.embedding = Embedding()
+    ple.key_proj = SimpleNamespace(weight=torch.empty(4, 8, dtype=torch.bfloat16))
+    ple._capture_embed = None
+    ple._capture_host = None
+    ple._pending_embed = None
+    batch = SimpleNamespace()
+
+    ple.begin_external_input(batch)
+    assert [kind for kind, _ in calls] == ["begin"]
+    ple.prepare_cuda_graph_inputs(batch)
+
+    assert [kind for kind, _ in calls] == ["begin", "finish"]
+    torch.testing.assert_close(ple._capture_embed, rows)
 
 
 def test_ple_stages_smaller_batch_into_stable_graph_input_prefix():

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -143,6 +143,46 @@ def test_layer_lru_borrows_then_protects_each_layers_quota_cpu():
     assert cache.slot_for_id[0, 3] >= 0
 
 
+def test_layer_lru_supports_weighted_draft_layer_reservation_cpu():
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    cache = OffloadMoeCache(
+        num_layers=4,
+        num_experts=8,
+        cache_size=16,
+        device=torch.device("cpu"),
+        cache_policy="layer_lru",
+    )
+    cache.reserve_layer_slots((3,), 7)
+
+    assert cache.layer_quotas.tolist() == [3, 3, 3, 7]
+    for layer, count in enumerate(cache.layer_quotas.tolist()):
+        ids = torch.arange(count, dtype=torch.int32)
+        cache.ensure_experts(layer, ids)
+    assert cache.layer_counts.tolist() == [3, 3, 3, 7]
+
+    # Once full, a target miss replaces only within its own quota and cannot
+    # evict the separately protected draft working set.
+    before = cache.slot_for_id[3].clone()
+    cache.ensure_experts(0, torch.tensor([7], dtype=torch.int32))
+    assert torch.equal(cache.slot_for_id[3], before)
+
+
+def test_layer_lru_supports_exact_per_layer_quotas_cpu():
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    cache = OffloadMoeCache(
+        num_layers=4,
+        num_experts=8,
+        cache_size=20,
+        device=torch.device("cpu"),
+        cache_policy="layer_lru",
+    )
+    cache.reserve_layer_quotas({2: 7, 3: 5})
+
+    assert cache.layer_quotas.tolist() == [4, 4, 7, 5]
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_layer_lru_cuda_matches_cpu_reference():
     from sparklab.moe.offload_cache import OffloadMoeCache
@@ -748,6 +788,47 @@ def test_offload_moe_layer_decode_forward_uses_remapped_slot_ids(monkeypatch):
     assert calls["topk_weights"] is topk_weights
     assert calls["topk_ids"].dtype == torch.int32
     assert calls["topk_ids"].tolist() == [[5, 0]]
+
+
+@pytest.mark.parametrize(
+    ("uses_prefill_kernels", "is_verify", "is_speculative_replay", "expected"),
+    [
+        (True, False, False, "prefill"),
+        (True, True, False, "decode"),
+        (True, False, True, "decode"),
+        (False, False, False, "decode"),
+    ],
+)
+def test_offload_moe_verification_uses_small_batch_decode_kernel(
+    monkeypatch, uses_prefill_kernels, is_verify, is_speculative_replay, expected
+):
+    from types import SimpleNamespace
+
+    layer, _ = _make_layer_and_cache()
+    batch = SimpleNamespace(
+        uses_prefill_kernels=uses_prefill_kernels,
+        is_verify=is_verify,
+        is_speculative_replay=is_speculative_replay,
+    )
+    monkeypatch.setattr(
+        "sparklab.layers.moe.get_global_ctx",
+        lambda: SimpleNamespace(batch=batch),
+    )
+    calls = []
+    monkeypatch.setattr(
+        layer,
+        "prefill_forward",
+        lambda hidden, logits: calls.append("prefill") or hidden,
+    )
+    monkeypatch.setattr(
+        layer,
+        "decode_forward",
+        lambda hidden, logits: calls.append("decode") or hidden,
+    )
+
+    hidden = torch.randn(4, 8)
+    assert layer.forward(hidden, torch.randn(4, 4)) is hidden
+    assert calls == [expected]
 
 
 

--- a/tests/runtime/engine/test_speculative_attention_routing.py
+++ b/tests/runtime/engine/test_speculative_attention_routing.py
@@ -40,6 +40,21 @@ def test_hybrid_attention_routes_verification_through_multitoken_backend():
     assert decode.calls == []
 
 
+def test_hybrid_attention_keeps_speculative_replay_on_sequential_backend():
+    prefill = _RecordingBackend("prefill")
+    decode = _RecordingBackend("decode")
+    backend = HybridBackend(prefill, decode)
+    batch = _batch("prefill")
+    batch.is_speculative_replay = True
+
+    assert backend.prepare_metadata(batch) == "prefill"
+    assert backend.forward(
+        torch.empty(0), torch.empty(0), torch.empty(0), 0, batch
+    ) == "prefill"
+    assert [call[0] for call in prefill.calls] == ["prepare", "forward"]
+    assert decode.calls == []
+
+
 def test_hybrid_attention_keeps_single_token_decode_on_decode_backend():
     prefill = _RecordingBackend("prefill")
     decode = _RecordingBackend("decode")

--- a/tests/runtime/kvcache/test_dsv4_pool.py
+++ b/tests/runtime/kvcache/test_dsv4_pool.py
@@ -64,6 +64,56 @@ def test_pool_tiers_present_per_ratio():
                 assert pool.idx_pool[L] is None
 
 
+def test_fp8_storage_is_physical_for_window_and_compressed_tiers():
+    bf16_args = _args()
+    fp8_args = _args(kv_storage_dtype="fp8")
+    bf16_sizes = dsv4_pool_sizes(8, bf16_args, 0.5, P=P)
+    fp8_sizes = dsv4_pool_sizes(8, fp8_args, 0.5, P=P)
+    pool = DSV4PagedKVCache(
+        sizes=fp8_sizes, args=fp8_args, device=DEVICE,
+        dtype=torch.bfloat16, P=P,
+    )
+    bf16_pool = DSV4PagedKVCache(
+        sizes=bf16_sizes, args=bf16_args, device=DEVICE,
+        dtype=torch.bfloat16, P=P,
+    )
+
+    assert all(t.dtype == torch.float8_e4m3fn for t in pool.window_pool)
+    assert all(
+        t is None or t.dtype == torch.float8_e4m3fn for t in pool.cmp_pool
+    )
+    # Index storage is independently selectable and defaults to BF16.
+    assert all(t is None or t.dtype == torch.bfloat16 for t in pool.idx_pool)
+    assert pool.total_bytes() < bf16_pool.total_bytes()
+
+
+def test_fp4_index_storage_is_packed_and_roundtrips_quantized_rows():
+    from sparklab.kernels.triton.dsv4.fp4_cache import (
+        pack_fp4_rows, unpack_fp4_rows,
+    )
+
+    args = _args(index_storage_dtype="fp4")
+    sizes = dsv4_pool_sizes(8, args, 0.5, P=P)
+    pool = DSV4PagedKVCache(
+        sizes=sizes, args=args, device=DEVICE,
+        dtype=torch.bfloat16, P=P,
+    )
+    layer = RATIOS.index(4)
+    packed = pool.idx_pool[layer]
+    scales = pool.idx_scale_pool[layer]
+    assert packed.dtype == torch.uint8
+    assert packed.shape[1] == args.index_head_dim // 2
+    assert scales.shape[1] == args.index_head_dim // 32
+
+    lut = torch.tensor([0, .5, 1, 1.5, 2, 3, 4, 6], dtype=torch.float32)
+    codes = torch.arange(args.index_head_dim) % 8
+    values = (lut[codes] * 2.0).to(torch.bfloat16).view(1, -1)
+    rows = torch.tensor([3])
+    pack_fp4_rows(values, rows, packed, scales)
+    restored = unpack_fp4_rows(packed, scales, rows, args.index_head_dim)
+    torch.testing.assert_close(restored, values, rtol=0, atol=0)
+
+
 def test_state_ring_layout_and_dtype():
     pool, sizes, _ = _pool()
     for L, ratio in enumerate(RATIOS):

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -138,6 +138,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
         "GB10-QWEN36-FAST-001",
         "GB10-QWEN36-FAST-002",
         "GB10-QWEN36-MTP-003",
+        "GB10-QWEN36-MTP-004",
     )
     assert qwen36.runtime_artifact is not None
     assert qwen36.runtime_artifact.repo_id == "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW"


### PR DESCRIPTION
## Summary

- optimize Qwen3.6 MTP verification and rejection replay with decode-sized MoE and recurrent kernels
- publish versioned GB10 evidence for the opt-in two-draft profile and update model documentation
- include the preceding Qwen3.8 and DeepSeek V4 inference optimizations already developed on this branch

## Validation

- 23 focused Qwen/runtime/MoE/catalog tests passed
- 79 product-layer tests passed
- Python compilation and Ruff checks passed
- the broader MoE-focused run passed 51 tests; one unrelated GPU cache test was blocked by the local sparklab-kernel-cache 0.1.0 versus SparkLab 0.1.1 version mismatch

Signed-off commits satisfy the repository DCO requirement.