### PR TITLE
perf(glm53): add optimized native MTP decoding

### DIFF
--- a/benchmarks/gb10/results/GB10-GLM53-MTP-004.json
+++ b/benchmarks/gb10/results/GB10-GLM53-MTP-004.json
@@ -1,0 +1,163 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-GLM53-MTP-004",
+  "status": "measured",
+  "date": "2026-09-03",
+  "recipe": {
+    "slug": "glm-5.3-flash",
+    "recipe_version": "0.3.2",
+    "revision": "9eaeadaf026871a90640e32c0604f6ab0b2d641d"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "e66fd0ede48b9b99fd1533370db8874e5d4ec2b6",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "os": "Linux 6.17.0-1014-nvidia",
+    "driver": "580.126.09",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "target_repository": "oakmindai/GLM-5.3-Flash-NVFP4-FTW",
+    "target_revision": "f296cec0baceb2276121efe76f14d61b62c1e47d",
+    "target_source_repository": "RedHatAI/GLM-5.3-Flash-NVFP4",
+    "target_source_revision": "9eaeadaf026871a90640e32c0604f6ab0b2d641d",
+    "mtp_repository": "RedHatAI/GLM-5.3-Flash-NVFP4",
+    "mtp_revision": "36c184c6cda000a481711306df5adde42f63321a",
+    "format": "ftw-nvfp4-kda-fp8 + native block-FP8 MTP sidecar",
+    "fingerprint": "4c021651a1e61802",
+    "target_bytes": 184716947456,
+    "mtp_sidecar_bytes": 7618560424
+  },
+  "workload": {
+    "name": "AIME-25 problem 0 fixed decode probe",
+    "batch_size": 1,
+    "sampling": "greedy",
+    "prompt_tokens": 54,
+    "requested_completion_tokens": 256,
+    "returned_completion_tokens": 256,
+    "warmup_requests": 1,
+    "measured_width_sweep_trials": 1,
+    "selected_profile_confirmation_trials": 1,
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "expert_storage": "disk",
+    "expert_cache_slots": 6149,
+    "host_cache_gib": 0.0,
+    "memory_ratio": 0.96,
+    "disk_read_workers": 16,
+    "nvfp4_backend": "triton",
+    "attention_backend": "dsa",
+    "cuda_graph": false,
+    "kv_tokens": 8691,
+    "page_size": 1,
+    "cache_type": "naive",
+    "sparse_prefill_max_tokens": 512,
+    "prefill_overlap": false,
+    "prefill_hit_d2d": true,
+    "selected_speculative_tokens": 3,
+    "draft_sample_method": "greedy",
+    "max_running_requests": 1,
+    "cache_selection": "fixed identically for target-only and every MTP width"
+  },
+  "metrics": {
+    "decode_tokens_per_second": 7.232163486318814,
+    "decode_milliseconds_per_token": 138.27121052942377,
+    "warm_ttft_seconds": 6.35418865000247,
+    "cold_ttft_seconds": 10.6965050130093,
+    "target_only_decode_tokens_per_second": 5.515925334392649,
+    "target_only_warm_ttft_seconds": 6.539440016989829,
+    "mtp1_decode_tokens_per_second": 6.624414297614111,
+    "mtp2_decode_tokens_per_second": 6.925768188974994,
+    "mtp3_decode_tokens_per_second": 7.232163486318814,
+    "mtp4_decode_tokens_per_second": 6.37130701778905,
+    "mtp3_improvement_over_matched_target_percent": 31.11423828065898,
+    "mtp3_improvement_over_published_target_percent": 15.319605724290408,
+    "confirmation_decode_tokens_per_second": 7.326788713314543,
+    "confirmation_delta_percent": 1.308394468332108,
+    "selected_profile_two_trial_mean_tokens_per_second": 7.279476099816678,
+    "device_allocation_gib": 101.408203125,
+    "minimum_mem_available_gib": 7.317588806152344,
+    "expert_cache_miss_rate_percent": 11.447956234023748,
+    "expert_disk_read_operations": 76494,
+    "physical_io_gib": 168.2721710205078,
+    "power_watts_average": 28.031,
+    "power_watts_peak": 34.86,
+    "estimated_request_energy_joules": 1166.5182497995693
+  },
+  "trials": {
+    "mtp3_tokens_per_second": [
+      7.232163486318814,
+      7.326788713314543
+    ],
+    "mtp3_warm_ttft_seconds": [
+      6.35418865000247,
+      6.324655018994235
+    ],
+    "mtp3_output_sha1": [
+      "d3523265958c",
+      "d3523265958c"
+    ]
+  },
+  "speculative": {
+    "draft_tokens_per_step": 3,
+    "accepted_drafts": 174,
+    "drafted_tokens": 198,
+    "acceptance_rate": 0.879,
+    "outputs": 256,
+    "target_forwards": 82,
+    "outputs_per_target_forward": 3.12,
+    "replay_calls": 15,
+    "replay_tokens": 36
+  },
+  "validation": {
+    "complete_target_checkpoint_loaded": true,
+    "native_mtp_weights_loaded": true,
+    "released_sidecar_tensor_layout_validated": true,
+    "transactional_rejection_rollback": true,
+    "forced_rejection_smoke_test": true,
+    "api_stream_completed": true,
+    "target_only_output_sha1": "d3523265958c",
+    "mtp2_output_sha1": "d3523265958c",
+    "mtp3_output_sha1": "d3523265958c",
+    "mtp3_exact_target_only_trace_parity": true,
+    "mtp3_confirmation_deterministic": true,
+    "focused_tests_passed": 219,
+    "oom_count": 0,
+    "service_restarts": 0,
+    "swap_growth_bytes": 0
+  },
+  "admission": {
+    "tier": "frontier",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "Three native MTP draft tokens improved matched batch-one greedy decode throughput by 31.11% and the published target-only result by 15.32%.",
+      "The selected MTP-3 trace and exact target-only output hash reproduced in a confirmation run.",
+      "The 64K context, parser, coding-agent, broad quality, concurrent traffic, sampled traffic, and endurance gates remain outstanding."
+    ]
+  },
+  "source": {
+    "width_sweep_artifact": "$HOME/results/glm5.3-gb10/glm53_mtp_sweep_decode256.jsonl",
+    "confirmation_artifact": "$HOME/results/glm5.3-gb10/glm53_mtp3_confirm_decode256.jsonl",
+    "prior_target_evidence": "GB10-GLM53-MHC-003"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The sweep covers one batch-one greedy math workload with one measured request per width; only the selected MTP-3 profile received a confirmation trial.",
+    "The resident MTP block raises device allocation by about 7.25 GiB. The matched target control therefore fixed the expert cache at 6,149 slots, below the 6,711-slot cache used by the published target-only result.",
+    "MTP-1 and MTP-4 differ from the target-only greedy output hash because verification batch shapes can change BF16 reduction order; MTP-2 and both MTP-3 trials exactly match the target-only hash.",
+    "The pinned prebuilt FTW predates native-MTP packaging and requires SPARKLAB_GLM5_MTP_PATH; new source conversions copy the sidecar into the prepared artifact.",
+    "The installed sparklab-kernel-cache reports 0.1.0+cu130 while the source runtime reports 0.1.1; the version guard was explicitly bypassed for this source-tree benchmark.",
+    "The exact 64K context, parser, coding-agent, broad quality, concurrent, sampled, and endurance gates were not rerun for this optimization evidence."
+  ]
+}

