### PR TITLE
perf(dsv4): optimize small-row DSpark decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ a SparkLab support claim.
     <tr>
       <td><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731">DeepSeek V4 Flash</a></td>
       <td>284B total / 13B active</td>
-      <td>DS-FP4</td>
+      <td>DS-FP4 · FTW + optional DSpark5</td>
       <td>Preview</td>
-      <td align="right">10.28</td>
-      <td align="right">0.604</td>
+      <td align="right">13.15</td>
+      <td align="right">0.518</td>
       <td><a href="docs/models/deepseek-v4.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -12,6 +12,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
 - `results/GB10-DSV4-ADAPTIVE-004.json` records confidence-adaptive DSpark,
   replay-free first-draft rejection commits, residency profiling, true FP8
   window/compressed KV, and packed FP4 Lightning-Indexer storage.
+- `results/GB10-DSV4-SMALLM-005.json` records the SM121 small-row FP8/BF16 kernels,
+  the 6,550-slot residency and confidence-threshold sweeps, and the selected
+  three-trial DSpark5 burst median of 13.15 tok/s. Its 256-token control records
+  why target-only remains the sustained/default profile.
 - `results/GB10-BASELINE-001.json` records the measured DeepSeek V4 launch baseline.
 - `results/GB10-DSV4-SPARSE-001.json` records the optimized DeepSeek V4 route-first
   sparse-prefill probe: 10.28 decode tok/s and 0.604 s warm TTFT, with the baseline

