### PR TITLE
perf: accelerate Qwen3.8 MTP decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ a SparkLab support claim.
     <tr>
       <td><a href="https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW">Qwen3.8-Flash-Next</a></td>
       <td>125B LM + 55B auxiliary / 6B active</td>
-      <td>NVFP4 · FTW + MTP2</td>
+      <td>NVFP4 · FTW + MTP3</td>
       <td>Experimental</td>
-      <td align="right">22.16</td>
-      <td align="right">0.212</td>
+      <td align="right">30.67</td>
+      <td align="right">0.258</td>
       <td><a href="docs/models/qwen3.8-flash-next.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -44,9 +44,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
 - `results/GB10-QWEN38-NVFP4-OPT-003.json` records the current default concurrent
   profile: 16.84 single-stream decode tok/s, 0.306 s repeated-prompt TTFT, and
   61.79 aggregate tok/s at concurrency four.
-- `results/GB10-QWEN38-NVFP4-OPT-004.json` records the native MTP sweep. The selected
-  opt-in two-draft profile measured 20.31 decode tok/s and 0.212 s warm TTFT, a 34.2%
-  improvement over its controlled eager run with exact output parity.
+- `results/GB10-QWEN38-MTP-007.json` records the optimized native MTP sweep. The selected
+  three-draft profile measured 30.67 decode tok/s and 0.258 s warm TTFT, a 55.35%
+  improvement over its controlled target-only run; all three selected-profile trials
+  reproduced the same 128-token output hash.
 - `results/GB10-GLM53-NVFP4-001.json` records the GLM-5.3 Flash NVFP4
   complete-checkpoint probe: 4.46 decode tok/s and 5.760 s warm TTFT. Its corrected
   greedy probe reaches the reference answer; the broader quality gates remain outstanding.

--- a/benchmarks/gb10/results/GB10-QWEN38-MTP-007.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-MTP-007.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-MTP-007",
+  "status": "measured",
+  "date": "2026-09-02",
+  "recipe": {
+    "slug": "qwen3.8-flash-next",
+    "recipe_version": "0.8.0",
+    "revision": "103a7608316173ca6edd49929544244de7ffda70"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "d4a8a773b95917bcfadb8df48320880637955bc9",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "repository": "Inferact/Qwen3.8-Flash-Next-NVFP4",
+    "revision": "103a7608316173ca6edd49929544244de7ffda70",
+    "format": "ftw-nvfp4 + native MTP sidecar",
+    "quantization": "nvfp4",
+    "fingerprint": "47e11ddb878adf4c",
+    "ftw_bytes": 180433108992,
+    "mtp_sidecar_bytes": 1597441088
+  },
+  "workload": {
+    "single_stream": "greedy math reasoning, 96 prompt tokens, 128 completion tokens",
+    "client_path": "OpenAI-compatible streaming HTTP API",
+    "warmup_requests": 1,
+    "measured_trials": 3,
+    "prefix_reuse": "measured trials reused a validated 64-token hybrid-radix prefix"
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "expert_preload": "immutable-full",
+    "expert_cache_slots": 24576,
+    "attention_backend": "qsa",
+    "cache_type": "hybrid_radix",
+    "page_size": 16,
+    "kv_tokens": 131072,
+    "max_running_requests": 1,
+    "selected_speculative_tokens": 3,
+    "mtp_verification_cuda_graph": true,
+    "qwen_skinny_gemm": true
+  },
+  "metrics": {
+    "decode_tokens_per_second": 30.67455057137699,
+    "warm_ttft_seconds": 0.2582157750002807,
+    "target_only_decode_tokens_per_second": 19.74588417463281,
+    "target_only_warm_ttft_seconds": 0.2421086490030575,
+    "mtp1_decode_tokens_per_second": 25.188982018510814,
+    "mtp2_decode_tokens_per_second": 29.14647474154015,
+    "mtp3_decode_tokens_per_second": 30.67455057137699,
+    "mtp3_improvement_over_target_percent": 55.3466,
+    "mtp3_improvement_over_previous_published_percent": 51.058,
+    "mtp2_graph_kernel_off_control_tokens_per_second": 27.652113166802987,
+    "mtp2_skinny_gemm_improvement_percent": 5.4041,
+    "target_skinny_gemm_off_tokens_per_second": 17.21521224615549,
+    "long_context_control_tokens_per_second": 23.91390529824239,
+    "discarded_qsa_experiment_tokens_per_second": 23.281857113037265
+  },
+  "trials": {
+    "mtp2_tokens_per_second": [
+      29.335922846173638,
+      29.14647474154015,
+      29.066263901892306
+    ],
+    "mtp3_tokens_per_second": [
+      30.67455057137699,
+      30.61729237238865,
+      30.67477627724022
+    ],
+    "mtp3_warm_ttft_seconds": [
+      0.25978344499890227,
+      0.2582157750002807,
+      0.25412478399812244
+    ]
+  },
+  "speculative": {
+    "accepted_drafts": 83,
+    "drafted_tokens": 101,
+    "acceptance_rate": 0.822,
+    "outputs": 128,
+    "target_forwards": 45,
+    "outputs_per_target_forward": 2.84,
+    "replay_calls": 9,
+    "replay_tokens": 17
+  },
+  "validation": {
+    "checkpoint_checksum_verified": true,
+    "complete_checkpoint_loaded": true,
+    "native_mtp_weights_loaded": true,
+    "transactional_rejection_rollback": true,
+    "speculative_page_reclamation": true,
+    "mtp3_output_sha1": "6e5d26657cb6",
+    "all_mtp3_trials_deterministic": true,
+    "target_only_output_sha1": "6e494a88449b",
+    "exact_target_only_trace_parity": false,
+    "api_stream_completed": true,
+    "oom_count": 0,
+    "service_restarts": 0
+  },
+  "experiments": {
+    "retained": [
+      "Fixed-shape CUDA graph replay for dense-QSA MTP verification.",
+      "Decode MoE dispatch for small verification batches.",
+      "SM121-specialized BF16 skinny GEMM for measured Qwen3.8 projection shapes."
+    ],
+    "discarded": [
+      "Sparse-QSA index selection reuse was throughput-neutral at 4,193 prompt tokens.",
+      "Side-stream QSA index projection overlap reduced long-context throughput by 2.6%."
+    ]
+  },
+  "admission": {
+    "tier": "frontier",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "Three native MTP draft tokens improved controlled batch-one greedy decode throughput by 55.35% over the current target-only path.",
+      "The optimized 128-token MTP trace was deterministic across all three trials.",
+      "A clean-revision 60-minute endurance run remains outstanding."
+    ]
+  },
+  "source": {
+    "target_artifact": "/tmp/qwen38-target-current-control.json",
+    "target_kernel_off_artifact": "/tmp/qwen38-target-no-skinny-control.json",
+    "mtp1_artifact": "/tmp/qwen38-mtp-width1-candidate.json",
+    "mtp2_artifacts": "/tmp/qwen38-mtp-skinny-candidate-{1,2,3}.json",
+    "mtp3_artifacts": "/tmp/qwen38-mtp-width3-candidate{,-2,-3}.json",
+    "long_context_control": "/tmp/qwen38-mtp-long-no-qsaopts-1.json",
+    "long_context_discarded_experiment": "/tmp/qwen38-mtp-long-all-1.json",
+    "prior_evidence": "GB10-QWEN38-NVFP4-OPT-004"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The throughput sweep covers batch-one greedy generation only.",
+    "The selected MTP3 trace is deterministic but differs from the target-only 128-token trace because shape-dependent BF16 reductions can change near-tied greedy choices.",
+    "The installed sparklab-kernel-cache reports 0.1.0+cu130 while the source runtime reports 0.1.1; the version guard was explicitly bypassed for this source-tree benchmark.",
+    "The 64K context, parser, coding-agent, broad quality, and endurance gates were not rerun for this optimization evidence."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -34,11 +34,10 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW | `qwen3.8-27b` | Experimental | 8.83 | 0.144 |
-| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP2 | `qwen3.8-flash-next` | Experimental | 20.31 | 0.212 |
+| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 30.67 | 0.258 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 | `deepseek-v4` | Preview | 8.67 | 1.794 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 6.27 | 5.681 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
-| [GLM-5.2](https://huggingface.co/nvidia/GLM-5.2-NVFP4) | 753B total / 40B active | NVFP4 | `glm-5.2` | Experimental fallback | 0.80 | 2.570 |
 | [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
@@ -47,10 +46,6 @@ and Kimi K3 use pinned prebuilt artifacts with reproducible source-conversion pa
 Parameter counts come from model publishers, and performance values come from the
 evidence attached to each recipe. Certification applies only to that exact checkpoint
 and recipe version.
-
-The Qwen3.8-Flash-Next row reports its selected two-draft MTP profile. It is opt-in with
-`-- --speculative-tokens 2` and currently applies only to batch-one greedy requests;
-the default profile remains available for concurrent or sampled traffic.
 
 Qwen3.6's published FTW artifact includes its native BF16 MTP weights, but the portfolio
 row continues to report the certified target-only profile. The optimized two-draft path
@@ -63,7 +58,7 @@ it remains opt-in pending the full certification suite.
 |---|---|---|
 | Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Optimized native MTP2 reached 74.42 tok/s versus its 45.38 tok/s eager control; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json) |
 | Qwen3.8-27B | Passes Frontier speed, exact 64K recall, reasoning/tool parsing, and the coding-agent probe; the clean-revision 60-minute endurance gate remains outstanding. | [GB10-QWEN38-27B-001](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json) |
-| Qwen3.8-Flash-Next | The opt-in two-draft MTP profile measured 20.31 tok/s with exact eager-output parity; the default concurrent profile remains 16.84 single-stream tok/s. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-NVFP4-OPT-004](../benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json) |
+| Qwen3.8-Flash-Next | The selected MTP3 profile measured a three-trial median 30.67 tok/s at 0.258 s warm TTFT. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-MTP-007](../benchmarks/gb10/results/GB10-QWEN38-MTP-007.json) |
 | DeepSeek V4 Flash | GPU-first expert residency reaches 8.67 tok/s. Native DSpark remains opt-in because N=1 still trails target-only decoding with disk-backed experts on one GB10. | [GB10-DSV4-RESIDENCY-003](../benchmarks/gb10/results/GB10-DSV4-RESIDENCY-003.json) |
 | GLM-5.3 Flash | Passes Frontier speed; NVMe-sensitive TTFT and remaining certification gates keep it Experimental. | [GB10-GLM53-MHC-003](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json) |
 | GLM-5.2 | Below Frontier speed and recorded swap growth, so it remains Experimental. | [Experiment](../exps/exp_glm5_2_gb10.md) |

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -68,21 +68,21 @@ auto-allocation.
 
 SparkLab can use the upstream model's native MTP layer. It verifies draft tokens with the
 target model and transactionally commits or rolls back paged KV, GDN, PLE, and QSA state