--- a/benchmarks/gb10/results/GB10-GLM53-OPT-005.json
+++ b/benchmarks/gb10/results/GB10-GLM53-OPT-005.json
@@ -1,0 +1,182 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-GLM53-OPT-005",
+  "status": "measured",
+  "date": "2026-09-03",
+  "recipe": {
+    "slug": "glm-5.3-flash",
+    "recipe_version": "0.3.2",
+    "revision": "9eaeadaf026871a90640e32c0604f6ab0b2d641d"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "e66fd0ede48b9b99fd1533370db8874e5d4ec2b6",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "os": "Linux 6.17.0-1014-nvidia",
+    "driver": "580.126.09",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "target_repository": "oakmindai/GLM-5.3-Flash-NVFP4-FTW",
+    "target_revision": "f296cec0baceb2276121efe76f14d61b62c1e47d",
+    "mtp_repository": "RedHatAI/GLM-5.3-Flash-NVFP4",
+    "mtp_revision": "36c184c6cda000a481711306df5adde42f63321a",
+    "format": "ftw-nvfp4-kda-fp8 + native block-FP8 MTP sidecar",
+    "fingerprint": "4c021651a1e61802"
+  },
+  "workload": {
+    "name": "AIME-25 problem 0 fixed decode probe",
+    "batch_size": 1,
+    "sampling": "greedy",
+    "prompt_tokens": 54,
+    "requested_completion_tokens": 256,
+    "returned_completion_tokens": 256,
+    "warmup_requests": 1,
+    "measured_requests_per_profile": 1,
+    "selected_profile_trials": 2,
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "configuration": {
+    "moe_backend": "offload",
+    "expert_storage": "disk",
+    "expert_cache_slots": 6149,
+    "host_cache_gib": 0.0,
+    "memory_ratio": 0.96,
+    "disk_read_workers": 16,
+    "nvfp4_backend": "triton",
+    "attention_backend": "dsa",
+    "cuda_graph": false,
+    "kv_tokens": 8691,
+    "page_size": 1,
+    "cache_type": "naive",
+    "sparse_prefill_max_tokens": 512,
+    "prefill_overlap": false,
+    "prefill_hit_d2d": true,
+    "shared_expert_overlap": true,
+    "speculative_tokens": 3,
+    "draft_sample_method": "greedy",
+    "max_running_requests": 1
+  },
+  "optimization": {
+    "lm_head": "Add the measured (154880, 4096) BF16 LM-head shape to the SM121 skinny-linear dispatch plan.",
+    "moe": "Enable shared-expert compute overlap with routed-expert fetches.",
+    "kernel_microbenchmark": {
+      "shape": [1, 4096, 154880],
+      "dtype": "bfloat16",
+      "cublas_median_milliseconds": 7.259,
+      "skinny_kernel_median_milliseconds": 5.189,
+      "kernel_speedup_percent": 39.89207939872807
+    }
+  },
+  "metrics": {
+    "decode_tokens_per_second_trials": [
+      7.434312587204139,
+      7.438127464997259
+    ],
+    "decode_tokens_per_second_mean": 7.436220026100699,
+    "decode_milliseconds_per_token_mean": 134.477,
+    "warm_ttft_seconds_trials": [
+      6.338262710007257,
+      6.322526349991676
+    ],
+    "prior_mtp3_tokens_per_second": 7.232163486318814,
+    "improvement_over_prior_mtp3_percent": 2.8215144772086864,
+    "device_allocation_gib": 101.4296875,
+    "minimum_mem_available_gib": 7.349803924560547,
+    "expert_cache_miss_rate_percent": 11.447956234023748,
+    "expert_disk_read_operations": 76494,
+    "physical_io_gib": 168.2721710205078,
+    "shared_expert_overlap_calls": 4074,
+    "power_watts_average_trials": [
+      28.44325,
+      28.472249999999995
+    ],
+    "output_sha1": "d3523265958c"
+  },
+  "matched_target_only_probe": {
+    "note": "Supportive one-trial A/B with the same optimized LM-head dispatch; it is not used as the headline result.",
+    "cache_slots": 6711,
+    "without_shared_overlap_tokens_per_second": 6.00923206154776,
+    "with_shared_overlap_tokens_per_second": 6.179847285746255,
+    "shared_overlap_improvement_percent": 2.8392184300925605,
+    "without_shared_overlap_warm_ttft_seconds": 5.650309573989944,
+    "with_shared_overlap_warm_ttft_seconds": 5.722599658998661,
+    "identical_output_sha1": "d3523265958c",
+    "identical_expert_disk_reads": 59604,
+    "identical_physical_io_gib": 131.1171875
+  },
+  "speculative": {
+    "draft_tokens_per_step": 3,
+    "accepted_drafts": 174,
+    "drafted_tokens": 198,
+    "acceptance_rate": 0.879,
+    "outputs": 256,
+    "target_forwards": 82,
+    "outputs_per_target_forward": 3.12,
+    "replay_calls": 15,
+    "replay_tokens": 36
+  },
+  "tested_not_selected": [
+    {
+      "change": "Increase disk readers from 16 to 20",
+      "decode_tokens_per_second": 7.329066073383206,
+      "reason": "No measurable benefit over the 16-reader 7.3316799344508405 tok/s trial."
+    },
+    {
+      "change": "Use layer_lru instead of lru expert-cache policy",
+      "decode_tokens_per_second": 6.932931152812196,
+      "expert_cache_miss_rate_percent": 12.72725100934088,
+      "physical_io_gib": 206.77322578430176,
+      "reason": "Throughput fell 5.44% while cache misses and physical I/O increased."
+    },
+    {
+      "change": "Convert one real resident MTP expert from FP8 to NVFP4",
+      "fp8_median_milliseconds": 0.201,
+      "nvfp4_median_milliseconds": 0.336,
+      "storage_reduction_percent": 43.691,
+      "cosine_similarity": 0.98774493,
+      "relative_l2_error": 0.156581,
+      "reason": "The current NVFP4 kernel was 67% slower for this shape and introduced excessive error."
+    }
+  ],
+  "validation": {
+    "api_stream_completed": true,
+    "two_trial_output_hash_match": true,
+    "exact_prior_target_only_output_hash": true,
+    "identical_acceptance_and_route_counts_across_trials": true,
+    "focused_tests_passed": 52,
+    "oom_count": 0,
+    "service_restarts": 0,
+    "swap_growth_bytes": 0
+  },
+  "admission": {
+    "tier": "frontier",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "The optimized MTP-3 profile reproduced at 7.434 and 7.438 tok/s with exact output parity.",
+      "This is a focused dirty-worktree optimization probe; quality, long-context, concurrent, sampled, and endurance gates remain outstanding."
+    ]
+  },
+  "source": {
+    "prior_mtp_evidence": "GB10-GLM53-MTP-004",
+    "selected_trial_artifacts": [
+      "/tmp/glm53-combined-opt.jsonl",
+      "/tmp/glm53-combined-confirm.jsonl"
+    ]
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The end-to-end comparison covers one batch-one greedy math workload.",
+    "The target-only overlap comparison contains one measured request per profile and exhibits host-level run-to-run variability.",
+    "The exact 64K context, parser, coding-agent, broad quality, concurrent, sampled, and endurance gates were not rerun."
+  ]
+}

--- a/docs/models/glm-5.3-flash.md
+++ b/docs/models/glm-5.3-flash.md
@@ -49,6 +49,23 @@ curl http://127.0.0.1:1919/v1/models
 
 See the [quick start](../quickstart.md) for API and agent examples.
 