--- a/benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json
+++ b/benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json
@@ -1,0 +1,156 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-DSV4-SMALLM-005",
+  "status": "measured",
+  "date": "2026-09-03",
+  "recipe": {
+    "slug": "deepseek-v4",
+    "recipe_version": "0.4.0",
+    "revision": "7872f01b1d1fe23eabc4c98b48bffcef5a386062"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "dda9be1cd89c06eddac74df43ba042320e18bb53",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "repository": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "revision": "7872f01b1d1fe23eabc4c98b48bffcef5a386062",
+    "format": "ftw-ds-fp4",
+    "quantization": "ds-fp4",
+    "fingerprint": "aeb9734fe8747554",
+    "ftw_bytes": 168424579072,
+    "target_layers": 43,
+    "draft_layers": 3
+  },
+  "workload": {
+    "single_stream": "AIME-25 problem 0, greedy, 48 prompt tokens, 128 completion tokens",
+    "client_path": "OpenAI-compatible streaming HTTP API",
+    "warmup_requests": 1,
+    "measured_trials": 3,
+    "sustained_control_completion_tokens": 256
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "moe_storage": "disk",
+    "expert_cache_slots": 6550,
+    "host_expert_cache_gib": 0,
+    "attention_backend": "dsv4_sparse",
+    "cache_type": "swa_radix",
+    "kv_tokens": 2048,
+    "max_running_requests": 1,
+    "selected_speculative_tokens": 5,
+    "dspark_confidence_threshold": 0.45,
+    "cuda_graph": false,
+    "small_m_fp8": true,
+    "skinny_bf16_head": true,
+    "fused_markov_argmax": true
+  },
+  "metrics": {
+    "decode_tokens_per_second": 13.147538086548575,
+    "warm_ttft_seconds": 0.5180109490029281,
+    "improvement_over_5250_slot_control_percent": 57.98967712169685,
+    "improvement_over_previous_homepage_result_percent": 27.866153204684085,
+    "kernel_improvement_percent": 3.691234974661861,
+    "target_only_128_tokens_per_second": 10.731684175383169,
+    "target_only_256_tokens_per_second": 10.515454285367987,
+    "target_only_256_warm_ttft_seconds": 0.6067378919979092,
+    "dspark_n1_256_tokens_per_second": 9.66932423182299,
+    "adaptive_n5_256_tokens_per_second": 9.312696881108959,
+    "adaptive_n5_256_warm_ttft_seconds": 1.5459657100000186,
+    "selected_device_allocation_gib": 92.15625,
+    "selected_free_memory_after_init_gib": 13.37
+  },
+  "trials": {
+    "selected_tokens_per_second": [
+      13.213165706067072,
+      13.147538086548575,
+      13.107955448735508
+    ],
+    "selected_warm_ttft_seconds": [
+      0.517095994000556,
+      0.5212577430065721,
+      0.5180109490029281
+    ],
+    "residency_sweep_tokens_per_second": {
+      "5250": 8.321770337198197,
+      "6304": 11.816098342148774,
+      "6550": 12.080325772943393
+    },
+    "confidence_threshold_sweep_tokens_per_second": {
+      "0.35": 12.011964384516189,
+      "0.40": 12.653360106908407,
+      "0.45": 13.147538086548575,
+      "0.47": 12.769929451541474,
+      "0.50": 12.12502939987536
+    },
+    "kernel_ablation_tokens_per_second": {
+      "all_disabled": 12.679507665003051,
+      "markov_only": 12.737322754104817,
+      "small_m_only": 13.002361199406996,
+      "all_enabled_median": 13.147538086548575
+    }
+  },
+  "speculative": {
+    "accepted_drafts": 66,
+    "drafted_tokens": 97,
+    "acceptance_rate": 0.68,
+    "outputs": 128,
+    "target_forwards": 62,
+    "outputs_per_target_forward": 2.06,
+    "replay_calls": 10,
+    "replay_tokens": 26,
+    "fast_carry_commits": 9
+  },
+  "validation": {
+    "checkpoint_checksum_verified": true,
+    "complete_checkpoint_loaded": true,
+    "native_dspark_weights_loaded": true,
+    "selected_output_sha1": "1a3ff31fdb3c",
+    "all_selected_trials_deterministic": true,
+    "all_selected_trials_same_speculative_counters": true,
+    "target_only_256_output_sha1": "461810a57c7c",
+    "target_only_256_preserved_prior_hash": true,
+    "api_stream_completed": true,
+    "oom_count": 0,
+    "swap_growth_bytes": 0,
+    "kernel_tests_passed": 17
+  },
+  "experiments": {
+    "retained": [
+      "SM121 small-row FP8 GEMM plans for the DSV4 decode projection shapes.",
+      "SM121 BF16 skinny vocabulary projection for one to six rows.",
+      "Fused BF16 Markov projection, base-logit addition, and greedy argmax.",
+      "A 6550-slot high-residency profile with a 0.45 adaptive DSpark threshold."
+    ],
+    "rejected": [
+      "Memory ratio 0.93 auto-sized 6958 expert slots but left only 8.15 GiB free after initialization.",
+      "Thresholds 0.35, 0.40, 0.47, and 0.50 all trailed the selected 0.45 profile.",
+      "DSpark N=1 and adaptive N=5 both trailed target-only decoding over the 256-token sustained probe."
+    ]
+  },
+  "source": {
+    "selected_artifacts": "/tmp/dsv4-smallm-adaptive-n5-t045-cache6550-{1,2,3}.json",
+    "disabled_control": "/tmp/dsv4-disabled-adaptive-n5-t045-cache6550-1.json",
+    "residency_artifacts": "/tmp/dsv4-current-adaptive-n5-{baseline,cache6304,cache6550}-1.json",
+    "sustained_target": "/tmp/dsv4-smallm-target-cache6550-256-1.json",
+    "sustained_dspark": "/tmp/dsv4-smallm-adaptive-n5-t045-cache6550-256-1.json",
+    "prior_evidence": "GB10-DSV4-ADAPTIVE-004"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The selected throughput profile covers batch-one greedy 128-token generation only and requires explicit DSpark and cache-size flags.",
+    "Over 256 generated tokens, target-only decoding remained faster than both tested DSpark profiles as later routes increased expert-cache churn.",
+    "The installed sparklab-kernel-cache reports 0.1.0+cu130 while the source runtime reports 0.1.1; the version guard was explicitly bypassed for this source-tree benchmark.",
+    "The 64K context, parser, coding-agent, broad quality, and endurance gates were not rerun for this optimization evidence."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -35,7 +35,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW | `qwen3.8-27b` | Experimental | 8.83 | 0.144 |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 30.67 | 0.258 |
-| [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 | `deepseek-v4` | Preview | 8.67 | 1.794 |
+| [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 13.15 | 0.518 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW | `glm-5.3-flash` | Experimental | 6.27 | 5.681 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
@@ -59,7 +59,7 @@ it remains opt-in pending the full certification suite.
 | Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Optimized native MTP2 reached 74.42 tok/s versus its 45.38 tok/s eager control; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json) |
 | Qwen3.8-27B | Passes Frontier speed, exact 64K recall, reasoning/tool parsing, and the coding-agent probe; the clean-revision 60-minute endurance gate remains outstanding. | [GB10-QWEN38-27B-001](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json) |
 | Qwen3.8-Flash-Next | The selected MTP3 profile measured a three-trial median 30.67 tok/s at 0.258 s warm TTFT. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-MTP-007](../benchmarks/gb10/results/GB10-QWEN38-MTP-007.json) |
-| DeepSeek V4 Flash | GPU-first expert residency reaches 8.67 tok/s. Native DSpark remains opt-in because N=1 still trails target-only decoding with disk-backed experts on one GB10. | [GB10-DSV4-RESIDENCY-003](../benchmarks/gb10/results/GB10-DSV4-RESIDENCY-003.json) |
+| DeepSeek V4 Flash | The selected three-trial DSpark5 burst profile reaches 13.15 tok/s. Target-only remains the default and wins the 256-token sustained control, 10.52 versus 9.31 tok/s. | [GB10-DSV4-SMALLM-005](../benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json) |
 | GLM-5.3 Flash | Passes Frontier speed; NVMe-sensitive TTFT and remaining certification gates keep it Experimental. | [GB10-GLM53-MHC-003](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json) |
 | GLM-5.2 | Below Frontier speed and recorded swap growth, so it remains Experimental. | [Experiment](../exps/exp_glm5_2_gb10.md) |
 | GLM-5.3 | Correctness is not established; the measured output reached its length cap before answering. | [GB10-GLM53-RESEARCH-001](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json) |

--- a/docs/models/deepseek-v4.md
+++ b/docs/models/deepseek-v4.md
@@ -57,25 +57,42 @@ See the [quick start](../quickstart.md) for API and agent examples.
 
 The fused 0731 checkpoint supports one to seven speculative tokens. DSpark is deliberately
 disabled in the default single-GB10 recipe because its extra three MoE draft layers and wider
-target verification increase expert traffic when experts are disk-backed. To experiment with
-the official probabilistic draft policy:
+target verification increase expert traffic when experts are disk-backed. For short,
+batch-one greedy bursts, the selected high-residency profile is:
 
 ```bash
 sparklab run deepseek-v4 --root /path/to/models -- \
   --speculative-method dspark \
-  --speculative-tokens 1 \
-  --draft-sample-method probabilistic
+  --speculative-tokens 5 \
+  --dspark-confidence-threshold 0.45 \
+  --moe-cache-size 6550
 ```
 
-The measured 256-token, batch-one matrix on one GB10 was:
+The 128-token threshold sweep used the same AIME-25 problem 0 prompt, one warmup request,
+greedy sampling, 2,048 KV tokens, and a 6,550-slot expert cache:
 
-| DSpark tokens | Decode tok/s | Acceptance | Outputs / target forward | Physical expert I/O |
-|---:|---:|---:|---:|---:|
-| disabled | 7.41 | — | 1.00 | 38.44 GiB |
-| 1 | 7.07 | 77.2% | 1.62 | 49.58 GiB |
-| 3 | 6.19 | 42.3% | 1.68 | 52.64 GiB |
-| 5 | 5.97 | 32.7% | 1.82 | 59.87 GiB |
-| 7 | 5.16 | 17.5% | 1.60 | 61.56 GiB |
+| Profile | Decode tok/s | Acceptance | Outputs / target forward |
+|---|---:|---:|---:|
+| target-only | 10.73 | — | 1.00 |
+| DSpark5, threshold 0.35 | 12.01 | 53.6% | 2.10 |
+| DSpark5, threshold 0.40 | 12.65 | 60.0% | 2.06 |
+| **DSpark5, threshold 0.45** | **13.15** | **68.0%** | **2.06** |
+| DSpark5, threshold 0.47 | 12.77 | 70.9% | 1.78 |
+| DSpark5, threshold 0.50 | 12.13 | 64.7% | 1.75 |
+
+The selected 0.45 profile reproduced the same output hash and speculative counters in
+three trials (13.21, 13.15, and 13.11 tok/s). The SM121 small-row FP8/BF16 kernels account
+for a measured 3.7% of its gain; higher expert residency and the adaptive cutoff provide
+the rest.
+
+This is a burst profile, not a universal default. Over the matched 256-token sustained
+probe, later routed-expert churn reversed the ordering:
+
+| Profile | Decode tok/s | Warm TTFT |
+|---|---:|---:|
+| **target-only** | **10.52** | **0.607 s** |
+| DSpark1 | 9.67 | 1.579 s |
+| DSpark5, threshold 0.45 | 9.31 | 1.546 s |
 
 These numbers are not directly comparable to vLLM's resident two-DGX-Spark setup. SparkLab's
 single-GB10 path makes the 167 GB fused checkpoint fit by keeping most experts on NVMe, and the

--- a/python/sparklab/kernels/triton/dsv4/fp8_linear.py
+++ b/python/sparklab/kernels/triton/dsv4/fp8_linear.py
@@ -22,6 +22,9 @@ Assumes ``K % 128 == 0`` and ``N % 128 == 0`` (true for every DeepSeek-V4 projec
 
 from __future__ import annotations
 
+import functools
+import os
+
 import torch
 import triton
 import triton.language as tl
@@ -315,6 +318,25 @@ _DECODE_FP8_CFG = {
     (8192, 1024): (16, 2, 4),    # indexer wq_b
 }
 
+# DSpark and target verification present only 2--6 rows to these projections.  A
+# 32-row tile spends most of its work on masked lanes, so use the swept-best
+# SM121 configurations for the exact DSV4 matrix shapes.  Larger prefill batches
+# retain the established general GEMM configuration.
+_SM121_SMALL_M_FP8_CFG = {
+    (1024, 4096): (4, 4),
+    (32768, 1024): (4, 4),
+    (512, 4096): (4, 4),
+    (4096, 8192): (8, 4),
+    (2048, 4096): (8, 3),
+    (4096, 2048): (4, 2),
+    (4096, 12288): (8, 4),
+}
+
+
+@functools.cache
+def _is_sm121(device_index: int) -> bool:
+    return torch.cuda.get_device_capability(device_index) == (12, 1)
+
 
 def _decode_cfg(N: int, K: int) -> tuple[int, int, int]:
     cfg = _DECODE_FP8_CFG.get((N, K))
@@ -380,9 +402,18 @@ def block_fp8_linear(
         return out
 
     out = torch.empty((M, N), dtype=compute_dtype, device=x.device)
-    BLOCK_M = 32
+    small_m_cfg = _SM121_SMALL_M_FP8_CFG.get((N, K))
+    use_small_m = (
+        2 <= M <= 6
+        and small_m_cfg is not None
+        and _is_sm121(x.device.index or 0)
+        and os.getenv("SPARKLAB_DISABLE_DSV4_SMALL_M", "0").strip().lower()
+        not in {"1", "true", "yes", "on"}
+    )
+    BLOCK_M = 16 if use_small_m else 32
     BLOCK_N = 128
     BLOCK_K = 128
+    num_warps, num_stages = small_m_cfg if use_small_m else (4, 3)
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
     _fp8_act_gemm_kernel[grid](
         a_fp8, w, sa, sb, out,
@@ -391,7 +422,7 @@ def block_fp8_linear(
         sa.stride(0), sa.stride(1), sb.stride(0), sb.stride(1),
         out.stride(0), out.stride(1),
         BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
-        compute_type=_TL_DTYPE[compute_dtype], num_warps=4, num_stages=3,
+        compute_type=_TL_DTYPE[compute_dtype], num_warps=num_warps, num_stages=num_stages,
     )
     out = out.reshape(*lead, N)
     if bias is not None:

--- a/python/sparklab/kernels/triton/dsv4/skinny.py
+++ b/python/sparklab/kernels/triton/dsv4/skinny.py
@@ -1,0 +1,178 @@
+"""Small-row BF16 kernels for DeepSeek-V4 decode and DSpark."""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _bf16_skinny_kernel(
+    x_ptr,
+    w_ptr,
+    out_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_xm: tl.constexpr,
+    stride_wn: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs_m = tl.arange(0, BLOCK_M)
+    m_mask = offs_m < M
+    offs_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    n_mask = offs_n < N
+    acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+    for k0 in range(0, K, BLOCK_K):
+        offs_k = k0 + tl.arange(0, BLOCK_K)
+        k_mask = offs_k < K
+        x = tl.load(
+            x_ptr + offs_m[:, None] * stride_xm + offs_k[None, :],
+            mask=m_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        w = tl.load(
+            w_ptr + offs_n[:, None] * stride_wn + offs_k[None, :],
+            mask=n_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        acc += tl.sum(x[:, None, :] * w[None, :, :], axis=2)
+    tl.store(
+        out_ptr + offs_m[:, None] * N + offs_n[None, :],
+        acc,
+        mask=m_mask[:, None] & n_mask[None, :],
+    )
+
+
+def bf16_skinny_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute a contiguous bias-free BF16 linear for one to six rows."""
+    *lead, k = x.shape
+    m = x.numel() // k
+    n = weight.shape[0]
+    if not 1 <= m <= 6:
+        raise ValueError(f"DSV4 skinny linear requires 1 <= M <= 6, got {m}")
+    x2 = x.reshape(m, k).contiguous()
+    out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    num_warps = 8 if m == 1 else 2 if m == 3 else 4
+    _bf16_skinny_kernel[(n,)](
+        x2,
+        weight,
+        out,
+        M=m,
+        N=n,
+        K=k,
+        stride_xm=x2.stride(0),
+        stride_wn=weight.stride(0),
+        BLOCK_M=triton.next_power_of_2(m),
+        BLOCK_N=1,
+        BLOCK_K=min(triton.next_power_of_2(k), 4096),
+        num_warps=num_warps,
+    )
+    return out.reshape(*lead, n)
+
+
+@functools.cache
+def _is_sm121(device_index: int) -> bool:
+    return torch.cuda.get_device_capability(device_index) == (12, 1)
+
+
+def dsv4_head_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Use the measured SM121 vocabulary kernel when eligible."""
+    k = x.shape[-1]
+    m = x.numel() // k
+    if not (
+        x.is_cuda
+        and x.dtype == torch.bfloat16
+        and weight.dtype == torch.bfloat16
+        and weight.is_contiguous()
+        and tuple(weight.shape) == (129280, 4096)
+        and 1 <= m <= 6
+        and _is_sm121(x.device.index or 0)
+        and os.getenv("SPARKLAB_DISABLE_DSV4_SMALL_M", "0").strip().lower()
+        not in {"1", "true", "yes", "on"}
+    ):
+        return F.linear(x, weight)
+    return bf16_skinny_linear(x, weight)
+
+
+@triton.jit
+def _markov_partial_argmax_kernel(
+    base_ptr,
+    markov_ptr,
+    weight_ptr,
+    values_ptr,
+    indices_ptr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    n_mask = offs_n < N
+    offs_k = tl.arange(0, K)
+    markov = tl.load(markov_ptr + offs_k).to(tl.float32)
+    weight = tl.load(
+        weight_ptr + offs_n[:, None] * K + offs_k[None, :],
+        mask=n_mask[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    # Match torch's BF16 linear followed by its BF16 add before comparing.
+    projected = tl.sum(weight * markov[None, :], axis=1).to(tl.bfloat16)
+    base = tl.load(base_ptr + offs_n, mask=n_mask, other=-float("inf"))
+    score = (projected + base).to(tl.bfloat16).to(tl.float32)
+    local = tl.argmax(score, axis=0)
+    tl.store(values_ptr + pid, tl.max(score, axis=0))
+    tl.store(indices_ptr + pid, pid * BLOCK_N + local)
+
+
+def dsv4_markov_argmax(
+    base_logits: torch.Tensor,
+    markov: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """Fuse the DSpark Markov projection, base-logit add, and greedy argmax."""
+    n, k = weight.shape
+    eligible = (
+        os.getenv("SPARKLAB_DISABLE_DSV4_MARKOV_FUSION", "0").strip().lower()
+        not in {"1", "true", "yes", "on"}
+        and base_logits.is_cuda
+        and markov.is_cuda
+        and weight.is_cuda
+        and base_logits.dtype == torch.bfloat16
+        and markov.dtype == torch.bfloat16
+        and weight.dtype == torch.bfloat16
+        and weight.is_contiguous()
+        and tuple(base_logits.shape) == (1, n)
+        and tuple(markov.shape) == (1, k)
+        and k == 256
+        and _is_sm121(weight.device.index or 0)
+    )
+    if not eligible:
+        return torch.argmax(base_logits + F.linear(markov, weight), dim=-1)
+    block_n = 8
+    blocks = triton.cdiv(n, block_n)
+    values = torch.empty(blocks, dtype=torch.float32, device=weight.device)
+    indices = torch.empty(blocks, dtype=torch.int64, device=weight.device)
+    _markov_partial_argmax_kernel[(blocks,)](
+        base_logits.reshape(-1),
+        markov.reshape(-1),
+        weight,
+        values,
+        indices,
+        N=n,
+        K=k,
+        BLOCK_N=block_n,
+        num_warps=8,
+    )
+    return indices[torch.argmax(values)].reshape(1)
+
+
+__all__ = ["bf16_skinny_linear", "dsv4_head_linear", "dsv4_markov_argmax"]

--- a/python/sparklab/models/deepseek_v4/dspark.py
+++ b/python/sparklab/models/deepseek_v4/dspark.py
@@ -15,6 +15,10 @@ from torch import nn
 
 from sparklab.core import get_global_ctx
 from sparklab.kernels.triton.dsv4.hc import hc_pre_combine
+from sparklab.kernels.triton.dsv4.skinny import (
+    dsv4_head_linear,
+    dsv4_markov_argmax,
+)
 
 from .args import DeepseekV4Args
 from .layers import Linear, RMSNorm
@@ -245,7 +249,7 @@ class DSparkDraft(nn.Module):
                 context_start=context_start,
             )
         head_hidden = self.hc_head(hidden)
-        base_logits = F.linear(self.norm(head_hidden)[0], head_weight)
+        base_logits = dsv4_head_linear(self.norm(head_hidden)[0], head_weight)
 
         previous = anchor
         drafts = []
@@ -254,12 +258,14 @@ class DSparkDraft(nn.Module):
         for row in range(n_query):
             markov = F.embedding(previous, self.markov_w1)
             markov_embeds.append(markov.squeeze(0))
-            logits = base_logits[row : row + 1] + F.linear(markov, self.markov_w2)
             if req.sampling_params.is_greedy:
-                token = torch.argmax(logits, dim=-1)
+                token = dsv4_markov_argmax(
+                    base_logits[row : row + 1], markov, self.markov_w2
+                )
             else:
                 from sparklab.runtime.engine.sample import sampling_distribution
 
+                logits = base_logits[row : row + 1] + F.linear(markov, self.markov_w2)
                 probs = sampling_distribution(logits, req.sampling_params)
                 token = torch.multinomial(probs, 1).squeeze(-1)
                 draft_probs.append(probs.squeeze(0))

--- a/python/sparklab/models/deepseek_v4/model.py
+++ b/python/sparklab/models/deepseek_v4/model.py
@@ -27,6 +27,7 @@ from torch import nn
 
 from sparklab.core import get_global_ctx
 from sparklab.kernels.triton.dsv4.hc import hc_post_combine, hc_pre_combine
+from sparklab.kernels.triton.dsv4.skinny import dsv4_head_linear
 from sparklab.kernels.triton.dsv4.sinkhorn import hc_split_sinkhorn
 from sparklab.models.blocks import BaseLLMModel
 
@@ -208,7 +209,7 @@ class Transformer(nn.Module):
         h = self.hc_head(h)
         h = self.norm(h)
         rows = h[0] if return_all_logits else h[0, last_indices]
-        logits = F.linear(rows, self.head)
+        logits = dsv4_head_linear(rows, self.head)
         return (logits, aux) if aux_layer_ids else logits
 
     def decode(
@@ -242,7 +243,7 @@ class Transformer(nn.Module):
                 aux.append(h.mean(dim=2))
         h = self.hc_head(h)
         h = self.norm(h)
-        logits = F.linear(h[:, -1], self.head)
+        logits = dsv4_head_linear(h[:, -1], self.head)
         return (logits, aux) if aux_layer_ids else logits
 
 

--- a/python/sparklab/recipes/deepseek-v4.json
+++ b/python/sparklab/recipes/deepseek-v4.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.3.1",
+  "recipe_version": "0.4.0",
   "slug": "deepseek-v4",
   "name": "DeepSeek V4 Flash",
   "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
@@ -38,17 +38,17 @@
     "total_bytes": 107374182400
   },
   "performance": {
-    "decode_tokens_per_second": 8.673403327989714,
-    "warm_ttft_seconds": 1.7943157120025717,
-    "evidence": "GB10-DSV4-RESIDENCY-003",
-    "note": "A zero-entry host LRU leaves GB10 unified memory available for 6,304 GPU expert slots. The fixed 256-token target-only probe improved 17.1% over the prior 4 GiB host-LRU recipe while preserving its exact greedy hash. DSpark N=1 improved to 8.27 tok/s but remains slower than target-only."
+    "decode_tokens_per_second": 13.147538086548575,
+    "warm_ttft_seconds": 0.5180109490029281,
+    "evidence": "GB10-DSV4-SMALLM-005",
+    "note": "The selected opt-in DSpark5 batch-one greedy profile measured a three-trial median 13.15 tok/s and 0.518 s warm TTFT over 128 tokens with 6,550 expert slots and a 0.45 confidence threshold. Target-only remains the default and measured 10.52 tok/s over the sustained 256-token control."
   },
-  "description": "Fused DS-FP4 Frontier recipe with GPU-first expert residency, optional native DSpark speculative decoding, and route-first sparse prefill on one NVIDIA GB10.",
-  "evidence": ["GB10-DSV4-RESIDENCY-003", "GB10-DSV4-DSPARK-002"],
+  "description": "Fused DS-FP4 Frontier recipe with GPU-first expert residency, SM121 small-row kernels, optional confidence-adaptive DSpark speculative decoding, and route-first sparse prefill on one NVIDIA GB10.",
+  "evidence": ["GB10-DSV4-SMALLM-005", "GB10-DSV4-RESIDENCY-003", "GB10-DSV4-ADAPTIVE-004", "GB10-DSV4-DSPARK-002"],
   "limitations": [
     "The 64K context and 60-minute agent gates have not passed.",
     "Capability, quality, parser, and agent gates remain incomplete.",
-    "DSpark is opt-in: N=1 measured 8.27 tok/s versus an 8.67 tok/s target-only control after the residency optimization; longer draft widths need a fresh matrix under this policy.",
+    "The selected DSpark5 profile is opt-in and tuned for batch-one greedy bursts: it reached 13.15 tok/s over 128 tokens, while target-only remained faster over the 256-token sustained probe (10.52 versus 9.31 tok/s).",
     "The zero-entry host LRU is tuned for GB10 unified memory, where host and GPU allocations compete for the same physical capacity; discrete-GPU systems may benefit from a host LRU.",
     "The 512-token sparse-prefill threshold is optimized for short interactive prompts; longer prefills retain the bounded full-layer streaming path."
   ]

--- a/tests/kernels/test_dsv4_skinny.py
+++ b/tests/kernels/test_dsv4_skinny.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+@pytest.mark.parametrize("rows", [1, 3, 6])
+def test_dsv4_bf16_skinny_linear_matches_torch(rows: int) -> None:
+    from sparklab.kernels.triton.dsv4.skinny import bf16_skinny_linear
+
+    torch.manual_seed(17)
+    x = torch.randn(rows, 96, device="cuda", dtype=torch.bfloat16) * 0.1
+    weight = torch.randn(65, 96, device="cuda", dtype=torch.bfloat16) * 0.1
+
+    actual = bf16_skinny_linear(x, weight)
+    expected = F.linear(x, weight)
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_dsv4_markov_argmax_matches_torch() -> None:
+    from sparklab.kernels.triton.dsv4.skinny import dsv4_markov_argmax
+
+    torch.manual_seed(23)
+    base = torch.randn(1, 1025, device="cuda", dtype=torch.bfloat16)
+    markov = torch.randn(1, 256, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1025, 256, device="cuda", dtype=torch.bfloat16)
+
+    actual = dsv4_markov_argmax(base, markov, weight)
+    expected = torch.argmax(base + F.linear(markov, weight), dim=-1)
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.cuda.get_device_capability() != (12, 1),
+    reason="needs SM121 CUDA",
+)
+def test_dsv4_small_m_fp8_plan_matches_general_plan(monkeypatch) -> None:
+    from sparklab.kernels.triton.dsv4.fp8_linear import block_fp8_linear
+
+    torch.manual_seed(29)
+    x = torch.randn(5, 4096, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1024, 4096, device="cuda").to(torch.float8_e4m3fn)
+    scale = torch.full(
+        (1024 // 128, 4096 // 128), 127, device="cuda", dtype=torch.uint8
+    )
+
+    actual = block_fp8_linear(x, weight, scale)
+    monkeypatch.setenv("SPARKLAB_DISABLE_DSV4_SMALL_M", "1")
+    expected = block_fp8_linear(x, weight, scale)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_dsv4_skinny_helpers_fall_back_on_cpu() -> None:
+    from sparklab.kernels.triton.dsv4.skinny import (
+        dsv4_head_linear,
+        dsv4_markov_argmax,
+    )
+
+    x = torch.randn(2, 4)
+    weight = torch.randn(3, 4)
+    torch.testing.assert_close(dsv4_head_linear(x, weight), F.linear(x, weight))
+
+    base = torch.randn(1, 3)
+    markov = torch.randn(1, 4)
+    torch.testing.assert_close(
+        dsv4_markov_argmax(base, markov, weight),
+        torch.argmax(base + F.linear(markov, weight), dim=-1),
+    )

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -117,13 +117,13 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert glm52.performance.decode_tokens_per_second == pytest.approx(0.802)
     assert glm52.performance.warm_ttft_seconds == pytest.approx(2.57)
     deepseek = get_recipe("deepseek-v4")
-    assert deepseek.recipe_version == "0.3.1"
+    assert deepseek.recipe_version == "0.4.0"
     assert deepseek.revision == "7872f01b1d1fe23eabc4c98b48bffcef5a386062"
     assert deepseek.performance.decode_tokens_per_second == pytest.approx(
-        8.673403327989714
+        13.147538086548575
     )
     assert deepseek.performance.warm_ttft_seconds == pytest.approx(
-        1.7943157120025717
+        0.5180109490029281
     )
     assert deepseek.deployment.backend_options["moe_prefill_sparse_max_tokens"] == 512
     assert deepseek.deployment.backend_options["moe_cache_auto"] is True
@@ -225,34 +225,36 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert deepseek.minimum_free_bytes > deepseek.source_bytes + deepseek.prepared_bytes
 
 
-def test_deepseek_recipe_points_to_checked_in_residency_evidence():
+def test_deepseek_recipe_points_to_checked_in_small_m_evidence():
     recipe = get_recipe("deepseek-v4")
     assert recipe.evidence == (
+        "GB10-DSV4-SMALLM-005",
         "GB10-DSV4-RESIDENCY-003",
+        "GB10-DSV4-ADAPTIVE-004",
         "GB10-DSV4-DSPARK-002",
     )
     root = Path(__file__).resolve().parents[2]
     result = json.loads(
-        (root / "benchmarks/gb10/results/GB10-DSV4-RESIDENCY-003.json").read_text()
+        (root / "benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json").read_text()
     )
     assert result["result_id"] == recipe.evidence[0]
     assert result["status"] == "measured"
-    assert result["model"]["revision"] == recipe.revision
-    assert result["model"]["checkpoint_bytes"] == recipe.prepared_bytes
-    assert result["metrics"]["target_only"]["decode_tokens_per_second"] == pytest.approx(
-        8.673403327989714
+    assert result["recipe"]["revision"] == recipe.revision
+    assert result["checkpoint"]["ftw_bytes"] == recipe.prepared_bytes
+    assert result["metrics"]["decode_tokens_per_second"] == pytest.approx(
+        13.147538086548575
     )
-    assert result["metrics"]["target_only"]["warm_ttft_seconds"] == pytest.approx(
-        1.7943157120025717
+    assert result["metrics"]["warm_ttft_seconds"] == pytest.approx(
+        0.5180109490029281
     )
-    assert result["metrics"]["target_only"]["speedup_percent"] == pytest.approx(
-        17.087012508833933
+    assert result["metrics"]["kernel_improvement_percent"] == pytest.approx(
+        3.691234974661861
     )
-    assert result["metrics"]["dspark_n1"]["decode_tokens_per_second"] < result[
+    assert result["metrics"]["adaptive_n5_256_tokens_per_second"] < result[
         "metrics"
-    ]["target_only"]["decode_tokens_per_second"]
-    assert result["validation"]["target_output_hash_preserved"] is True
-    assert result["validation"]["all_runs_oom_count"] == 0
+    ]["target_only_256_tokens_per_second"]
+    assert result["validation"]["all_selected_trials_deterministic"] is True
+    assert result["validation"]["oom_count"] == 0
 
 
 def test_glm53_recipe_points_to_checked_in_fused_mhc_evidence():

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -53,7 +53,7 @@ def test_models_human_table_groups_tiers_and_shows_performance_metrics(capsys):
     assert "FAST — Routine chat, editing, and short agent loops" in output
     assert "FRONTIER — Hard coding, reasoning, and long agent work" in output
     assert "RESEARCH — Complete or novel models" in output
-    assert "8.67" in output and "1.794" in output
+    assert "13.15" in output and "0.518" in output
     assert "Qwen3.6 35B A3B" in output and "NVFP4" in output
     assert "Qwen3.8 27B" in output
     assert "35B total / 3B active" in output


### PR DESCRIPTION
## Summary
- add SM121 small-row FP8 and BF16 kernels for DeepSeek V4 decode
- fuse the DSpark Markov projection and greedy argmax
- publish the selected 13.15 tok/s DSpark5 burst profile and sustained controls
- update the model recipe, performance tables, documentation, and tests

## Benchmark
- selected three-trial median: 13.15 tok/s, 0.518 s warm TTFT
- improvement over previous homepage result: 27.9%
- kernel ablation improvement: 3.7%
- sustained 256-token target-only control: 10.52 tok/s versus 9.31 tok/s DSpark5

## Tests
- `PYTHONPATH=python:. .venv/bin/pytest -q tests/sparklab/test_catalog.py tests/sparklab/test_cli.py tests/kernels/test_dsv4_skinny.py tests/kernels/test_e4m3_compat.py tests/dsv4 tests/runtime/engine/test_cache_budget.py`
- 70 passed
- final targeted rerun after adding FP8-plan coverage: 28 passed
- `git diff --check`