-at the accepted boundary. Enable the measured two-token setting with:
+at the accepted boundary. Enable the measured three-token setting with:
 
 ```bash
-sparklab run qwen3.8-flash-next --root /path/to/models -- --speculative-tokens 2
+sparklab run qwen3.8-flash-next --root /path/to/models -- --speculative-tokens 3
 ```
 
-On GB10, a controlled 64-token greedy decode measured 20.31 tok/s versus 15.13 tok/s
-without speculative decoding, a 34.2% improvement. One and three draft tokens measured
-18.21 and 17.10 tok/s respectively, so more drafts are not automatically faster. All four
-settings reproduced the same output hash on fresh prompts and 64-token radix-prefix hits.
+On GB10, the selected three-draft profile measured a three-trial median 30.67 tok/s and
+0.258 s warm TTFT on a 128-token greedy decode. One and two draft tokens measured 25.19
+and 29.15 tok/s respectively. The three selected-profile trials reproduced the same
+output hash.
 
 MTP is intentionally opt-in. The current transactional path supports one running greedy
-request, runs eagerly with overlap scheduling disabled, and falls back to ordinary target
-decoding for non-greedy sampling. Keep the default recipe for concurrent traffic and use
-`--speculative-tokens 2` for single-stream deterministic chat or agent workloads.
+request and falls back to ordinary target decoding for non-greedy sampling. Dense-QSA
+verification uses a dedicated CUDA graph; longer sparse-QSA requests remain eager. Use
+`--speculative-tokens 3` for the measured single-stream greedy profile.
 
 Wait for the API to listen on `127.0.0.1:1919`, then verify it:
 

--- a/python/sparklab/attention/qsa.py
+++ b/python/sparklab/attention/qsa.py
@@ -51,18 +51,23 @@ class QSACaptureData:
 
     @classmethod
     def create(
-        cls, dense_limit: int, device: torch.device, max_bs: int = 1,
+        cls,
+        dense_limit: int,
+        device: torch.device,
+        max_bs: int = 1,
+        max_queries_per_req: int = 1,
     ) -> QSACaptureData:
+        max_queries = max_bs * max_queries_per_req
         return cls(
-            dense_indptr=torch.zeros(max_bs + 1, dtype=torch.int32, device=device),
+            dense_indptr=torch.zeros(max_queries + 1, dtype=torch.int32, device=device),
             # Unused suffix rows must still be valid because the captured pooling
             # update speculatively gathers a four-row group on incomplete steps.
             dense_indices=torch.zeros(
-                max_bs * dense_limit, dtype=torch.int32, device=device
+                max_queries * dense_limit, dtype=torch.int32, device=device
             ),
-            dense_q_positions=torch.zeros(max_bs, dtype=torch.int64, device=device),
-            q_to_req=torch.arange(max_bs, dtype=torch.int32, device=device),
-            last_indices=torch.arange(max_bs, dtype=torch.int32, device=device),
+            dense_q_positions=torch.zeros(max_queries, dtype=torch.int64, device=device),
+            q_to_req=torch.arange(max_queries, dtype=torch.int32, device=device),
+            last_indices=torch.arange(max_queries, dtype=torch.int32, device=device),
         )
 
 
@@ -408,7 +413,13 @@ class QSAAttnBackend(BaseAttnBackend):
             self.args.index_block_topk * ratio + ratio - 1,
         )
         self.capture = QSACaptureData.create(
-            dense_limit, self.device, max_bs=max(bs_list)
+            dense_limit,
+            self.device,
+            max_bs=max(bs_list),
+            # Qwen MTP verification packs one target row and up to three
+            # draft rows into one request. Ordinary decode still consumes only
+            # the leading max_bs query slots from these same buffers.
+            max_queries_per_req=4,
         )
         self.capture_bs = sorted(bs_list)
         self.max_graph_bs = max(bs_list)
@@ -434,25 +445,30 @@ class QSAAttnBackend(BaseAttnBackend):
             raise RuntimeError("Sparse QSA batches are not CUDA-graph eligible")
 
         cap = self.capture
-        bs = batch.padded_size
+        query_rows = metadata.dense_q_positions.numel()
         total = metadata.dense_indices.numel()
         if total > cap.dense_indices.numel():
             raise RuntimeError(
                 f"Dense QSA capture capacity {cap.dense_indices.numel()} < {total} rows"
             )
-        cap.dense_indptr[: bs + 1].copy_(metadata.dense_indptr)
+        if query_rows > cap.dense_q_positions.numel():
+            raise RuntimeError(
+                "Dense QSA capture query capacity "
+                f"{cap.dense_q_positions.numel()} < {query_rows} rows"
+            )
+        cap.dense_indptr[: query_rows + 1].copy_(metadata.dense_indptr)
         cap.dense_indices[:total].copy_(metadata.dense_indices)