+### Optional MTP speculative decoding
+
+GLM-5.3 Flash includes a publisher-trained next-token prediction layer. SparkLab can
+use it for batch-one greedy serving by placing `model_mtp.safetensors` beside the FTW
+artifact, or by pointing `SPARKLAB_GLM5_MTP_PATH` at the sidecar. The current pinned
+prebuilt FTW predates this support and therefore needs the explicit sidecar path:
+
+```bash
+SPARKLAB_GLM5_MTP_PATH=/path/to/model_mtp.safetensors \
+  sparklab run glm-5.3-flash --root /path/to/models -- \
+  --speculative-tokens 3
+```
+
+Source conversions now copy an available `model_mtp.safetensors` into the prepared
+artifact automatically. MTP remains opt-in; target-only serving is unchanged when no
+speculative token count is requested.
+
 ## Performance and TTFT
 
 The fixed batch-one DGX Spark probe measured 6.27 decode tok/s and 5.681 s warm TTFT.
@@ -64,3 +81,28 @@ cannot pre-resident every routed expert row.
 
 See the [versioned GB10 evidence](../../benchmarks/gb10/results/GB10-GLM53-MHC-003.json)
 for the complete configuration, comparison, and remaining validation gaps.
+
+An opt-in width sweep on the same batch-one greedy workload selected three draft tokens:
+
+| Profile | Decode tok/s | Draft acceptance | Output hash vs target |
+|---|---:|---:|---|
+| Target only | 5.516 | — | reference |
+| MTP-1 | 6.624 | 96.9% | different |
+| MTP-2 | 6.926 | 89.1% | exact |
+| **MTP-3** | **7.232** | **87.9%** | **exact** |
+| MTP-4 | 6.371 | 73.7% | different |
+
+MTP-3 is 31.1% faster than the matched fixed-cache target-only control and 15.3%
+faster than the published 6.271 tok/s target-only result. The comparison is optimization
+evidence, not a replacement certification: it uses one problem, one measured request per
+width, a smaller 6,149-slot expert cache required by the resident MTP layer, and no
+quality, long-context, concurrent, sampled, or endurance suite. See
+[`GB10-GLM53-MTP-004`](../../benchmarks/gb10/results/GB10-GLM53-MTP-004.json).
+
+A follow-up GB10 pass adds a measured skinny BF16 kernel plan for the
+154,880-by-4,096 LM head and overlaps shared-expert compute with routed-expert
+fetches. Two MTP-3 trials measured 7.434 and 7.438 tok/s (7.436 tok/s mean),
+2.82% above the earlier 7.232 tok/s result, while retaining 87.9% acceptance,
+the same route/I/O counts, and the exact target-only output hash. Shared-expert
+overlap is enabled by the recipe; MTP itself remains opt-in. See
+[`GB10-GLM53-OPT-005`](../../benchmarks/gb10/results/GB10-GLM53-OPT-005.json).

--- a/exps/exp_glm5_3_nvfp4_gb10.md
+++ b/exps/exp_glm5_3_nvfp4_gb10.md
@@ -1,6 +1,6 @@
 # GLM-5.3 Flash NVFP4 on NVIDIA GB10
 
-Last updated: 2026-08-30
+Last updated: 2026-09-03
 
 ## Result
 
@@ -17,6 +17,67 @@ host had pre-existing swap use, and the context, capability, quality, and endura
 remain outstanding. A second optimized run reproduced the same greedy output hash at
 6.284 tok/s. Compact evidence:
 [`GB10-GLM53-MHC-003`](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json).
+
+An opt-in native-MTP follow-up selected three draft tokens at **7.232 tok/s**, 31.1%
+above a matched 5.516 tok/s target-only control and 15.3% above the published optimized
+target-only result. The MTP-3 trace accepted 87.9% of drafts, produced 3.12 output tokens
+per target forward, and exactly matched the target-only output hash. This remains a
+single-workload optimization probe rather than certification evidence. Compact evidence:
+[`GB10-GLM53-MTP-004`](../benchmarks/gb10/results/GB10-GLM53-MTP-004.json).
+
+The next optimization pass specialized the 154,880-by-4,096 BF16 LM head for
+SM121 and enabled shared-expert overlap. Two otherwise identical MTP-3 trials
+measured **7.434 and 7.438 tok/s** (**7.436 tok/s mean**), 2.82% above the
+earlier 7.232 tok/s result. Both runs retained 87.9% draft acceptance, 3.12
+outputs per target forward, identical expert routes and disk I/O, and the exact
+`d3523265958c` target-only hash. Compact evidence:
+[`GB10-GLM53-OPT-005`](../benchmarks/gb10/results/GB10-GLM53-OPT-005.json).
+
+## Native MTP speculative decoding
+
+The released checkpoint stores its single next-token prediction block in a standalone
+`model_mtp.safetensors`. SparkLab now loads that block as a resident block-FP8 MoE,
+extends the DSA/KPool cache geometry for layer 45, and transactionally snapshots and
+replays the KDA recurrent state when target verification rejects a draft. Source FTW
+conversion copies the sidecar beside the prepared model; the older pinned prebuilt used
+for this probe requires `SPARKLAB_GLM5_MTP_PATH`.
+
+The controlled sweep fixed the expert cache at 6,149 slots for every profile and kept
+all other workload and serving settings identical: AIME-25 problem 0, batch one, greedy
+sampling, 54 prompt tokens, 256 requested completion tokens, one warm request, DSA,
+8,691 KV tokens, disk-backed routed experts, sparse prefill through 512 tokens, and no
+CUDA graph.
+
+| Profile | Decode tok/s | Warm TTFT | Acceptance | Outputs / target forward | Hash |
+|---|---:|---:|---:|---:|---|
+| Target only | 5.516 | 6.539 s | — | 1.00 | `d3523265958c` |
+| MTP-1 | 6.624 | 6.232 s | 96.9% | 1.92 | `75078f6e1f98` |
+| MTP-2 | 6.926 | 6.373 s | 89.1% | 2.53 | `d3523265958c` |
+| **MTP-3** | **7.232** | **6.354 s** | **87.9%** | **3.12** | `d3523265958c` |
+| MTP-4 | 6.371 | 6.358 s | 73.7% | 2.91 | `1d5492568beb` |
+| **MTP-3 optimized (mean of 2)** | **7.436** | **6.330 s** | **87.9%** | **3.12** | `d3523265958c` |
+
+```bash
+CUDA_VISIBLE_DEVICES=0 SPARKLAB_DISABLE_KERNEL_CACHE=1 \
+SPARKLAB_GLM5_MTP_PATH=/path/to/model_mtp.safetensors \
+SPARKLAB_DISK_READ_WORKERS=16 PYTHONPATH=python:. \
+  .venv/bin/python benchmarks/bench_decode_moe.py \
+  --model /path/to/glm-5.3-flash/prepared/0.3.2 \
+  --recipe glm-5.3-flash --backend offload --storage disk \
+  --attention-backend dsa --nvfp4-backend triton --host-cache-gb 0 \
+  --cache 6149 --mem-ratio 0.96 --num-tokens 8691 \
+  --speculative-method mtp --speculative-tokens 3 \
+  --disable-prefill-overlap --prefill-hit-d2d \
+  --shared-expert-overlap \
+  --prefill-sparse-max-tokens 512 --page-size 1 --cache-type naive \
+  --no-graph --collect-moe-stats --include-output --greedy --decode 256
+```
+
+MTP-4 loses despite drafting farther: acceptance drops to 73.7%, rejection replay rises
+to 85 tokens, and physical expert I/O rises to 181.68 GiB. MTP-3 is the local optimum:
+it reduces target forwards from 255 to 82 while keeping rejection and extra I/O bounded.
+The resident MTP block adds about 7.25 GiB of device allocation, so this paired comparison
+uses fewer expert-cache slots than the earlier 6,711-slot published target-only result.
 
 ## Artifact and system
 

