### PR TITLE
docs: simplify main portfolio metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ a SparkLab support claim.
       <td>320B total / 18B active</td>
       <td>NVFP4 + KDA FP8 · FTW + optional MTP3</td>
       <td>Experimental</td>
-      <td align="right">6.27 target<br>7.44 MTP3</td>
-      <td align="right">5.681 target<br>6.330 MTP3</td>
+      <td align="right">7.44</td>
+      <td align="right">6.330</td>
       <td><a href="docs/models/glm-5.3-flash.md">Instructions</a></td>
     </tr>
     <tr>
@@ -161,16 +161,6 @@ Status meanings:
 
 Run `sparklab models --json` for exact recipe versions, checkpoint revisions, artifact
 fingerprints, implementation state, evidence IDs, and known constraints.
-
-The Qwen3.6 row reports the latest opt-in two-draft MTP probe: 74.42 tok/s and 0.368 s
-warm TTFT. Its Certified status remains tied to the target-only profile (67.79 tok/s and
-0.329 s warm TTFT); MTP is still awaiting the full certification suite. See
-[GB10-QWEN36-MTP-004](benchmarks/gb10/results/GB10-QWEN36-MTP-004.json).
-
-The GLM-5.3 Flash row separates the default target-only profile from the opt-in MTP3
-probe. MTP3 averaged 7.436 tok/s with 6.330 s warm TTFT and exact target-only output
-parity, but remains Experimental pending the broader certification suite. See
-[GB10-GLM53-OPT-005](benchmarks/gb10/results/GB10-GLM53-OPT-005.json).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- remove model-specific benchmark commentary from the main README
- keep GLM-5.3 Flash metric columns numeric and consistent with other rows
- report the selected MTP3 result as 7.44 tok/s and 6.330 s TTFT

Detailed benchmark context remains in the model portfolio and evidence files.

## Validation

- git diff --check