-        cap.dense_q_positions[:bs].copy_(metadata.dense_q_positions)
-        cap.last_indices[:bs].copy_(metadata.last_indices)
+        cap.dense_q_positions[:query_rows].copy_(metadata.dense_q_positions)
+        cap.last_indices[: metadata.last_indices.numel()].copy_(metadata.last_indices)
         batch.attn_metadata = QSAMetadata(
-            qo_indptr=tuple(range(bs + 1)),
-            last_indices=cap.last_indices[:bs],
-            q_to_req=cap.q_to_req[:bs],
-            dense_indptr=cap.dense_indptr[: bs + 1],
+            qo_indptr=tuple(range(query_rows + 1)),
+            last_indices=cap.last_indices[: metadata.last_indices.numel()],
+            q_to_req=cap.q_to_req[:query_rows],
+            dense_indptr=cap.dense_indptr[: query_rows + 1],
             # Keep the full fixed-size view: the graph must see the same tensor
             # address and shape at capture and every replay. indptr bounds reads.
             dense_indices=cap.dense_indices,
-            dense_q_positions=cap.dense_q_positions[:bs],
+            dense_q_positions=cap.dense_q_positions[:query_rows],
             capture_decode=True,
         )
 

--- a/python/sparklab/kernels/triton/qwen4_skinny.py
+++ b/python/sparklab/kernels/triton/qwen4_skinny.py
@@ -1,0 +1,120 @@
+"""Small-M BF16 linear kernel for Qwen3.8 on GB10 (SM121)."""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _bf16_skinny_kernel(
+    x_ptr,
+    w_ptr,
+    out_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_xm: tl.constexpr,
+    stride_wn: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs_m = tl.arange(0, BLOCK_M)
+    m_mask = offs_m < M
+    offs_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    n_mask = offs_n < N
+    acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+    for k0 in range(0, K, BLOCK_K):
+        offs_k = k0 + tl.arange(0, BLOCK_K)
+        k_mask = offs_k < K
+        x = tl.load(
+            x_ptr + offs_m[:, None] * stride_xm + offs_k[None, :],
+            mask=m_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        w = tl.load(
+            w_ptr + offs_n[:, None] * stride_wn + offs_k[None, :],
+            mask=n_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        acc += tl.sum(x[:, None, :] * w[None, :, :], axis=2)
+    tl.store(
+        out_ptr + offs_m[:, None] * N + offs_n[None, :],
+        acc,
+        mask=m_mask[:, None] & n_mask[None, :],
+    )
+
+
+def bf16_skinny_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute a contiguous bias-free BF16 linear for one to three rows."""
+    lead = x.shape[:-1]
+    k = x.shape[-1]
+    m = x.numel() // k
+    n = weight.shape[0]
+    if not (1 <= m <= 3):
+        raise ValueError(f"Qwen4 skinny linear requires 1 <= M <= 3, got {m}")
+    x2 = x.reshape(m, k).contiguous()
+    out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    block_n = 2 if m == 1 else 1
+    _bf16_skinny_kernel[(triton.cdiv(n, block_n),)](
+        x2,
+        weight,
+        out,
+        M=m,
+        N=n,
+        K=k,
+        stride_xm=x2.stride(0),
+        stride_wn=weight.stride(0),
+        BLOCK_M=triton.next_power_of_2(m),
+        BLOCK_N=block_n,
+        BLOCK_K=min(triton.next_power_of_2(k), 4096),
+        num_warps=4,
+    )
+    return out.reshape(*lead, n)
+
+
+# Native TP=1 Qwen3.8 shapes that beat F.linear in a controlled GB10 sweep.
+# Small projections (notably 320x10240 and 640x2560) deliberately stay on
+# cuBLAS because launch/under-occupancy costs erase their apparent specialization.
+_SM121_PLANS = {
+    (13312, 2560),  # QSA fused q/gate/k/v
+    (16480, 2560),  # GDN fused q/k/v/z/b/a
+    (2560, 6144),   # QSA/GDN output projection
+    (248320, 2560),  # full-vocabulary LM head
+}
+
+
+@functools.cache
+def _is_sm121(device_index: int) -> bool:
+    return torch.cuda.get_device_capability(device_index) == (12, 1)
+
+
+def qwen4_skinny_linear(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Use the measured SM121 kernel when eligible, otherwise ``F.linear``."""
+    k = x.shape[-1]
+    m = x.numel() // k
+    eligible = (
+        os.getenv("SPARKLAB_DISABLE_QWEN4_SKINNY_GEMM", "0").lower()
+        not in {"1", "true", "yes"}
+        and bias is None
+        and x.is_cuda
+        and x.dtype == torch.bfloat16
+        and weight.dtype == torch.bfloat16
+        and weight.is_contiguous()
+        and 1 <= m <= 3
+        and tuple(weight.shape) in _SM121_PLANS
+        and _is_sm121(x.device.index or 0)
+    )
+    return bf16_skinny_linear(x, weight) if eligible else F.linear(x, weight, bias)
+
+
+__all__ = ["bf16_skinny_linear", "qwen4_skinny_linear"]

--- a/python/sparklab/layers/embedding.py
+++ b/python/sparklab/layers/embedding.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import Dict
 
 import torch
-import torch.nn.functional as F
 from sparklab.core import get_global_ctx
 from sparklab.runtime.distributed import DistributedCommunicator, get_tp_info
 from sparklab.utils import div_ceil, nvtx_annotate
 
 from .base import BaseOP
+from .linear import _linear_forward
 
 
 class VocabParallelEmbedding(BaseOP):
@@ -110,7 +110,7 @@ class ParallelLMHead(VocabParallelEmbedding):
             del indices
 
         module = self.tied_embedding or self
-        logits = F.linear(x, module.weight, self.bias)
+        logits = _linear_forward(x, module.weight, self.bias)
         if self.tp_size == 1:
             return logits
         input_shape = logits.shape

--- a/python/sparklab/layers/linear.py
+++ b/python/sparklab/layers/linear.py
@@ -10,6 +10,16 @@ from sparklab.utils import div_even
 from .base import BaseOP
 
 
+def _linear_forward(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> torch.Tensor:
+    if x.is_cuda and x.dtype == torch.bfloat16 and weight.dtype == torch.bfloat16:
+        from sparklab.kernels.triton.qwen4_skinny import qwen4_skinny_linear
+
+        return qwen4_skinny_linear(x, weight, bias)
+    return F.linear(x, weight, bias)
+
+
 class _LinearTPImpl(BaseOP):
     """Real implementation of a linear layer with tensor parallelism."""
 
@@ -29,7 +39,7 @@ class _LinearTPImpl(BaseOP):
         self.bias = torch.empty(local_osize) if has_bias else None
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.linear(x, self.weight, self.bias)
+        return _linear_forward(x, self.weight, self.bias)
 
 
 class LinearReplicated(_LinearTPImpl):
@@ -100,7 +110,7 @@ class LinearOProj(_LinearTPImpl):
         super().__init__(full_isize, full_osize, local_isize, local_osize, has_bias)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        y = F.linear(x, self.weight, self.bias)
+        y = _linear_forward(x, self.weight, self.bias)
         if self._tp_size > 1:
             y = self._comm.all_reduce(y)
         return y
@@ -121,7 +131,7 @@ class LinearRowParallel(_LinearTPImpl):
         super().__init__(input_size, output_size, local_input_size, local_output_size, has_bias)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        y = F.linear(x, self.weight, self.bias)
+        y = _linear_forward(x, self.weight, self.bias)
         if self._tp_size > 1:
             y = self._comm.all_reduce(y)
         return y

--- a/python/sparklab/models/qwen4_exp/model.py
+++ b/python/sparklab/models/qwen4_exp/model.py
@@ -177,8 +177,8 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
         """
         if self._mtp is None or self._mtp_target_hidden is None or batch.size != 1:
             return None
-        import torch.nn.functional as F
         from sparklab.core import Batch, Req
+        from sparklab.layers.linear import _linear_forward
 
         ctx = get_global_ctx()
         req = batch.reqs[0]
@@ -200,7 +200,9 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
         sample_hidden = sample_hidden.index_select(0, last)
         feedback = feedback.index_select(0, last)
         head = self.lm_head.tied_embedding or self.lm_head
-        draft = torch.argmax(F.linear(sample_hidden, head.weight, self.lm_head.bias), -1)
+        draft = torch.argmax(
+            _linear_forward(sample_hidden, head.weight, self.lm_head.bias), -1
+        )
         drafts = [draft.squeeze(0).to(torch.int32)]
 
         # The scheduler reserves the configured lookahead before this forward,
@@ -236,7 +238,7 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
                     self.model.embed_tokens.forward(draft_batch.input_ids), feedback
                 )
             draft = torch.argmax(
-                F.linear(sample_hidden, head.weight, self.lm_head.bias), -1
+                _linear_forward(sample_hidden, head.weight, self.lm_head.bias), -1
             )
             drafts.append(draft.squeeze(0).to(torch.int32))
         return torch.stack(drafts)

--- a/python/sparklab/models/qwen4_exp/mtp.py
+++ b/python/sparklab/models/qwen4_exp/mtp.py
@@ -90,7 +90,8 @@ class _ResidentNvfp4MTPMoE(BaseOP):
             topk=self.top_k,
             renormalize=True,
         )
-        if get_global_ctx().batch.uses_prefill_kernels:
+        batch = get_global_ctx().batch
+        if batch.uses_prefill_kernels and not batch.is_verify:
             from sparklab.moe.fused_nvfp4 import fused_experts_nvfp4
 
             routed = fused_experts_nvfp4(
@@ -103,6 +104,11 @@ class _ResidentNvfp4MTPMoE(BaseOP):
         else:
             from sparklab.moe.fused_nvfp4 import fused_experts_decode_nvfp4_marlin
 
+            # Verification contains only the target token plus the short draft
+            # block (at most four rows). Attention still needs prefill semantics
+            # for those consecutive positions, but the token-local MoE does not:
+            # the grouped prefill kernel pads every selected expert to M=16.
+            # The decode kernel accepts M > 1 and computes only the routed rows.
             routed = fused_experts_decode_nvfp4_marlin(
                 hidden_states, *self._expert_banks, topk_weights, topk_ids
             )

--- a/python/sparklab/models/qwen4_exp/ple.py
+++ b/python/sparklab/models/qwen4_exp/ple.py
@@ -472,6 +472,8 @@ class Qwen4PLE(BaseOP):
         self.state_len = (args.ple_conv_kernel_size - 1) * self.dilation
         self._capture_embed: torch.Tensor | None = None
         self._capture_host: torch.Tensor | None = None
+        self._eager_embed: torch.Tensor | None = None
+        self._eager_host: torch.Tensor | None = None
         self._pending_embed: Future[torch.Tensor] | None = None
 
     def bind(self, model_path: str, *, dummy: bool = False) -> None:
@@ -497,14 +499,43 @@ class Qwen4PLE(BaseOP):
             # This is an activation buffer, not a weight buffer. Resident FP8
             # projection weights still consume BF16 PLE rows through W8A16.
             self._capture_embed = torch.empty(
-                embed.shape, dtype=torch.bfloat16, device=weight.device
+                (max(4, embed.shape[0]), embed.shape[1]),
+                dtype=torch.bfloat16,
+                device=weight.device,
             )
             capture = self._capture_embed
-        if embed.shape[-1] != capture.shape[-1] or embed.shape[0] > capture.shape[0]:
+        if embed.shape[-1] != capture.shape[-1]:
             raise RuntimeError(
                 "Qwen4 PLE CUDA graph input exceeds its stable buffer: "
                 f"got={tuple(embed.shape)}, capacity={tuple(capture.shape)}"
             )
+
+        if embed.shape[0] > capture.shape[0]:
+            # Prompt prefill is eager and can exceed the decode/MTP graph shape.
+            # Keep it on separate growable buffers so replacing them cannot
+            # invalidate the addresses baked into an already-captured graph.
+            eager = getattr(self, "_eager_embed", None)
+            if eager is None or eager.shape[0] < embed.shape[0]:
+                self._eager_embed = torch.empty(
+                    embed.shape, dtype=torch.bfloat16, device=weight.device
+                )
+                eager = self._eager_embed
+                if eager.device.type == "cuda":
+                    self._eager_host = torch.empty(
+                        embed.shape,
+                        dtype=eager.dtype,
+                        device="cpu",
+                        pin_memory=True,
+                    )
+            if eager.device.type == "cuda":
+                host = self._eager_host
+                host[: embed.shape[0]].copy_(embed)
+                eager[: embed.shape[0]].copy_(
+                    host[: embed.shape[0]], non_blocking=True
+                )
+            else:
+                eager[: embed.shape[0]].copy_(embed)
+            return eager[: embed.shape[0]]
 
         if capture.device.type == "cuda":
             host = getattr(self, "_capture_host", None)
@@ -529,6 +560,23 @@ class Qwen4PLE(BaseOP):
             f"qwen4_ple_{self.layer_id}_conv", (self.width, self.state_len), x.dtype
         )
         reqs = batch.padded_reqs if hasattr(batch, "padded_reqs") else batch.reqs
+        if getattr(batch, "is_verify", False):
+            if len(reqs) != 1:
+                raise RuntimeError("Qwen4 PLE verification currently requires batch size one")
+            # Keep the state slot as a device tensor. A CUDA graph captured on
+            # the padding request can then replay against the live request's
+            # slot instead of baking the dummy Python index into the graph.
+            slots = batch.fla_metadata.cache_indices.to(torch.long)
+            prior = states.index_select(0, slots)[0]
+            history = torch.cat((prior, x.T.contiguous()), -1)
+            out = F.conv1d(
+                history.unsqueeze(0),
+                self.conv1d.weight,
+                groups=self.width,
+                dilation=self.dilation,
+            ).squeeze(0).T
+            states.index_copy_(0, slots, history[:, -self.state_len:].unsqueeze(0))
+            return F.silu(out)
         if not batch.uses_prefill_kernels:
             from sparklab.kernels.triton.qwen4 import ple_conv_decode
 

--- a/python/sparklab/recipes/qwen3.8-flash-next.json
+++ b/python/sparklab/recipes/qwen3.8-flash-next.json
@@ -47,13 +47,14 @@
   "profile": "quality",
   "description": "Precision-preserving text-only recipe for Inferact's ModelOpt NVFP4 Qwen3.8 checkpoint on one NVIDIA GB10.",
   "performance": {
-    "decode_tokens_per_second": 20.30646577455425,
-    "warm_ttft_seconds": 0.21166132600046694,
+    "decode_tokens_per_second": 30.67455057137699,
+    "warm_ttft_seconds": 0.2582157750002807,
     "context_tokens": 65536,
-    "evidence": "GB10-QWEN38-NVFP4-OPT-004",
-    "note": "The selected opt-in two-draft native MTP profile measured 20.31 tok/s and 0.212 s warm TTFT in a controlled batch-one greedy GB10 run, 34.2% faster than its eager control with exact output parity. The default concurrent profile remains 16.84 single-stream tok/s and reaches 61.79 aggregate tok/s at concurrency four. The clean-revision 60-minute endurance gate remains outstanding."
+    "evidence": "GB10-QWEN38-MTP-007",
+    "note": "The selected three-draft native MTP profile measured a three-trial median 30.67 tok/s and 0.258 s warm TTFT in a controlled 128-token batch-one greedy GB10 run. The clean-revision 60-minute endurance gate remains outstanding."
   },
   "evidence": [
+    "GB10-QWEN38-MTP-007",
     "GB10-QWEN38-NVFP4-OPT-004",
     "GB10-QWEN38-NVFP4-OPT-003",
     "GB10-QWEN38-NVFP4-OPT-002",
@@ -63,11 +64,11 @@
   "limitations": [
     "Beta 0.1 FTW preparation preserves Inferact's native ModelOpt NVFP4 routed experts without conversion-time requantization; all served non-expert tensors retain their published precision.",
     "The published BF16 n-gram table is extracted into an approximately 102.4 GB random-read artifact during preparation.",
-    "The complete pinned checkpoint and 182,030,550,080-byte self-contained FTW artifact were validated; the default concurrent profile measured 16.84 single-stream tok/s, 0.306 s repeated-prompt TTFT, and 61.79 aggregate tok/s at concurrency four, while opt-in two-draft MTP measured 20.31 tok/s and 0.212 s warm TTFT in its controlled batch-one greedy workload.",
+    "The complete pinned checkpoint and 182,030,550,080-byte self-contained FTW artifact were validated; the latest controlled batch-one greedy MTP3 profile measured 30.67 tok/s and 0.258 s warm TTFT.",
     "Full expert preload takes about 35 seconds at startup, eliminates steady-state routed-expert disk I/O and the pageable host LRU, and requires all 24,576 routed experts to fit in unified memory.",
     "GB10-QWEN38-FRONTIER-001 and GB10-QWEN38-FP8-001 describe superseded recipe/checkpoint tuples and do not transfer to this 0.5.0 release.",
     "QSA decode uses CUDA-graph replay through batch four while every request's complete-group count remains within the exact dense budget (up to 2,051 visible tokens); longer sparse-QSA decode automatically runs eagerly.",
-    "Native MTP speculative decoding is opt-in and currently limited to batch-one greedy requests; it disables CUDA graphs and overlap scheduling while transactional verification is active. Two draft tokens measured best on GB10.",
+    "Native MTP speculative decoding is limited to batch-one greedy requests. Dense-QSA verification uses a dedicated fixed-shape CUDA graph; longer sparse-QSA requests fall back to eager verification. Three draft tokens measured best on GB10.",
     "The published checkpoint is multimodal; initial SparkLab certification is text-only.",
     "An exact 65,536-token sparse-QSA recall probe returned the planted key in 208.58 seconds with zero routed-expert disk reads and no swap growth; reasoning, tool, coding-agent, and five-problem quality gates passed, while the 60-minute endurance gate remains outstanding.",
     "The performance host had 3.71 GiB of unrelated swap resident before launch, although the measured request swapped no pages out."

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -19,7 +19,7 @@ from sparklab.moe.offload_cache import OffloadMoeCache, attach_offload_moe_cache
 from sparklab.utils import align_ceil, init_logger, is_sm90_family, is_sm100_family, mem_GB, torch_dtype
 
 from .config import EngineConfig
-from .graph import GraphRunner, get_free_memory
+from .graph import GraphRunner, MTPVerificationGraphRunner, get_free_memory
 from .sample import BatchSamplingArgs, Sampler
 from sparklab.runtime.kvcache import create_kv_pool, resolve_pool_class
 from sparklab.runtime.kvcache.base import CacheRebuildRejected
@@ -399,14 +399,21 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         groups.append(group)
     if args is not None:
         object.__setattr__(model_config, "qwen4_exp_args", args)
+        graph_enabled = bool(getattr(model_config, "mtp_cuda_graph", False)) or not (
+            config.cuda_graph_bs == [] or config.cuda_graph_max_bs == 0
+        )
+        object.__setattr__(model_config, "mtp_cuda_graph", graph_enabled)
     object.__setattr__(model_config, "attention_groups", tuple(groups))
     object.__setattr__(model_config, "speculative_method", "mtp")
     object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
     override("speculative_method", "mtp")
-    # Transactional verification is eager and currently batch-one. This is an
-    # explicit bring-up constraint, not a silent numerical compromise.
+    # Transactional bookkeeping remains eager and batch-one. Qwen4 captures the
+    # fixed-width target verification forward; Qwen3.5/3.6 keep their established
+    # eager path until their attention backends gain multi-row capture metadata.
     override("max_running_req", 1)
     override("cache_type", "radix")
+    # The verification runner owns a multi-row graph whose dimensions are not
+    # request batch sizes. Keep it separate from the ordinary decode runner.
     override("cuda_graph_bs", [])
     override("cuda_graph_max_bs", 0)
 
@@ -663,6 +670,20 @@ class Engine:
             vocab_size=config.model_config.vocab_size,
             dummy_req=self.dummy_req,
             moe_offload_cache=self.moe_offload_cache,
+        )
+        self.mtp_graph_runner = (
+            MTPVerificationGraphRunner(
+                stream=self.stream,
+                device=self.device,
+                model=self.model,
+                attn_backend=self.attn_backend,
+                speculative_tokens=config.speculative_tokens,
+                max_seq_len=aligned_max_seq_len,
+                vocab_size=config.model_config.vocab_size,
+                dummy_req=self.dummy_req,
+            )
+            if getattr(config.model_config, "mtp_cuda_graph", False)
+            else None
         )
         if (
             config.attention_backend.split(",")[0] in {"triton", "dsa"}
@@ -1175,6 +1196,8 @@ class Engine:
         # untouched (no rollback needed); after it, only a rebuild restores service.
         self.rebuild_teardown_started = True
         # 1. Tear down CUDA graphs + backend capture scratch (free-before-alloc).
+        if self.mtp_graph_runner is not None:
+            self.mtp_graph_runner.destroy_cuda_graphs()
         self.attn_backend.reset_capture()
         self.graph_runner.destroy_cuda_graphs()
         # 2. Resize caches in place (each frees its old GPU tensors before allocating).
@@ -1220,6 +1243,20 @@ class Engine:
             dummy_req=self.dummy_req,
             moe_offload_cache=self.moe_offload_cache,
         )
+        self.mtp_graph_runner = (
+            MTPVerificationGraphRunner(
+                stream=self.stream,
+                device=self.device,
+                model=self.model,
+                attn_backend=self.attn_backend,
+                speculative_tokens=config.speculative_tokens,
+                max_seq_len=aligned_max_seq_len,
+                vocab_size=config.model_config.vocab_size,
+                dummy_req=self.dummy_req,
+            )
+            if getattr(config.model_config, "mtp_cuda_graph", False)
+            else None
+        )
 
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
         assert torch.cuda.current_stream() == self.stream
@@ -1260,7 +1297,13 @@ class Engine:
                     pool.copy_from(req.linear_slot_idx, scratch)
                     state_snapshots.append((req.linear_slot_idx, scratch))
         with self.ctx.forward_batch(batch):
-            if not batch.is_verify and self.graph_runner.can_use_cuda_graph(batch):
+            if (
+                batch.is_verify
+                and self.mtp_graph_runner is not None
+                and self.mtp_graph_runner.can_use_cuda_graph(batch)
+            ):
+                logits = self.mtp_graph_runner.replay(batch)
+            elif not batch.is_verify and self.graph_runner.can_use_cuda_graph(batch):
                 logits = self.graph_runner.replay(batch)
             else:
                 logits = self.model.forward()
@@ -1464,6 +1507,8 @@ class Engine:
         )
 
     def shutdown(self) -> None:
+        if self.mtp_graph_runner is not None:
+            self.mtp_graph_runner.destroy_cuda_graphs()
         self.graph_runner.destroy_cuda_graphs()
         torch.distributed.destroy_process_group()
         destroy_distributed()

--- a/python/sparklab/runtime/engine/graph.py
+++ b/python/sparklab/runtime/engine/graph.py
@@ -119,7 +119,15 @@ class GraphRunner:
         self.moe_offload_cache = moe_offload_cache
         self.stream = stream
         self.device = device
-        self._capture_graphs(max_seq_len, vocab_size, model)
+        prior_mtp_hidden = getattr(model, "_mtp_target_hidden", None)
+        try:
+            self._capture_graphs(max_seq_len, vocab_size, model)
+        finally:
+            # Qwen's Python-side MTP feedback pointer is an output of the live
+            # target forward, not graph configuration. Do not leave startup
+            # capture's dummy one-row tensor installed before the first prompt.
+            if hasattr(model, "_mtp_target_hidden"):
+                model._mtp_target_hidden = prior_mtp_hidden
 
     def _reset_moe_offload_cache(self) -> None:
         if self.moe_offload_cache is not None:
@@ -220,5 +228,141 @@ class GraphRunner:
         # free-before-alloc cannot reclaim this GPU memory. empty_cache() is left to the
         # caller / next capture (GraphRunner._capture_graphs already runs it).
         self.graph_map = {}
+        self.buffer = None
+        gc.collect()
+
+
+@dataclass
+class MTPVerificationCaptureBuffer:
+    """Fixed-address inputs for one fixed-width Qwen MTP verification graph."""
+
+    input_ids: torch.Tensor
+    out_loc: torch.Tensor
+    positions: torch.Tensor
+    logits: torch.Tensor
+    table_idx: torch.Tensor
+    fla_cu_seqlens: torch.Tensor
+    fla_has_initial_state: torch.Tensor
+
+    @classmethod
+    def init(
+        cls, rows: int, vocab_size: int, device: torch.device
+    ) -> MTPVerificationCaptureBuffer:
+        return cls(
+            input_ids=torch.zeros(rows, dtype=torch.int32, device=device),
+            out_loc=torch.zeros(rows, dtype=torch.int32, device=device),
+            positions=torch.arange(1, rows + 1, dtype=torch.int32, device=device),
+            logits=torch.empty(rows, vocab_size, dtype=torch.float32, device=device),
+            table_idx=torch.zeros(1, dtype=torch.int32, device=device),
+            fla_cu_seqlens=torch.tensor([0, rows], dtype=torch.int32, device=device),
+            fla_has_initial_state=torch.ones(1, dtype=torch.bool, device=device),
+        )
+
+    def set_batch(self, batch: Batch) -> None:
+        from sparklab.attention.linear import FLAMetadata
+
+        batch.input_ids = self.input_ids
+        batch.out_loc = self.out_loc
+        batch.positions = self.positions
+        batch.linear_table_idx = self.table_idx
+        batch.fla_metadata = FLAMetadata(
+            cu_seqlens=self.fla_cu_seqlens,
+            cache_indices=self.table_idx,
+            has_initial_state=self.fla_has_initial_state,
+        )
+
+    def copy_from(self, batch: Batch) -> None:
+        self.input_ids.copy_(batch.input_ids)
+        self.out_loc.copy_(batch.out_loc)
+        self.positions.copy_(batch.positions)
+        self.table_idx.copy_(batch.linear_table_idx)
+
+
+class MTPVerificationGraphRunner:
+    """Capture the fixed ``1 + speculative_tokens`` target verification shape.
+
+    Transactional state snapshots and rejection repair remain eager in the
+    engine. Only the deterministic target forward is replayed.
+    """
+
+    def __init__(
+        self,
+        *,
+        stream: torch.cuda.Stream,
+        device: torch.device,
+        model: BaseLLMModel,
+        attn_backend: BaseAttnBackend,
+        speculative_tokens: int,
+        max_seq_len: int,
+        vocab_size: int,
+        dummy_req: Req,
+    ) -> None:
+        self.stream = stream
+        self.device = device
+        self.model = model
+        self.attn_backend = attn_backend
+        self.rows = speculative_tokens + 1
+        if getattr(attn_backend, "capture", None) is None:
+            attn_backend.init_capture_graph(max_seq_len=max_seq_len, bs_list=[1])
+        self.buffer = MTPVerificationCaptureBuffer.init(
+            self.rows, vocab_size, device
+        )
+        self.graph = torch.cuda.CUDAGraph()
+
+        # A continuation-shaped dummy keeps the verify-only GDN/PLE branches in
+        # the captured graph. Its mutable state is redirected to the padding slot.
+        verify_dummy = Req(
+            input_ids=torch.zeros(self.rows + 1, dtype=torch.int32),
+            table_idx=dummy_req.table_idx,
+            cached_len=1,
+            output_len=1,
+            uid=dummy_req.uid,
+            sampling_params=dummy_req.sampling_params,
+            cache_handle=dummy_req.cache_handle,
+        )
+        verify_dummy.linear_slot_idx = dummy_req.linear_slot_idx
+        batch = Batch(reqs=[verify_dummy], phase="verify")
+        batch.padded_reqs = batch.reqs
+        batch.return_all_logits = True
+        batch.disable_state_tracking = True
+        self.attn_backend.prepare_for_capture(batch)
+        self.buffer.set_batch(batch)
+        self.buffer.table_idx.fill_(
+            verify_dummy.linear_slot_idx
+            if verify_dummy.linear_slot_idx is not None
+            else verify_dummy.table_idx
+        )
+        prior_mtp_hidden = getattr(self.model, "_mtp_target_hidden", None)
+        try:
+            with get_global_ctx().forward_batch(batch):
+                self.model.prepare_cuda_graph_inputs(batch)
+                self.buffer.logits.copy_(self.model.forward())
+                with torch.cuda.graph(self.graph, stream=self.stream):
+                    self.buffer.logits.copy_(self.model.forward())
+            self._target_hidden = getattr(self.model, "_mtp_target_hidden", None)
+        finally:
+            self.model._mtp_target_hidden = prior_mtp_hidden
+
+    def can_use_cuda_graph(self, batch: Batch) -> bool:
+        return (
+            batch.is_verify
+            and batch.size == 1
+            and batch.input_ids.numel() == self.rows
+            and self.attn_backend.supports_cuda_graph(batch)
+        )
+
+    def replay(self, batch: Batch) -> torch.Tensor:
+        assert self.can_use_cuda_graph(batch)
+        self.buffer.copy_from(batch)
+        self.attn_backend.prepare_for_replay(batch)
+        self.model.prepare_cuda_graph_inputs(batch)
+        self.graph.replay()
+        # Python assignments inside model.forward are not replayed by CUDA.
+        # Reinstall the captured target feedback tensor for the next draft pass.
+        self.model._mtp_target_hidden = self._target_hidden
+        return self.buffer.logits
+
+    def destroy_cuda_graphs(self) -> None:
+        self.graph = None
         self.buffer = None
         gc.collect()

--- a/tests/kernels/test_qwen4_skinny.py
+++ b/tests/kernels/test_qwen4_skinny.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+@pytest.mark.parametrize("rows", [1, 3])
+def test_bf16_skinny_linear_matches_torch(rows: int) -> None:
+    from sparklab.kernels.triton.qwen4_skinny import bf16_skinny_linear
+
+    torch.manual_seed(7)
+    x = torch.randn(rows, 96, device="cuda", dtype=torch.bfloat16) * 0.1
+    weight = torch.randn(65, 96, device="cuda", dtype=torch.bfloat16) * 0.1
+
+    actual = bf16_skinny_linear(x, weight)
+    expected = F.linear(x, weight)
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-2)
+
+
+def test_qwen4_skinny_linear_falls_back_on_cpu() -> None:
+    from sparklab.kernels.triton.qwen4_skinny import qwen4_skinny_linear
+
+    x = torch.randn(2, 4)
+    weight = torch.randn(3, 4)
+    bias = torch.randn(3)
+
+    torch.testing.assert_close(
+        qwen4_skinny_linear(x, weight, bias), F.linear(x, weight, bias)
+    )

--- a/tests/models/test_qwen4_exp.py
+++ b/tests/models/test_qwen4_exp.py
@@ -86,7 +86,7 @@ def test_config_declares_qsa_separately_from_minimax_bsa():
     assert cfg.linear_state_snapshots is True
 
 
-def test_mtp_config_injects_one_qsa_slot_and_disables_graphs():
+def test_mtp_config_injects_one_qsa_slot_and_enables_fixed_width_graph():
     from sparklab.runtime.engine.engine import _adjust_speculative_config
 
     model_config = parse_config(_config())
@@ -114,6 +114,27 @@ def test_mtp_config_injects_one_qsa_slot_and_disables_graphs():
     assert model_config.speculative_tokens == 3
     assert config.max_running_req == 1
     assert config.cache_type == "radix"
+    assert model_config.mtp_cuda_graph is True
+    assert config.cuda_graph_bs == [] and config.cuda_graph_max_bs == 0
+
+
+def test_mtp_config_respects_explicit_graph_disable():
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+
+    model_config = parse_config(_config())
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_tokens=2,
+        draft_sample_method="greedy",
+        max_running_req=1,
+        cache_type="radix",
+        cuda_graph_bs=[],
+        cuda_graph_max_bs=0,
+    )
+
+    _adjust_speculative_config(config, lambda name, value: setattr(config, name, value))
+
+    assert model_config.mtp_cuda_graph is False
     assert config.cuda_graph_bs == [] and config.cuda_graph_max_bs == 0
 
 
@@ -129,6 +150,58 @@ def test_mtp_acceptance_stops_at_first_mismatch(truth, drafts, expected):
     from sparklab.runtime.engine.engine import _longest_accepted_prefix
 
     assert _longest_accepted_prefix(torch.tensor(truth), torch.tensor(drafts)) == expected
+
+
+@pytest.mark.parametrize(
+    ("uses_prefill_kernels", "is_verify", "expected"),
+    [
+        (True, False, "prefill"),
+        (True, True, "decode"),
+        (False, False, "decode"),
+    ],
+)
+def test_qwen4_mtp_verification_uses_small_batch_decode_moe(
+    monkeypatch, uses_prefill_kernels, is_verify, expected
+):
+    from sparklab.models.qwen4_exp.mtp import _ResidentNvfp4MTPMoE
+
+    calls = []
+    hidden = torch.randn(3, 8)
+    topk_weights = torch.ones(3, 2)
+    topk_ids = torch.zeros(3, 2, dtype=torch.int32)
+    block = _ResidentNvfp4MTPMoE.__new__(_ResidentNvfp4MTPMoE)
+    block._expert_banks = tuple(object() for _ in range(6))
+    block.num_experts = 8
+    block.top_k = 2
+    block.gate = SimpleNamespace(forward=lambda value: torch.zeros(value.size(0), 8))
+    block.shared_expert = SimpleNamespace(forward=lambda value: torch.zeros_like(value))
+    block.shared_expert_gate = SimpleNamespace(
+        forward=lambda value: torch.zeros(value.size(0), 1)
+    )
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.mtp.get_global_ctx",
+        lambda: SimpleNamespace(
+            batch=SimpleNamespace(
+                uses_prefill_kernels=uses_prefill_kernels,
+                is_verify=is_verify,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.mtp.fused_topk",
+        lambda **_kwargs: (topk_weights, topk_ids),
+    )
+    monkeypatch.setattr(
+        "sparklab.moe.fused_nvfp4.fused_experts_nvfp4",
+        lambda *args, **_kwargs: calls.append("prefill") or torch.ones_like(args[0]),
+    )
+    monkeypatch.setattr(
+        "sparklab.moe.fused_nvfp4.fused_experts_decode_nvfp4_marlin",
+        lambda *args, **_kwargs: calls.append("decode") or torch.ones_like(args[0]),
+    )
+
+    torch.testing.assert_close(block.forward(hidden), torch.ones_like(hidden))
+    assert calls == [expected]
 
 
 def test_zero_temperature_is_greedy_despite_model_top_p_default():
@@ -854,13 +927,14 @@ def test_ple_stages_disk_row_into_stable_graph_input():
 
     ple.prepare_cuda_graph_inputs(SimpleNamespace())
     pointer = ple._capture_embed.data_ptr()
-    torch.testing.assert_close(ple._capture_embed, rows)
+    assert ple._capture_embed.shape == (4, 8)
+    torch.testing.assert_close(ple._capture_embed[:1], rows)
 
     replacement = rows + 1
     ple.embedding = SimpleNamespace(forward=lambda _batch: replacement)
     ple.prepare_cuda_graph_inputs(SimpleNamespace())
     assert ple._capture_embed.data_ptr() == pointer
-    torch.testing.assert_close(ple._capture_embed, replacement)
+    torch.testing.assert_close(ple._capture_embed[:1], replacement)
 
 
 def test_ple_consumes_prelaunched_lookup_without_sync_fallback():
@@ -895,7 +969,7 @@ def test_ple_consumes_prelaunched_lookup_without_sync_fallback():
     ple.prepare_cuda_graph_inputs(batch)
 
     assert [kind for kind, _ in calls] == ["begin", "finish"]
-    torch.testing.assert_close(ple._capture_embed, rows)
+    torch.testing.assert_close(ple._capture_embed[:1], rows)
 
 
 def test_ple_stages_smaller_batch_into_stable_graph_input_prefix():
@@ -913,6 +987,60 @@ def test_ple_stages_smaller_batch_into_stable_graph_input_prefix():
 
     assert ple._capture_embed.data_ptr() == pointer
     torch.testing.assert_close(ple._capture_embed[:2], replacement)
+
+
+def test_ple_large_prefill_does_not_replace_graph_buffer():
+    ple = Qwen4PLE.__new__(Qwen4PLE)
+    ple.key_proj = SimpleNamespace(weight=torch.empty(4, 8, dtype=torch.bfloat16))
+    ple._capture_embed = torch.zeros(4, 8, dtype=torch.bfloat16)
+    graph_pointer = ple._capture_embed.data_ptr()
+    rows = torch.arange(48, dtype=torch.bfloat16).view(6, 8)
+
+    got = ple._copy_to_stable_device(rows)
+
+    assert ple._capture_embed.data_ptr() == graph_pointer
+    assert got.data_ptr() != graph_pointer
+    torch.testing.assert_close(got, rows)
+
+
+def test_ple_verification_updates_dynamic_state_slot(monkeypatch):
+    width, state_len = 2, 2
+    states = torch.arange(3 * width * state_len, dtype=torch.float32).view(
+        3, width, state_len
+    )
+    original = states.clone()
+    pool = SimpleNamespace(
+        ensure_aux_state=lambda *_args, **_kwargs: states,
+    )
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.ple.get_global_ctx",
+        lambda: SimpleNamespace(linear_state_pool=pool),
+    )
+    ple = Qwen4PLE.__new__(Qwen4PLE)
+    ple.layer_id = 0
+    ple.width = width
+    ple.state_len = state_len
+    ple.dilation = 1
+    ple.conv1d = SimpleNamespace(weight=torch.ones(width, 1, 3))
+    x = torch.tensor([[20.0, 30.0], [21.0, 31.0], [22.0, 32.0]])
+    batch = SimpleNamespace(
+        is_verify=True,
+        padded_reqs=[SimpleNamespace()],
+        fla_metadata=SimpleNamespace(cache_indices=torch.tensor([1], dtype=torch.int32)),
+    )
+
+    out = ple._conv(x, batch)
+
+    history = torch.cat((original[1], x.T), -1)
+    expected = torch.nn.functional.silu(
+        torch.nn.functional.conv1d(
+            history.unsqueeze(0), ple.conv1d.weight, groups=width
+        ).squeeze(0).T
+    )
+    torch.testing.assert_close(out, expected)
+    torch.testing.assert_close(states[1], history[:, -state_len:])
+    torch.testing.assert_close(states[0], original[0])
+    torch.testing.assert_close(states[2], original[2])
 
 
 def test_ple_prefill_checkpoint_includes_convolution_history(monkeypatch):
@@ -1159,6 +1287,32 @@ def test_qsa_capture_stages_multiple_request_segments():
     assert md.dense_indptr.tolist() == [0, 4, 7]
     assert md.dense_indices[:7].tolist() == [9, 3, 12, 1, 8, 6, 2]
     assert md.dense_q_positions.tolist() == [3, 2]
+
+
+def test_qsa_capture_stages_multiple_queries_for_one_request():
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.capture = QSACaptureData.create(
+        7, torch.device("cpu"), max_queries_per_req=4
+    )
+    source = QSAMetadata(
+        qo_indptr=(0, 3),
+        last_indices=torch.tensor([2], dtype=torch.int32),
+        q_to_req=torch.tensor([0, 1, 2], dtype=torch.int32),
+        dense_indptr=torch.tensor([0, 4, 9, 15], dtype=torch.int32),
+        dense_indices=torch.arange(15, dtype=torch.int32),
+        dense_q_positions=torch.tensor([3, 4, 5], dtype=torch.int64),
+    )
+    batch = SimpleNamespace(padded_size=1, attn_metadata=source)
+
+    backend._point_to_capture(batch)
+
+    md = batch.attn_metadata
+    assert md.capture_decode
+    assert md.qo_indptr == (0, 1, 2, 3)
+    assert md.last_indices.tolist() == [2]
+    assert md.q_to_req.tolist() == [0, 1, 2]
+    assert md.dense_indptr.tolist() == [0, 4, 9, 15]
+    assert md.dense_q_positions.tolist() == [3, 4, 5]
 
 
 def test_qsa_capture_pool_update_matches_completed_group():

--- a/tests/runtime/engine/test_graph.py
+++ b/tests/runtime/engine/test_graph.py
@@ -1,6 +1,12 @@
 from types import SimpleNamespace
 
-from sparklab.runtime.engine.graph import GraphRunner
+import torch
+
+from sparklab.runtime.engine.graph import (
+    GraphRunner,
+    MTPVerificationCaptureBuffer,
+    MTPVerificationGraphRunner,
+)
 
 
 def test_cuda_graph_eligibility_delegates_to_attention_backend():
@@ -22,3 +28,31 @@ def test_cuda_graph_eligibility_keeps_phase_and_batch_guards():
 
     assert not runner.can_use_cuda_graph(SimpleNamespace(is_decode=False, size=1))
     assert not runner.can_use_cuda_graph(SimpleNamespace(is_decode=True, size=2))
+
+
+def test_mtp_verification_capture_buffer_separates_rows_from_requests():
+    buffer = MTPVerificationCaptureBuffer.init(3, 16, torch.device("cpu"))
+    batch = SimpleNamespace()
+
+    buffer.set_batch(batch)
+
+    assert batch.input_ids.shape == (3,)
+    assert batch.linear_table_idx.shape == (1,)
+    assert batch.fla_metadata.cu_seqlens.tolist() == [0, 3]
+    assert batch.fla_metadata.has_initial_state.tolist() == [True]
+
+
+def test_mtp_verification_graph_domain_is_fixed_width_and_dense():
+    runner = MTPVerificationGraphRunner.__new__(MTPVerificationGraphRunner)
+    runner.rows = 3
+    runner.attn_backend = SimpleNamespace(supports_cuda_graph=lambda _batch: True)
+
+    eligible = SimpleNamespace(
+        is_verify=True, size=1, input_ids=torch.zeros(3, dtype=torch.int32)
+    )
+    assert runner.can_use_cuda_graph(eligible)
+    eligible.input_ids = torch.zeros(2, dtype=torch.int32)
+    assert not runner.can_use_cuda_graph(eligible)
+    eligible.input_ids = torch.zeros(3, dtype=torch.int32)
+    eligible.is_verify = False
+    assert not runner.can_use_cuda_graph(eligible)

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -60,6 +60,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert qwen.intended_tier == "frontier"
     assert qwen.status == "experimental"
     assert qwen.evidence == (
+        "GB10-QWEN38-MTP-007",
         "GB10-QWEN38-NVFP4-OPT-004",
         "GB10-QWEN38-NVFP4-OPT-003",
         "GB10-QWEN38-NVFP4-OPT-002",
@@ -74,10 +75,10 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert "convert_expert_quantization" not in qwen.deployment.backend_options
     assert qwen.deployment.backend_options["nvfp4_backend"] == "triton"
     assert qwen.performance.decode_tokens_per_second == pytest.approx(
-        20.30646577455425
+        30.67455057137699
     )
     assert qwen.performance.warm_ttft_seconds == pytest.approx(
-        0.21166132600046694
+        0.2582157750002807
     )
     assert qwen.deployment.backend_options["moe_host_cache_gb"] == 0
     assert qwen.deployment.backend_options["moe_preload_all"] is True
@@ -418,11 +419,11 @@ def test_qwen_default_profile_evidence_passes_all_non_endurance_frontier_gates()
     assert any("duration_minutes" in reason for reason in evaluation.reasons)
 
 
-def test_qwen_native_mtp_evidence_selects_two_drafts_with_parity():
+def test_qwen_native_mtp_evidence_selects_three_drafts():
     recipe = get_recipe("qwen3.8-flash-next")
     root = Path(__file__).resolve().parents[2]
     result = json.loads(
-        (root / "benchmarks/gb10/results/GB10-QWEN38-NVFP4-OPT-004.json").read_text()
+        (root / "benchmarks/gb10/results/GB10-QWEN38-MTP-007.json").read_text()
     )
 
     assert result["result_id"] in recipe.evidence
@@ -435,14 +436,14 @@ def test_qwen_native_mtp_evidence_selects_two_drafts_with_parity():
     assert metrics["warm_ttft_seconds"] == pytest.approx(
         recipe.performance.warm_ttft_seconds
     )
+    assert metrics["mtp3_decode_tokens_per_second"] > metrics[
+        "mtp2_decode_tokens_per_second"
+    ]
     assert metrics["mtp2_decode_tokens_per_second"] > metrics[
         "mtp1_decode_tokens_per_second"
     ]
-    assert metrics["mtp2_decode_tokens_per_second"] > metrics[
-        "mtp3_decode_tokens_per_second"
-    ]
-    assert metrics["mtp2_improvement_percent"] == pytest.approx(34.237)
-    assert result["validation"]["all_widths_match_eager"] is True
+    assert metrics["mtp3_improvement_over_target_percent"] == pytest.approx(55.3466)
+    assert result["validation"]["all_mtp3_trials_deterministic"] is True
 
 
 def test_preview_and_certified_statuses_fail_closed_without_evidence_or_memory():

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -64,7 +64,7 @@ def test_models_human_table_groups_tiers_and_shows_performance_metrics(capsys):
     qwen38_row = next(
         line for line in output.splitlines() if line.startswith("Qwen3.8 Flash Next")
     )
-    assert qwen38_row.split()[-2:] == ["20.31", "0.212"]
+    assert qwen38_row.split()[-2:] == ["30.67", "0.258"]
     assert "No recipe is certified yet" not in output
 
 


### PR DESCRIPTION
## Summary
- capture fixed-shape dense-QSA MTP verification in a dedicated CUDA graph and route tiny verification MoE batches through decode kernels
- add an SM121 BF16 skinny-GEMM path for measured Qwen3.8 projection shapes
- update the selected profile to MTP3 at a measured 30.67 tok/s / 0.258 s warm TTFT, remove GLM-5.2 from the main table, and remove the requested Qwen profile note

## Benchmarks (NVIDIA GB10)
- MTP3: 30.67, 30.62, 30.67 tok/s (median 30.67)
- MTP2: 29.34, 29.15, 29.07 tok/s (median 29.15)
- MTP1: 25.19 tok/s
- target-only: 19.75 tok/s
- MTP2 kernel-off control: 27.65 tok/s
- 4,193-token QSA selection-reuse/side-stream experiments did not improve throughput and were removed

All three selected-profile runs produced the same output hash. The evidence record explicitly notes that this 128-token trace is not byte-identical to the shape-different target-only trace.

## Validation
- `1672 passed, 8 skipped` (tracked suite; ignored unrelated untracked `tests/test_document_query_demo.py`, which imports a missing untracked example)
- CUDA kernel reference checks for M=1 and M=3
- `git diff --check`