--- a/python/sparklab/kernels/triton/qwen4_skinny.py
+++ b/python/sparklab/kernels/triton/qwen4_skinny.py
@@ -1,4 +1,4 @@
-"""Small-M BF16 linear kernel for Qwen3.8 on GB10 (SM121)."""
+"""Small-M BF16 linear kernel for measured GB10 (SM121) model shapes."""
 
 from __future__ import annotations
 
@@ -59,7 +59,7 @@ def bf16_skinny_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     m = x.numel() // k
     n = weight.shape[0]
     if not (1 <= m <= 3):
-        raise ValueError(f"Qwen4 skinny linear requires 1 <= M <= 3, got {m}")
+        raise ValueError(f"skinny linear requires 1 <= M <= 3, got {m}")
     x2 = x.reshape(m, k).contiguous()
     out = torch.empty((m, n), dtype=x.dtype, device=x.device)
     block_n = 2 if m == 1 else 1
@@ -80,7 +80,7 @@ def bf16_skinny_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     return out.reshape(*lead, n)
 
 
-# Native TP=1 Qwen3.8 shapes that beat F.linear in a controlled GB10 sweep.
+# Native TP=1 shapes that beat F.linear in controlled GB10 sweeps.
 # Small projections (notably 320x10240 and 640x2560) deliberately stay on
 # cuBLAS because launch/under-occupancy costs erase their apparent specialization.
 _SM121_PLANS = {
@@ -88,6 +88,7 @@ _SM121_PLANS = {
     (16480, 2560),  # GDN fused q/k/v/z/b/a
     (2560, 6144),   # QSA/GDN output projection
     (248320, 2560),  # full-vocabulary LM head
+    (154880, 4096),  # GLM-5.3 Flash full-vocabulary LM head
 }
 
 

--- a/python/sparklab/models/config.py
+++ b/python/sparklab/models/config.py
@@ -318,9 +318,10 @@ class ModelConfig:
     glm5_next_args: Any | None = None
     # Qwen4-Exp text-tower payload: QSA, Hyper-Connection and PLE geometry.
     qwen4_exp_args: Any | None = None
-    # Number of checkpoint-native Qwen3.5/3.6 MTP decoder layers. These draft
-    # weights are opt-in at runtime and stored separately in FTW so target-only
-    # serving does not allocate them.
+    # Number of checkpoint-native next-token-prediction decoder layers. These
+    # draft weights are opt-in at runtime and stored separately so target-only
+    # serving does not allocate them. Qwen3.5/3.6 and GLM-5.3 Flash currently
+    # use this common capability flag.
     mtp_num_hidden_layers: int = 0
     # Runtime speculative-decoding selection injected after parsing.
     speculative_method: str = "none"

--- a/python/sparklab/models/glm5_next/__init__.py
+++ b/python/sparklab/models/glm5_next/__init__.py
@@ -1,9 +1,15 @@
 from .config import parse_config
 from .model import Glm5NextForCausalLM
-from .weight import iter_weights, load_nvfp4_expert_sources, setup_offload_expert_banks
+from .weight import (
+    copy_external_artifacts,
+    iter_weights,
+    load_nvfp4_expert_sources,
+    setup_offload_expert_banks,
+)
 
 __all__ = [
     "Glm5NextForCausalLM",
+    "copy_external_artifacts",
     "iter_weights",
     "load_nvfp4_expert_sources",
     "parse_config",

--- a/python/sparklab/models/glm5_next/config.py
+++ b/python/sparklab/models/glm5_next/config.py
@@ -219,6 +219,7 @@ def parse_config(hf_config: Any) -> ModelConfig:
         vision_config=None,
         image_token_id=_get(hf_config, "image_token_id"),
         glm5_next_args=args,
+        mtp_num_hidden_layers=int(_get(text, "num_nextn_predict_layers", 0) or 0),
         single_stream_only=True,
     )
 

--- a/python/sparklab/models/glm5_next/kda.py
+++ b/python/sparklab/models/glm5_next/kda.py
@@ -157,7 +157,11 @@ class Glm5NextDeltaAttention(BaseOP):
             ],
             dim=-1,
         )
-        mixed = self._conv(raw, fla, pool, batch.is_decode)
+        # Verification is a decode lifecycle event but contains a contiguous
+        # candidate sequence. Run it through the varlen path so convolution and
+        # recurrent state advance in token order instead of treating every row
+        # as an independent one-token request.
+        mixed = self._conv(raw, fla, pool, not batch.uses_prefill_kernels)
         q, k, v = mixed.split([self.projection_size] * 3, dim=-1)
         total = hidden_states.shape[0]
         q = q.view(1, total, self.num_heads, self.head_dim)

--- a/python/sparklab/models/glm5_next/model.py
+++ b/python/sparklab/models/glm5_next/model.py
@@ -87,7 +87,40 @@ class Glm5NextForCausalLM(BaseLLMModel):
             tie_word_embeddings=config.tie_word_embeddings,
             tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
         )
+        self._mtp_steps = int(getattr(config, "speculative_tokens", 0) or 0)
+        self._mtp = None
+        if self._mtp_steps:
+            from .mtp import Glm5NextMultiTokenPredictor
+
+            self._mtp = Glm5NextMultiTokenPredictor(config)
+        self._mtp_path: str | None = None
+        self._mtp_target_hidden: torch.Tensor | None = None
         super().__init__()
+
+    def prepare_for_weight_load(self, model_path: str, *, dummy: bool = False) -> None:
+        if self._mtp is None or dummy:
+            return
+        from .weight import find_mtp_sidecar
+
+        self._mtp_path = find_mtp_sidecar(model_path)
+        if self._mtp_path is None:
+            raise FileNotFoundError(
+                "GLM-5.3 Flash MTP requires model_mtp.safetensors beside the "
+                "checkpoint or SPARKLAB_GLM5_MTP_PATH"
+            )
+
+    def load_speculative_weights(
+        self, model_path: str, device: torch.device, *, dummy: bool = False
+    ) -> None:
+        del model_path
+        if self._mtp is None:
+            return
+        if dummy:
+            self._mtp.load_dummy(device)
+            return
+        if self._mtp_path is None:
+            raise RuntimeError("GLM-5.3 MTP sidecar path was not prepared")
+        self._mtp.load_sidecar(self._mtp_path, device)
 
     def prepare_for_runtime(self) -> None:
         for layer in self.model.layers.op_list:
@@ -97,12 +130,82 @@ class Glm5NextForCausalLM(BaseLLMModel):
                 layer.self_attn.prepare_for_runtime()
             elif isinstance(layer.self_attn, Glm5NextDeltaAttention):
                 layer.self_attn.prepare_for_runtime()
+        if self._mtp is not None:
+            self._mtp.layer.self_attn.prepare_for_runtime()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
     def forward(self) -> torch.Tensor:
         output = self.model.forward(get_global_ctx().batch.input_ids)
+        if self._mtp is not None:
+            self._mtp_target_hidden = output
         return self.lm_head.forward(output)
+
+    def propose_mtp(self, batch, next_token: torch.Tensor) -> torch.Tensor | None:
+        if self._mtp is None or self._mtp_target_hidden is None or batch.size != 1:
+            return None
+        from sparklab.core import Batch, Req
+        from sparklab.layers.linear import _linear_forward
+
+        req = batch.reqs[0]
+        if not req.sampling_params.is_greedy:
+            return None
+        ctx = get_global_ctx()
+        head = self.lm_head.tied_embedding or self.lm_head
+
+        def project_logits(hidden: torch.Tensor) -> torch.Tensor:
+            # ParallelLMHead.forward applies prefill last-row selection. The MTP
+            # path has already selected its row, so project directly like Qwen4.
+            return _linear_forward(hidden, head.weight, self.lm_head.bias)
+
+        query = batch.input_ids
+        shifted = torch.cat((query[1:], next_token.reshape(1)))
+        original_input = batch.input_ids
+        batch.input_ids = shifted
+        try:
+            with ctx.forward_batch(batch):
+                feedback = self._mtp.forward(
+                    self.model.embed_tokens.forward(shifted), self._mtp_target_hidden
+                )
+                last = batch.attn_metadata.get_last_indices(1).to(torch.long)
+                feedback = feedback.index_select(0, last)
+                draft = torch.argmax(project_logits(feedback), dim=-1)
+        finally:
+            batch.input_ids = original_input
+
+        drafts = [draft.squeeze(0).to(torch.int32)]
+        steps = min(self._mtp_steps, max(1, req.max_device_len - req.device_len))
+        for step in range(1, steps):
+            position = req.device_len + step - 1
+            draft_req = Req(
+                input_ids=torch.zeros(position + 1, dtype=req.input_ids.dtype),
+                table_idx=req.table_idx,
+                cached_len=position,
+                output_len=1,
+                uid=req.uid,
+                sampling_params=req.sampling_params,
+                cache_handle=req.cache_handle,
+            )
+            draft_batch = Batch(reqs=[draft_req], phase="decode")
+            draft_batch.padded_reqs = draft_batch.reqs
+            draft_batch.input_ids = draft.reshape(1)
+            draft_batch.positions = torch.tensor(
+                [position], dtype=torch.int32, device=draft.device
+            )
+            draft_batch.out_loc = ctx.page_table[
+                draft_req.table_idx, position : position + 1
+            ]
+            draft_batch.active_table_idx = torch.tensor(
+                [draft_req.table_idx], dtype=torch.int64, device=draft.device
+            )
+            ctx.attn_backend.prepare_metadata(draft_batch)
+            with ctx.forward_batch(draft_batch):
+                feedback = self._mtp.forward(
+                    self.model.embed_tokens.forward(draft_batch.input_ids), feedback
+                )
+                draft = torch.argmax(project_logits(feedback), dim=-1)
+            drafts.append(draft.squeeze(0).to(torch.int32))
+        return torch.stack(drafts)
 
 
 __all__ = ["Glm5NextForCausalLM"]

--- a/python/sparklab/models/glm5_next/mtp.py
+++ b/python/sparklab/models/glm5_next/mtp.py
@@ -1,0 +1,153 @@
+"""Checkpoint-native NextN predictor for GLM-5.3 Flash."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+
+import safetensors
+import torch
+
+from sparklab.core import get_global_ctx
+from sparklab.layers import BaseOP, LinearReplicated, RMSNorm, RMSNormFused
+
+from .attention import Glm5NextMLAAttention
+from .moe import Glm5NextSparseMoe
+
+
+class _MTPDecoderLayer(BaseOP):
+    """The released layer-45 block: MLA + sparse MoE, without target mHC."""
+
+    def __init__(self, config):
+        draft = replace(
+            config,
+            moe_backend="fused",
+            expert_quant="fp8_block",
+            attn_quant="none",
+            dense_quant="none",
+            shared_expert_quant="none",
+        )
+        self.self_attn = Glm5NextMLAAttention(draft, config.num_layers)
+        self.mlp = Glm5NextSparseMoe(draft, config.num_layers)
+        self.input_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNormFused(
+            config.hidden_size, config.rms_norm_eps
+        )
+
+    def forward(self, hidden: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        residual = hidden
+        hidden = self.input_layernorm.forward(hidden)
+        hidden = self.self_attn.forward(hidden)
+        hidden, residual = self.post_attention_layernorm.forward(hidden, residual)
+        return self.mlp.forward(hidden), residual
+
+
+class Glm5NextMultiTokenPredictor(BaseOP):
+    def __init__(self, config):
+        hidden = config.hidden_size
+        self._layer_id = config.num_layers
+        self.enorm = RMSNorm(hidden, config.rms_norm_eps)
+        self.hnorm = RMSNorm(hidden, config.rms_norm_eps)
+        self.eh_proj = LinearReplicated(2 * hidden, hidden, has_bias=False)
+        self.layer = _MTPDecoderLayer(config)
+        self.norm = RMSNormFused(hidden, config.rms_norm_eps)
+
+    def forward(
+        self, token_embeddings: torch.Tensor, target_hidden: torch.Tensor
+    ) -> torch.Tensor:
+        batch = get_global_ctx().batch
+        token_embeddings = torch.where(
+            batch.positions.view(-1, 1) == 0,
+            torch.zeros((), dtype=token_embeddings.dtype, device=token_embeddings.device),
+            token_embeddings,
+        )
+        embedded = self.enorm.forward(token_embeddings)
+        previous = self.hnorm.forward(target_hidden)
+        hidden = self.eh_proj.forward(torch.cat((embedded, previous), dim=-1))
+        hidden, residual = self.layer.forward(hidden)
+        return self.norm.forward(hidden, residual)[0]
+
+    def load_dummy(self, device: torch.device) -> None:
+        loaded = {
+            name: torch.zeros(tuple(param.shape), dtype=param.dtype, device=device)
+            for name, param in self.state_dict().items()
+        }
+        self.load_state_dict(loaded)
+
+    def load_sidecar(self, path: str, device: torch.device) -> None:
+        """Load the mixed BF16/block-FP8 layer without a multi-GB host fusion."""
+        expected = self.state_dict()
+        loaded: dict[str, torch.Tensor] = {}
+
+        def allocate(name: str) -> torch.Tensor:
+            target = expected[name]
+            return torch.empty(tuple(target.shape), dtype=target.dtype, device=device)
+
+        gate_up = allocate("layer.mlp.experts.gate_up_proj")
+        gate_up_scale = allocate("layer.mlp.experts.gate_up_scale_inv")
+        down = allocate("layer.mlp.experts.down_proj")
+        down_scale = allocate("layer.mlp.experts.down_scale_inv")
+        loaded.update(
+            {
+                "layer.mlp.experts.gate_up_proj": gate_up,
+                "layer.mlp.experts.gate_up_scale_inv": gate_up_scale,
+                "layer.mlp.experts.down_proj": down,
+                "layer.mlp.experts.down_scale_inv": down_scale,
+            }
+        )
+
+        prefix = f"model.language_model.layers.{self._layer_id}."
+        with safetensors.safe_open(path, framework="pt", device="cpu") as handle:
+            for expert in range(gate_up.shape[0]):
+                source = f"{prefix}mlp.experts.{expert}"
+                width = gate_up.shape[1] // 2
+                scale_width = gate_up_scale.shape[1] // 2
+                for role, rows, scale_rows in (
+                    ("gate_proj", slice(0, width), slice(0, scale_width)),
+                    (
+                        "up_proj",
+                        slice(width, 2 * width),
+                        slice(scale_width, 2 * scale_width),
+                    ),
+                ):
+                    base = f"{source}.{role}"
+                    gate_up[expert, rows].copy_(handle.get_tensor(base + ".weight"))
+                    gate_up_scale[expert, scale_rows].copy_(
+                        handle.get_tensor(base + ".weight_scale")
+                    )
+                base = f"{source}.down_proj"
+                down[expert].copy_(handle.get_tensor(base + ".weight"))
+                down_scale[expert].copy_(handle.get_tensor(base + ".weight_scale"))
+
+            for raw_name in handle.keys():
+                if not raw_name.startswith(prefix) or ".mlp.experts." in raw_name:
+                    continue
+                suffix = raw_name.removeprefix(prefix)
+                if suffix == "shared_head.norm.weight":
+                    name = "norm.weight"
+                elif suffix.startswith(("enorm.", "hnorm.", "eh_proj.")):
+                    name = suffix
+                else:
+                    name = "layer." + suffix
+                target = expected.get(name)
+                if target is None:
+                    raise RuntimeError(f"unexpected GLM-5.3 MTP tensor {raw_name!r}")
+                loaded[name] = handle.get_tensor(raw_name).to(
+                    device=device, dtype=target.dtype
+                )
+
+        missing = set(expected) - set(loaded)
+        if missing:
+            raise RuntimeError(f"GLM-5.3 MTP sidecar is missing tensors: {sorted(missing)}")
+        self.load_state_dict(loaded)
+        try:
+            fd = os.open(path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+            try:
+                os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+            finally:
+                os.close(fd)
+        except OSError:
+            pass
+
+
+__all__ = ["Glm5NextMultiTokenPredictor"]

--- a/python/sparklab/models/glm5_next/weight.py
+++ b/python/sparklab/models/glm5_next/weight.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
 from typing import Iterator
 
 import safetensors
@@ -79,6 +81,60 @@ def map_weight_name(raw_name: str) -> str | None:
         site = "attn_hc" if match["site"] == "attn" else "ffn_hc"
         return f"{match['prefix']}.{site}.{match['part']}"
     return name
+
+
+def find_mtp_sidecar(model_path: str) -> str | None:
+    """Resolve the opt-in layer-45 payload for source or prepared checkpoints."""
+    override = os.environ.get("SPARKLAB_GLM5_MTP_PATH")
+    candidates = [override] if override else []
+    candidates.extend(
+        [
+            os.path.join(model_path, "model_mtp.safetensors"),
+            os.path.join(model_path, "mtp", "model_mtp.safetensors"),
+        ]
+    )
+    return next((path for path in candidates if path and os.path.isfile(path)), None)
+
+
+def copy_external_artifacts(
+    model_path: str,
+    out_dir: str,
+    model_config,
+    *,
+    ngram_dtype: str = "preserve",
+) -> list[dict]:
+    """Copy the optional publisher MTP payload beside a prepared FTW artifact."""
+    del model_config, ngram_dtype  # shared converter-hook arguments
+    source = find_mtp_sidecar(model_path)
+    if source is None:
+        return []
+
+    filename = "model_mtp.safetensors"
+    destination = os.path.join(out_dir, filename)
+    temporary = destination + ".tmp"
+    os.makedirs(out_dir, exist_ok=True)
+    try:
+        with open(source, "rb", buffering=0) as src, open(
+            temporary, "wb", buffering=0
+        ) as dst:
+            shutil.copyfileobj(src, dst, length=16 << 20)
+            os.fsync(dst.fileno())
+        os.replace(temporary, destination)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+    return [
+        {
+            "kind": "glm5_mtp",
+            "file": filename,
+            "format": "safetensors-fp8-block",
+            "nbytes": os.path.getsize(destination),
+        }
+    ]
 
 
 def iter_weights(
@@ -176,9 +232,11 @@ def load_nvfp4_expert_sources(model_path: str, config, *, layer_sink=None):
 
 
 __all__ = [
+    "copy_external_artifacts",
     "iter_weights",
     "load_nvfp4_expert_sources",
     "map_weight_name",
+    "find_mtp_sidecar",
     "setup_offload_expert_banks",
     "_quant_fp8_per_row",
     "_is_kda_main_weight",

--- a/python/sparklab/recipes/glm-5.3-flash.json
+++ b/python/sparklab/recipes/glm-5.3-flash.json
@@ -38,6 +38,7 @@
       "moe_prefill_sparse_max_tokens": 512,
       "moe_prefill_overlap": false,
       "moe_prefill_hit_d2d": true,
+      "moe_shared_expert_overlap": true,
       "cuda_graph_max_bs": 0,
       "cache_type": "naive",
       "page_size": 1,
@@ -57,7 +58,9 @@
   "evidence": [
     "GB10-GLM53-NVFP4-001",
     "GB10-GLM53-KDA-FP8-002",
-    "GB10-GLM53-MHC-003"
+    "GB10-GLM53-MHC-003",
+    "GB10-GLM53-MTP-004",
+    "GB10-GLM53-OPT-005"
   ],
   "description": "Text-only GLM-5.3-Flash Frontier candidate using Red Hat AI's NVFP4 experts, SparkLab's FP8 KDA projection format, native NoPE MLA/KPool, mHC, and NVMe-MoE serving.",
   "limitations": [
@@ -67,6 +70,7 @@
     "Prompt-selected expert rows must still be read from NVMe when absent from the GPU cache; these compulsory reads dominate TTFT.",
     "FlashInfer 0.6.15's SM12x route packer exceeds Triton's tensor-size limit at 288 experts, so this recipe uses SparkLab's native Triton NVFP4 backend.",
     "KPool sparse selection is currently eager and CUDA graph capture is disabled.",
+    "Native MTP is opt-in for batch-one greedy serving. An optimized three-draft probe averaged 7.436 tok/s with 87.9% acceptance and exact target-only output hash, but the broader certification suite has not been rerun.",
     "Multimodal certification is a separate later gate."
   ]
 }

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -281,10 +281,15 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
     model_config = config.model_config
     requested = str(getattr(config, "speculative_method", "auto") or "auto")
     qwen4_mtp = getattr(model_config, "qwen4_exp_args", None) is not None
-    qwen35_mtp = int(
-        getattr(model_config, "mtp_num_hidden_layers", 0) or 0
-    ) > 0
+    qwen35_mtp = bool(
+        getattr(model_config, "glm5_next_args", None) is None
+        and int(getattr(model_config, "mtp_num_hidden_layers", 0) or 0) > 0
+    )
     qwen_mtp = qwen4_mtp or qwen35_mtp
+    glm5_mtp = bool(
+        getattr(model_config, "glm5_next_args", None) is not None
+        and int(getattr(model_config, "mtp_num_hidden_layers", 0) or 0) > 0
+    )
     dsv4_args = getattr(model_config, "dsv4_args", None)
     dsv4_dspark = bool(
         dsv4_args is not None
@@ -293,7 +298,7 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         and int(getattr(dsv4_args, "dspark_markov_rank", 0) or 0) > 0
     )
     if requested == "auto":
-        method = "dspark" if dsv4_dspark else "mtp" if qwen_mtp else "none"
+        method = "dspark" if dsv4_dspark else "mtp" if (qwen_mtp or glm5_mtp) else "none"
     else:
         method = requested
     if method == "none":
@@ -369,14 +374,16 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         override("cuda_graph_max_bs", 0)
         return
 
-    if method != "mtp" or not qwen_mtp:
+    if method != "mtp" or not (qwen_mtp or glm5_mtp):
         raise ValueError(
-            "--speculative-method mtp requires a supported Qwen checkpoint-native MTP head"
+            "--speculative-method mtp requires a supported checkpoint-native MTP head"
         )
-    if speculative_tokens > 3:
-        raise ValueError("Qwen MTP supports at most 3 speculative tokens")
+    max_tokens = 4 if glm5_mtp else 3
+    if speculative_tokens > max_tokens:
+        family = "GLM-5.3 Flash" if glm5_mtp else "Qwen"
+        raise ValueError(f"{family} MTP supports at most {max_tokens} speculative tokens")
     if getattr(config, "draft_sample_method", "greedy") != "greedy":
-        raise ValueError("Qwen4 MTP currently supports greedy draft sampling only")
+        raise ValueError("MTP currently supports greedy draft sampling only")
     # The draft layer owns an independent QSA KV/index slot at the first layer
     # id beyond the target tower. Inject it without changing num_layers, which
     # still constructs exactly the target blocks. Do this before hybrid-cache
@@ -385,15 +392,23 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
 
     mtp_layer_id = model_config.num_layers
     args = model_config.qwen4_exp_args
+    glm_args = model_config.glm5_next_args
+    if glm_args is not None and mtp_layer_id not in glm_args.dsa_layer_ids:
+        glm_args = replace(
+            glm_args, dsa_layer_ids=(*glm_args.dsa_layer_ids, mtp_layer_id)
+        )
     if args is not None and mtp_layer_id not in args.qsa_layer_ids:
         args = replace(args, qsa_layer_ids=(*args.qsa_layer_ids, mtp_layer_id))
     groups = []
     for group in model_config.attention_groups:
-        if isinstance(group, FullAttentionGroupConfig) and mtp_layer_id not in group.layer_ids:
+        if (
+            isinstance(group, FullAttentionGroupConfig)
+            and mtp_layer_id not in group.layer_ids
+        ):
             changes = {"layer_ids": (*group.layer_ids, mtp_layer_id)}
             # Qwen4's draft is QSA and owns an index slot. Qwen3.5/3.6 uses
             # ordinary full attention, so only its KV layer is added.
-            if args is not None:
+            if args is not None or glm_args is not None:
                 changes["num_index_layers"] = group.num_index_layers + 1
             group = replace(group, **changes)
         groups.append(group)
@@ -403,6 +418,8 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
             config.cuda_graph_bs == [] or config.cuda_graph_max_bs == 0
         )
         object.__setattr__(model_config, "mtp_cuda_graph", graph_enabled)
+    if glm_args is not None:
+        object.__setattr__(model_config, "glm5_next_args", glm_args)
     object.__setattr__(model_config, "attention_groups", tuple(groups))
     object.__setattr__(model_config, "speculative_method", "mtp")
     object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
@@ -411,7 +428,10 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
     # fixed-width target verification forward; Qwen3.5/3.6 keep their established
     # eager path until their attention backends gain multi-row capture metadata.
     override("max_running_req", 1)
-    override("cache_type", "radix")
+    # GLM-5.3 intentionally keeps naive prefix caching because its KDA chunk
+    # snapshots are not implemented. Its verifier uses one dedicated rollback
+    # slot instead of enabling cross-request recurrent-state reuse.
+    override("cache_type", "naive" if glm5_mtp else "radix")
     # The verification runner owns a multi-row graph whose dimensions are not
     # request batch sizes. Keep it separate from the ordinary decode runner.
     override("cuda_graph_bs", [])
@@ -568,7 +588,11 @@ class Engine:
                 config.model_path, dummy=config.use_dummy_weight
             )
         self.model.load_state_dict(self._load_weight_state_dict(config))
-        if hasattr(self.model, "speculative_state_dict"):
+        if hasattr(self.model, "load_speculative_weights"):
+            self.model.load_speculative_weights(
+                config.model_path, self.device, dummy=config.use_dummy_weight
+            )
+        elif hasattr(self.model, "speculative_state_dict"):
             speculative = self.model.speculative_state_dict()
             if speculative:
                 self.model.load_speculative_state_dict(
@@ -1291,11 +1315,17 @@ class Engine:
                 if pool is None:
                     raise RuntimeError("MTP verification requires a recurrent-state pool")
                 for req in batch.reqs:
-                    if req.linear_slot_idx is None or req.mamba_ping_pong is None:
-                        raise RuntimeError("MTP verification requires hybrid-radix state slots")
-                    scratch = req.mamba_ping_pong[req.mamba_next_track_idx]
-                    pool.copy_from(req.linear_slot_idx, scratch)
-                    state_snapshots.append((req.linear_slot_idx, scratch))
+                    if req.linear_slot_idx is not None and req.mamba_ping_pong is not None:
+                        live = req.linear_slot_idx
+                        scratch = req.mamba_ping_pong[req.mamba_next_track_idx]
+                    else:
+                        # Naive hybrid-attention models key live state directly by
+                        # table_idx. _linear_pool_num_slots reserves the last row
+                        # exclusively for speculative rollback.
+                        live = req.table_idx
+                        scratch = pool.num_slots - 1
+                    pool.copy_from(live, scratch)
+                    state_snapshots.append((live, scratch))
         with self.ctx.forward_batch(batch):
             if (
                 batch.is_verify
@@ -1436,8 +1466,13 @@ class Engine:
         if self.linear_state_pool is not None:
             from sparklab.attention.linear import build_fla_metadata
 
+            live_slot = (
+                original.linear_slot_idx
+                if original.linear_slot_idx is not None
+                else original.table_idx
+            )
             replay.linear_table_idx = torch.tensor(
-                [original.linear_slot_idx], dtype=torch.int32, device=self.device
+                [live_slot], dtype=torch.int32, device=self.device
             )
             replay.fla_metadata = build_fla_metadata(replay, self.device)
         self.attn_backend.prepare_metadata(replay)

--- a/python/sparklab/runtime/kvcache/linear_state_pool.py
+++ b/python/sparklab/runtime/kvcache/linear_state_pool.py
@@ -264,7 +264,12 @@ def _linear_pool_num_slots(config) -> int:
     snapshot cache and a padding sink; naive GDN keeps the old (max_running_req + 1)."""
     mr = config.max_running_req
     if config.cache_type != "hybrid_radix":
-        return mr + 1  # live + dummy/padding
+        # Native MTP target verification mutates recurrent state for a short
+        # candidate block. Models which deliberately keep the naive prefix
+        # cache (GLM-5.3 Flash) need one persistent rollback slot in addition
+        # to their table-indexed live slots and the dummy/padding slot.
+        speculative = int(getattr(config, "speculative_tokens", 0) or 0) > 0
+        return mr + 1 + int(speculative)
     ratio = config.linear_state_cache_ratio
     n_cache = max(4, int(ratio * mr))
     return 4 * mr + n_cache + 1  # live + 2 ping-pong + locked committed snapshot + cache + padding
@@ -278,5 +283,6 @@ def _linear_pool_min_slots(config) -> int:
     deadlocks -- so a runtime rebuild rejects a smaller request."""
     mr = config.max_running_req
     if config.cache_type != "hybrid_radix":
-        return mr + 1
+        speculative = int(getattr(config, "speculative_tokens", 0) or 0) > 0
+        return mr + 1 + int(speculative)
     return 4 * mr + 1

--- a/tests/kernels/test_qwen4_skinny.py
+++ b/tests/kernels/test_qwen4_skinny.py
@@ -28,3 +28,9 @@ def test_qwen4_skinny_linear_falls_back_on_cpu() -> None:
     torch.testing.assert_close(
         qwen4_skinny_linear(x, weight, bias), F.linear(x, weight, bias)
     )
+
+
+def test_glm53_lm_head_shape_uses_measured_sm121_plan() -> None:
+    from sparklab.kernels.triton.qwen4_skinny import _SM121_PLANS
+
+    assert (154_880, 4_096) in _SM121_PLANS

--- a/tests/models/test_glm5_next.py
+++ b/tests/models/test_glm5_next.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from safetensors.torch import save_file
 
 from sparklab.attention.base import AttnType
 from sparklab.models.glm5_next.config import parse_config
@@ -13,6 +14,7 @@ from sparklab.models.glm5_next.weight import (
     _CT_NVFP4_SOURCE_SPEC,
     _is_kda_main_weight,
     _quant_fp8_per_row,
+    copy_external_artifacts,
     load_nvfp4_expert_sources,
     map_weight_name,
 )
@@ -29,6 +31,7 @@ def _config(layers: int = 8):
         hidden_size=256,
         vocab_size=1024,
         num_hidden_layers=layers,
+        num_nextn_predict_layers=1,
         num_attention_heads=4,
         max_position_embeddings=4096,
         rms_norm_eps=1e-5,
@@ -143,6 +146,137 @@ def test_parse_config_builds_glm53_hybrid_geometry():
     assert spec.num_index_layers == 2
     assert cfg.num_moe_layers == 5
     assert cfg.linear_state_snapshots is False
+    assert cfg.mtp_num_hidden_layers == 1
+
+
+def test_glm53_mtp_adds_draft_mla_and_keeps_naive_state_cache():
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+
+    model_config = parse_config(_config())
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="auto",
+        speculative_tokens=4,
+        draft_sample_method="greedy",
+        max_running_req=8,
+        cache_type="radix",
+        cuda_graph_bs=[1, 2, 4],
+        cuda_graph_max_bs=4,
+    )
+
+    _adjust_speculative_config(
+        config, lambda name, value: setattr(config, name, value)
+    )
+    _adjust_speculative_config(
+        config, lambda name, value: setattr(config, name, value)
+    )
+
+    assert model_config.speculative_method == "mtp"
+    assert model_config.speculative_tokens == 4
+    assert model_config.glm5_next_args.dsa_layer_ids == (3, 7, 8)
+    full = next(group for group in model_config.attention_groups if group.name == "full")
+    assert full.layer_ids == (3, 7, 8)
+    assert full.num_index_layers == 3
+    assert config.max_running_req == 1
+    assert config.cache_type == "naive"
+    assert config.cuda_graph_bs == []
+    assert config.cuda_graph_max_bs == 0
+
+    from sparklab.runtime.kvcache.linear_state_pool import (
+        _linear_pool_min_slots,
+        _linear_pool_num_slots,
+    )
+
+    config.tp_info = SimpleNamespace(size=1)
+    config.dtype = torch.bfloat16
+    assert _linear_pool_num_slots(config) == 3
+    assert _linear_pool_min_slots(config) == 3
+
+
+def test_glm53_mtp_sidecar_loads_released_tensor_layout(tmp_path):
+    from sparklab.models.glm5_next.mtp import Glm5NextMultiTokenPredictor
+    from sparklab.runtime.distributed import set_tp_info, try_get_tp_info
+    from sparklab.utils.torch_utils import torch_dtype
+
+    if try_get_tp_info() is None:
+        set_tp_info(rank=0, size=1)
+    config = parse_config(_config())
+    with torch_dtype(torch.bfloat16):
+        mtp = Glm5NextMultiTokenPredictor(config)
+
+    prefix = f"model.language_model.layers.{config.num_layers}."
+    source = {}
+    for name, target in mtp.state_dict().items():
+        if name.startswith("layer.mlp.experts."):
+            continue
+        if name == "norm.weight":
+            suffix = "shared_head.norm.weight"
+        elif name.startswith(("enorm.", "hnorm.", "eh_proj.")):
+            suffix = name
+        else:
+            suffix = name.removeprefix("layer.")
+        source[prefix + suffix] = torch.ones(
+            tuple(target.shape), dtype=target.dtype
+        )
+
+    experts = mtp.layer.mlp.experts
+    for expert in range(config.num_experts):
+        base = f"{prefix}mlp.experts.{expert}."
+        width = experts.gate_up_proj.shape[1] // 2
+        scale_width = experts.gate_up_scale_inv.shape[1] // 2
+        for role in ("gate_proj", "up_proj"):
+            source[base + role + ".weight"] = torch.zeros(
+                (width, config.hidden_size), dtype=torch.float8_e4m3fn
+            )
+            source[base + role + ".weight_scale"] = torch.ones(
+                (scale_width, config.hidden_size // 128), dtype=torch.bfloat16
+            )
+        source[base + "down_proj.weight"] = torch.zeros(
+            (config.hidden_size, config.moe_intermediate_size),
+            dtype=torch.float8_e4m3fn,
+        )
+        source[base + "down_proj.weight_scale"] = torch.ones(
+            (config.hidden_size // 128, config.moe_intermediate_size // 128),
+            dtype=torch.bfloat16,
+        )
+
+    sidecar = tmp_path / "model_mtp.safetensors"
+    save_file(source, sidecar)
+    mtp.load_sidecar(str(sidecar), torch.device("cpu"))
+
+    assert mtp.eh_proj.weight.dtype == torch.bfloat16
+    assert mtp.layer.mlp.experts.gate_up_proj.dtype == torch.float8_e4m3fn
+    assert mtp.layer.mlp.experts.gate_up_scale_inv.dtype == torch.float32
+    assert torch.all(mtp.eh_proj.weight == 1)
+    assert torch.all(mtp.layer.mlp.experts.gate_up_scale_inv == 1)
+
+
+def test_glm53_conversion_copies_optional_mtp_sidecar(tmp_path):
+    source, out = tmp_path / "source", tmp_path / "out"
+    source.mkdir()
+    out.mkdir()
+    payload = b"publisher MTP sidecar"
+    (source / "model_mtp.safetensors").write_bytes(payload)
+
+    artifacts = copy_external_artifacts(str(source), str(out), object())
+
+    assert (out / "model_mtp.safetensors").read_bytes() == payload
+    assert artifacts == [
+        {
+            "kind": "glm5_mtp",
+            "file": "model_mtp.safetensors",
+            "format": "safetensors-fp8-block",
+            "nbytes": len(payload),
+        }
+    ]
+
+
+def test_glm53_conversion_keeps_target_only_artifacts_valid(tmp_path):
+    source, out = tmp_path / "source", tmp_path / "out"
+    source.mkdir()
+    out.mkdir()
+
+    assert copy_external_artifacts(str(source), str(out), object()) == []
 
 
 def test_parse_config_builds_opt_in_kda_fp8_projections():

--- a/tests/sparklab/test_backends.py
+++ b/tests/sparklab/test_backends.py
@@ -161,6 +161,7 @@ def test_native_backend_compiles_glm_residency_options(tmp_path):
     assert "--memory-ratio" in plan.arguments
     assert plan.arguments[plan.arguments.index("--memory-ratio") + 1] == "0.96"
     assert "--disable-moe-prefill-overlap" in plan.arguments
+    assert "--moe-shared-expert-overlap" in plan.arguments
 
 
 def test_native_backend_compiles_kimi_bounded_gb10_options(tmp_path):

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -198,6 +198,7 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert glm.deployment.backend_options["moe_host_cache_gb"] == 0
     assert glm.deployment.backend_options["memory_ratio"] == 0.96
     assert glm.deployment.backend_options["moe_prefill_overlap"] is False
+    assert glm.deployment.backend_options["moe_shared_expert_overlap"] is True
     assert glm.runtime_artifact is not None
     assert glm.runtime_artifact.repo_id == "oakmindai/GLM-5.3-Flash-NVFP4-FTW"
     assert glm.runtime_artifact.revision == "f296cec0baceb2276121efe76f14d61b62c1e47d"


### PR DESCRIPTION
## Summary

- add native GLM-5.3 Flash MTP loading, state rollback, and greedy speculative decoding
- specialize the GB10 BF16 LM head and enable shared-expert overlap
- document and record reproducible GB10 benchmark evidence

## Performance

MTP-3 averages 7.436 tok/s across two trials, up 2.82% from 7.232 tok/s, with 87.9% draft acceptance and exact target-only output hash parity.

## Validation

- 52 focused tests passed
- benchmark reproduced at 7.434 and 7.438 tok/s
- JSON evidence validation passed
- git diff --check passed

This remains focused dirty-worktree optimization evidence, not full model certification.