### PR TITLE
perf(qwen38): add DFlash2 Fast profile

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,3 +6,28 @@ SparkLab is developed by SixteenMiles Labs, a research lab under Oakmind AI.
 This distribution incorporates and adapts FreeToken research and software originally
 published at https://github.com/FlashML-org/FreeToken. See the repository README and
 source notices for additional third-party attribution.
+
+The native Qwen3.8 DFlash2 implementation is based on the architecture and DGX Spark
+reference published by Paolo Rosson at
+https://github.com/pangoleen/qwen3.8-27b-dgx-spark-dflash2 (revision
+2c7c38216cea410497ae222dc58030c021b74bd7), licensed under the MIT License.
+
+Copyright (c) 2026 Paolo Rosson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ a SparkLab support claim.
       <td><a href="docs/models/qwen3.6-35b-a3b.md">Instructions</a></td>
     </tr>
     <tr>
+      <td><a href="https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4">Qwen3.8-27B</a></td>
+      <td>27B dense</td>
+      <td>NVFP4 · FTW + optional DFlash2-8</td>
+      <td>Experimental</td>
+      <td align="right">8.83 target / 35.48 DFlash2-8</td>
+      <td align="right">0.144 target / 0.153 DFlash2-8</td>
+      <td><a href="docs/models/qwen3.8-27b.md">Instructions</a></td>
+    </tr>
+    <tr>
       <th colspan="7" align="left">Frontier — quality-first coding, reasoning, and long agent work</th>
     </tr>
     <tr>
@@ -123,8 +132,8 @@ a SparkLab support claim.
       <td>320B total / 18B active</td>
       <td>NVFP4 + KDA FP8 · FTW + optional MTP3</td>
       <td>Experimental</td>
-      <td align="right">7.44</td>
-      <td align="right">6.330</td>
+      <td align="right">6.27 target / 7.44 MTP3</td>
+      <td align="right">5.681 target / 6.330 MTP3</td>
       <td><a href="docs/models/glm-5.3-flash.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/bench_decode_moe.py
+++ b/benchmarks/bench_decode_moe.py
@@ -456,16 +456,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p.add_argument(
         "--speculative-method",
-        choices=("auto", "mtp", "dspark"),
+        choices=("auto", "mtp", "dspark", "dflash2"),
         default="auto",
         help="checkpoint-native speculative decoder",
     )
     p.add_argument(
         "--speculative-tokens",
         type=int,
-        choices=range(8),
+        choices=range(17),
         default=0,
-        help="draft length (0 disables, DSpark supports up to 7)",
+        help="draft/block length (0 disables, DSpark up to 7, DFlash2 up to 16)",
+    )
+    p.add_argument(
+        "--speculative-draft-model",
+        default=None,
+        help="local path or Hugging Face id for an external DFlash2 draft",
     )
     p.add_argument(
         "--draft-sample-method",
@@ -650,6 +655,8 @@ def serve_cmd(args: argparse.Namespace, backend: str, port: int) -> list[str]:
         "--dsv4-index-storage", args.dsv4_index_storage,
         "--qwen4-dense-storage", args.qwen4_dense_storage,
     ]
+    if args.speculative_draft_model:
+        cmd += ["--speculative-draft-model", args.speculative_draft_model]
     if args.num_tokens > 0:
         cmd += ["--num-tokens", str(args.num_tokens)]
     if args.cpu_threads > 0:
@@ -975,6 +982,7 @@ def run_one(args: argparse.Namespace, backend: str) -> dict:
             "requested_num_tokens": args.num_tokens,
             "speculative_method": args.speculative_method,
             "speculative_tokens": args.speculative_tokens,
+            "speculative_draft_model": args.speculative_draft_model,
             "draft_sample_method": args.draft_sample_method,
             "dspark_confidence_threshold": args.dspark_confidence_threshold,
             "dspark_draft_cache_slots": args.dspark_draft_cache_slots,

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -38,6 +38,13 @@ recipes. Raw logs and large result streams stay outside the source repository.
 - `results/GB10-QWEN38-27B-001.json` records the dense Qwen3.8-27B ModelOpt
   NVFP4 result: 8.83 decode tok/s, 0.144 s warm TTFT, exact 64K recall, and
   passing reasoning, tool-call, and coding-agent probes.
+- `results/GB10-QWEN38-DFLASH-002.json` records the native DFlash2-8 profile:
+  27.28 decode tok/s and 0.162 s warm TTFT across three matched trials, with
+  exact target-only output parity.
+- `results/GB10-QWEN38-DFLASH-003.json` records the optimized DFlash2-8 profile:
+  35.48 decode tok/s and 0.153 s warm TTFT across three trials, with exact
+  target-only output parity and zero rejection replays. The profile clears the
+  Fast performance thresholds; the remaining certification gates are outstanding.
 - `results/GB10-QWEN38-FRONTIER-001.json` records the certified text-only
   Qwen3.8-Flash-Next result for the superseded NVFP4 recipe.
 - `results/GB10-QWEN38-FP8-001.json` records the official FP8 recipe's measured

--- a/benchmarks/gb10/results/GB10-QWEN38-DFLASH-002.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-DFLASH-002.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-DFLASH-002",
+  "status": "measured",
+  "date": "2026-09-03",
+  "recipe": {
+    "slug": "qwen3.8-27b",
+    "recipe_version_at_run": "0.1.0",
+    "published_recipe_version": "0.2.0",
+    "revision": "6128240ebaf4eaa7bad2b3d1c72c37d677c5f462"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "3013c191fa420423a0db93b7096d4bb665a25455",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "os": "Linux 6.17.0-1014-nvidia",
+    "driver": "580.126.09",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0"
+  },
+  "checkpoint": {
+    "target_repository": "Inferact/Qwen3.8-27B-NVFP4",
+    "target_revision": "6128240ebaf4eaa7bad2b3d1c72c37d677c5f462",
+    "target_format": "ftw-nvfp4",
+    "target_fingerprint": "af78f7411817bb73",
+    "draft_repository": "maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal",
+    "draft_revision": "bd7a934213c47a9e7ef69eef36bb3325f47fd1f1",
+    "draft_format": "ModelOpt NVFP4",
+    "draft_bytes": 1550153248,
+    "draft_sha256": "2228b9b22e93a88d84556419c879448ab6c490ae65c4c0b166f4962190ddbf26"
+  },
+  "workload": {
+    "name": "AIME-25 problem 0 fixed decode probe",
+    "batch_size": 1,
+    "sampling": "greedy",
+    "prompt_tokens": 96,
+    "requested_completion_tokens": 128,
+    "returned_completion_tokens": 128,
+    "warmup_requests_per_process": 1,
+    "selected_profile_trials": 3,
+    "matched_target_only_trials": 1,
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "configuration": {
+    "execution_policy": "resident",
+    "nvfp4_backend": "triton",
+    "attention_backend": "triton",
+    "cache_type": "hybrid_radix",
+    "page_size": 16,
+    "kv_tokens": 8192,
+    "cuda_graphs": false,
+    "speculative_method": "dflash2",
+    "selected_block_size": 8,
+    "draft_sample_method": "greedy",
+    "max_running_requests": 1
+  },
+  "metrics": {
+    "target_only_decode_tokens_per_second": 9.178463227565516,
+    "target_only_warm_ttft_seconds": 0.158438461003243,
+    "dflash2_decode_tokens_per_second_trials": [
+      27.276591252792162,
+      27.27875936015706,
+      27.25780603359104
+    ],
+    "dflash2_decode_tokens_per_second_median": 27.276591252792162,
+    "dflash2_warm_ttft_seconds_trials": [
+      0.16291127700242215,
+      0.16200832700997125,
+      0.1609775079996325
+    ],
+    "dflash2_warm_ttft_seconds_median": 0.16200832700997125,
+    "dflash2_speedup_over_matched_target": 2.9718037297216444,
+    "dflash2_improvement_over_matched_target_percent": 197.18037297216443,
+    "target_only_vram_gib": 24.982421875,
+    "dflash2_vram_gib": 26.806640625,
+    "output_sha1": "fa04d7fa1fad"
+  },
+  "speculative": {
+    "block_size": 8,
+    "accepted_drafts": 98,
+    "drafted_tokens": 136,
+    "acceptance_rate": 0.721,
+    "outputs": 128,
+    "target_forwards": 30,
+    "outputs_per_target_forward": 4.27,
+    "replay_calls": 9,
+    "replay_tokens": 34
+  },
+  "tested_not_selected": [
+    {
+      "block_size": 16,
+      "decode_tokens_per_second_trials": [
+        24.46607511382484,
+        24.407302136376728,
+        24.39941973836552
+      ],
+      "decode_tokens_per_second_median": 24.407302136376728,
+      "warm_ttft_seconds_median": 0.1629613760014763,
+      "acceptance_rate": 0.441,
+      "output_sha1": "fa04d7fa1fad",
+      "reason": "Block size eight was 11.76% faster on the matched workload."
+    }
+  ],
+  "validation": {
+    "complete_target_checkpoint_loaded": true,
+    "complete_draft_checkpoint_loaded": true,
+    "draft_tensor_schema_verified": "106/106 tensors",
+    "api_stream_completed": true,
+    "all_selected_trials_match_target_output_hash": true,
+    "all_width_16_trials_match_target_output_hash": true,
+    "identical_acceptance_counts_across_selected_trials": true,
+    "oom_count": 0,
+    "service_restarts": 0,
+    "swap_growth_bytes": 0
+  },
+  "admission": {
+    "tier": "frontier",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "The selected DFlash2-8 profile measured a three-trial median 27.28 tok/s, 2.97x the matched 9.18 tok/s target-only control.",
+      "Every DFlash2-8 and DFlash2-16 trial reproduced the target-only greedy output hash.",
+      "This focused dirty-worktree optimization probe does not replace the existing context and capability evidence or satisfy the remaining endurance gate."
+    ]
+  },
+  "source": {
+    "target_only_artifact": "/tmp/qwen38-target-bench.json",
+    "selected_trial_artifact": "/tmp/qwen38-dflash8-bench.json",
+    "width_16_trial_artifact": "/tmp/qwen38-dflash-bench.json",
+    "prior_evidence": "GB10-QWEN38-27B-001",
+    "reference_implementation": "https://github.com/pangoleen/qwen3.8-27b-dgx-spark-dflash2@2c7c38216cea410497ae222dc58030c021b74bd7"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The matched target-only control contains one measured request; the selected DFlash2-8 profile contains three independently launched measured trials.",
+    "The probe covers one batch-one greedy 128-token math workload; sampled, concurrent, long-context, capability, and endurance suites were not rerun.",
+    "The host had 610,304 bytes of pre-existing swap resident, with zero growth during the measured requests.",
+    "The installed SparkLab kernel-cache wheel reported version 0.1.0+cu130 against the 0.1.1 source tree; the version guard was explicitly disabled for this source-tree benchmark."
+  ]
+}

--- a/benchmarks/gb10/results/GB10-QWEN38-DFLASH-003.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-DFLASH-003.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-DFLASH-003",
+  "status": "measured",
+  "date": "2026-09-04",
+  "recipe": {
+    "slug": "qwen3.8-27b",
+    "recipe_version_at_run": "0.2.0",
+    "published_recipe_version": "0.3.0",
+    "revision": "6128240ebaf4eaa7bad2b3d1c72c37d677c5f462"
+  },
+  "engine": {
+    "name": "FreeToken",
+    "product_identity": "SparkLab",
+    "git_revision": "3013c191fa420423a0db93b7096d4bb665a25455",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "os": "Linux 6.17.0-1014-nvidia",
+    "driver": "580.126.09",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0",
+    "flashinfer": "0.6.15.post1"
+  },
+  "checkpoint": {
+    "target_repository": "Inferact/Qwen3.8-27B-NVFP4",
+    "target_revision": "6128240ebaf4eaa7bad2b3d1c72c37d677c5f462",
+    "target_format": "ftw-nvfp4",
+    "target_fingerprint": "af78f7411817bb73",
+    "draft_repository": "maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal",
+    "draft_revision": "bd7a934213c47a9e7ef69eef36bb3325f47fd1f1",
+    "draft_format": "ModelOpt NVFP4",
+    "draft_bytes": 1550153248,
+    "draft_sha256": "2228b9b22e93a88d84556419c879448ab6c490ae65c4c0b166f4962190ddbf26"
+  },
+  "workload": {
+    "name": "AIME-25 problem 0 fixed decode probe",
+    "batch_size": 1,
+    "sampling": "greedy",
+    "prompt_tokens": 96,
+    "requested_completion_tokens": 128,
+    "returned_completion_tokens": 128,
+    "warmup_requests_per_process": 1,
+    "selected_profile_trials": 3,
+    "matched_target_only_control_evidence": "GB10-QWEN38-DFLASH-002",
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "configuration": {
+    "execution_policy": "resident",
+    "nvfp4_backend": "triton",
+    "attention_backend": "triton",
+    "cache_type": "hybrid_radix",
+    "page_size": 16,
+    "kv_tokens": 8192,
+    "cuda_graphs": false,
+    "speculative_method": "dflash2",
+    "selected_block_size": 8,
+    "draft_sample_method": "greedy",
+    "max_running_requests": 1,
+    "selector_top_k_backend": "flashinfer_radix",
+    "selector_walk_backend": "triton",
+    "selector_lm_head": "proposal-only-runtime-nvfp4",
+    "target_lm_head": "checkpoint-bf16",
+    "gdn_verify_commit": "per-token-transactional"
+  },
+  "metrics": {
+    "target_only_decode_tokens_per_second": 9.178463227565516,
+    "target_only_warm_ttft_seconds": 0.158438461003243,
+    "dflash2_decode_tokens_per_second_trials": [
+      35.480651510782415,
+      35.486649753560535,
+      35.387515682798416
+    ],
+    "dflash2_decode_tokens_per_second_median": 35.480651510782415,
+    "dflash2_warm_ttft_seconds_trials": [
+      0.15268474898766726,
+      0.15254554897546768,
+      0.15332875101012178
+    ],
+    "dflash2_warm_ttft_seconds_median": 0.15268474898766726,
+    "dflash2_speedup_over_matched_target": 3.865641843421457,
+    "dflash2_improvement_over_matched_target_percent": 286.56418434214567,
+    "dflash2_improvement_over_prior_native_percent": 30.0772929504175,
+    "target_only_vram_gib": 24.982421875,
+    "dflash2_vram_gib": 28.603515625,
+    "verify_transaction_buffer_bytes": 1215823872,
+    "output_sha1": "fa04d7fa1fad"
+  },
+  "speculative": {
+    "block_size": 8,
+    "accepted_drafts": 98,
+    "drafted_tokens": 136,
+    "acceptance_rate": 0.721,
+    "outputs": 128,
+    "target_forwards": 30,
+    "outputs_per_target_forward": 4.27,
+    "replay_calls": 0,
+    "replay_tokens": 0
+  },
+  "comparison": {
+    "prior_evidence": "GB10-QWEN38-DFLASH-002",
+    "prior_median_decode_tokens_per_second": 27.276591252792162,
+    "prior_replay_calls": 9,
+    "prior_replay_tokens": 34,
+    "optimized_eager_transaction_probe_tokens_per_second": 34.02090466543896,
+    "rejected_cuda_graph_probe_tokens_per_second": 14.43,
+    "rejected_cuda_graph_output_sha1": "25c2b57eb82a",
+    "rejected_cuda_graph_reason": "The experimental graph replay changed the target output and was removed."
+  },
+  "validation": {
+    "complete_target_checkpoint_loaded": true,
+    "complete_draft_checkpoint_loaded": true,
+    "api_stream_completed_all_trials": true,
+    "all_selected_trials_match_target_output_hash": true,
+    "identical_acceptance_counts_across_selected_trials": true,
+    "target_verification_uses_original_bf16_lm_head": true,
+    "oom_count": 0,
+    "service_restarts": 0,
+    "swap_growth_bytes": 0,
+    "swap_in_pages_delta": 0,
+    "swap_out_pages_delta": 0
+  },
+  "admission": {
+    "tier": "fast",
+    "performance_gate_passed": true,
+    "passed": false,
+    "reasons": [
+      "The optimized DFlash2-8 profile clears the Fast performance thresholds with a three-trial median 35.48 tok/s and 0.153 s warm TTFT, reaching 3.87x the matched 9.18 tok/s target-only control.",
+      "All selected trials reproduced the target-only greedy output hash and eliminated rejection replay.",
+      "This focused dirty-worktree optimization probe does not replace the existing context and capability evidence or satisfy the remaining endurance gate."
+    ]
+  },
+  "source": {
+    "selected_trial_artifact": "/tmp/qwen38-dflash-opt-fp4head.json",
+    "matched_control_artifact": "/tmp/qwen38-target-bench.json",
+    "prior_evidence": "GB10-QWEN38-DFLASH-002",
+    "reference_implementation": "https://github.com/pangoleen/qwen3.8-27b-dgx-spark-dflash2@2c7c38216cea410497ae222dc58030c021b74bd7"
+  },
+  "limitations": [
+    "This is dirty-worktree optimization evidence, not a clean-revision certification result.",
+    "The target-only control is the matched one-trial control recorded by GB10-QWEN38-DFLASH-002; it was not rerun for this optimization probe.",
+    "The probe covers one batch-one greedy 128-token math workload; sampled, concurrent, long-context, capability, and endurance suites were not rerun.",
+    "The host had 610304 bytes of pre-existing swap resident, with zero growth, swap-in, or swap-out during the selected requests.",
+    "The installed SparkLab kernel-cache wheel reported version 0.1.0+cu130 against the 0.1.1 source tree; the version guard was explicitly disabled for this source-tree benchmark."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -32,8 +32,8 @@ coding-agent task, and versioned benchmark evidence. Status means:
 |---|---|---|---|---|---:|---:|
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
+| [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW + optional DFlash2-8 | `qwen3.8-27b` | Experimental | 8.83 target / 35.48 DFlash2-8 | 0.144 target / 0.153 DFlash2-8 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
-| [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW | `qwen3.8-27b` | Experimental | 8.83 | 0.144 |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 30.67 | 0.258 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 13.15 | 0.518 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 6.27 target / 7.44 MTP3 | 5.681 target / 6.330 MTP3 |
@@ -62,7 +62,7 @@ output parity. It remains optimization evidence rather than certification.
 | Model | Current result | Evidence |
 |---|---|---|
 | Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Optimized native MTP2 reached 74.42 tok/s versus its 45.38 tok/s eager control; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json) |
-| Qwen3.8-27B | Passes Frontier speed, exact 64K recall, reasoning/tool parsing, and the coding-agent probe; the clean-revision 60-minute endurance gate remains outstanding. | [GB10-QWEN38-27B-001](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json) |
+| Qwen3.8-27B | The opt-in DFlash2-8 profile reached 35.48 tok/s with exact target-output parity and clears the Fast performance thresholds; full Fast certification remains pending. | [target-only](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json), [DFlash2](../benchmarks/gb10/results/GB10-QWEN38-DFLASH-003.json) |
 | Qwen3.8-Flash-Next | The selected MTP3 profile measured a three-trial median 30.67 tok/s at 0.258 s warm TTFT. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-MTP-007](../benchmarks/gb10/results/GB10-QWEN38-MTP-007.json) |
 | DeepSeek V4 Flash | The selected three-trial DSpark5 burst profile reaches 13.15 tok/s. Target-only remains the default and wins the 256-token sustained control, 10.52 versus 9.31 tok/s. | [GB10-DSV4-SMALLM-005](../benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json) |
 | GLM-5.3 Flash | Target-only reaches 6.27 tok/s. The opt-in optimized MTP3 path averaged 7.436 tok/s with 87.9% acceptance and exact target-only output parity; NVMe sensitivity and the remaining certification gates keep it Experimental. | [target-only](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json), [MTP sweep](../benchmarks/gb10/results/GB10-GLM53-MTP-004.json), [optimized MTP3](../benchmarks/gb10/results/GB10-GLM53-OPT-005.json) |

--- a/docs/models/qwen3.8-27b.md
+++ b/docs/models/qwen3.8-27b.md
@@ -1,0 +1,45 @@
+# Run Qwen3.8-27B
+
+Qwen3.8-27B is an Experimental Fast-tier, text-only resident NVFP4 recipe for
+one NVIDIA GB10. The target-only recipe remains the default; native DFlash2 is
+the optional batch-one greedy Fast profile.
+
+## Prepare
+
+Follow the [installation guide](../install.md), then prepare the pinned target:
+
+```bash
+sparklab pull qwen3.8-27b --root /path/to/models --prepare
+```
+
+Download the pinned DFlash2 draft separately:
+
+```bash
+hf download maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal \
+  --revision bd7a934213c47a9e7ef69eef36bb3325f47fd1f1 \
+  --local-dir /path/to/models/qwen3.8-27b-dflash2
+```
+
+## Run
+
+Target only:
+
+```bash
+sparklab run qwen3.8-27b --root /path/to/models
+```
+
+Opt-in DFlash2-8:
+
+```bash
+sparklab run qwen3.8-27b --root /path/to/models -- \
+  --attention-backend triton \
+  --speculative-method dflash2 \
+  --speculative-tokens 8 \
+  --speculative-draft-model /path/to/models/qwen3.8-27b-dflash2
+```
+
+The selected three-trial DGX Spark probe measured 35.48 decode tok/s and 0.153 s
+warm TTFT, with the same greedy output hash as target-only. DFlash2 supports block
+sizes 2–16, but remains limited to batch-one greedy requests and runs without CUDA
+graphs. It clears the Fast throughput and latency thresholds, while full Fast
+certification remains pending. See the [benchmark evidence](../../benchmarks/gb10/results/GB10-QWEN38-DFLASH-003.json).

--- a/python/sparklab/backends/native.py
+++ b/python/sparklab/backends/native.py
@@ -35,6 +35,7 @@ _VALUE_OPTIONS: dict[str, tuple[str, type | tuple[type, ...]]] = {
     "num_tokens": ("--num-tokens", int),
     "speculative_method": ("--speculative-method", str),
     "speculative_tokens": ("--speculative-tokens", int),
+    "speculative_draft_model": ("--speculative-draft-model", str),
     "draft_sample_method": ("--draft-sample-method", str),
 }
 _FLAG_OPTIONS: dict[str, str] = {
@@ -72,6 +73,7 @@ _OPTION_ORDER = (
     "num_tokens",
     "speculative_method",
     "speculative_tokens",
+    "speculative_draft_model",
     "draft_sample_method",
     "kimi_mlp_fp8",
     "disable_startup_prefill_warmup",

--- a/python/sparklab/core.py
+++ b/python/sparklab/core.py
@@ -171,6 +171,9 @@ class Batch:
     # is a multi-token continuation and therefore uses the varlen kernels.
     return_all_logits: bool = field(default=False, init=False)
     disable_state_tracking: bool = field(default=False, init=False)
+    # DFlash2 target verification caches the recurrent state after every input
+    # token, then commits only the accepted prefix without replaying the target.
+    cache_verify_states: bool = field(default=False, init=False)
     # A short sequential repair after speculative rejection. Attention still needs
     # prefill/varlen semantics, while token-local MoE and recurrent mixers should use
     # their low-latency verification kernels instead of padded prompt kernels.

--- a/python/sparklab/kernels/triton/dflash2.py
+++ b/python/sparklab/kernels/triton/dflash2.py
@@ -1,0 +1,52 @@
+"""Small fused kernels for native DFlash2 decoding."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _greedy_selector_walk_kernel(
+    scores_ptr,
+    candidate_ptr,
+    tokens_ptr,
+    slots: tl.constexpr,
+    top_k: tl.constexpr,
+):
+    """Walk one dependent K-way lattice without a kernel launch per slot."""
+    offsets = tl.arange(0, top_k)
+    previous = 0
+    for slot in range(slots):
+        base = slot * top_k
+        scores = tl.load(scores_ptr + (base + previous) * top_k + offsets).to(
+            tl.float32
+        )
+        best = tl.max(scores, axis=0)
+        # Match torch.argmax's first-index tie break.
+        index = tl.min(tl.where(scores == best, offsets, top_k), axis=0)
+        tl.store(tokens_ptr + slot, tl.load(candidate_ptr + base + index))
+        previous = index
+
+
+def greedy_selector_walk(
+    candidate_ids: torch.Tensor, scores: torch.Tensor
+) -> torch.Tensor:
+    """Return the greedy token path for ``scores[slot, predecessor, candidate]``."""
+    slots, top_k = candidate_ids.shape
+    if top_k <= 0 or top_k & (top_k - 1):
+        raise ValueError("DFlash2 selector top_k must be a power of two")
+    tokens = torch.empty(slots, dtype=candidate_ids.dtype, device=scores.device)
+    _greedy_selector_walk_kernel[(1,)](
+        scores.contiguous(),
+        candidate_ids.contiguous(),
+        tokens,
+        slots=slots,
+        top_k=top_k,
+        num_warps=1,
+    )
+    return tokens
+
+
+__all__ = ["greedy_selector_walk"]

--- a/python/sparklab/kernels/triton/nvfp4_linear.py
+++ b/python/sparklab/kernels/triton/nvfp4_linear.py
@@ -938,6 +938,41 @@ class Nvfp4LMHead(BaseOP):
         return nvfp4_dense_linear(x, self.weight, self.weight_scale, self.weight_global)
 
 
+def quantize_nvfp4_lm_head(weight: torch.Tensor) -> Nvfp4LMHead:
+    """Build a proposal-only W4A16 head from a resident BF16 vocabulary matrix."""
+    if weight.ndim != 2 or weight.dtype != torch.bfloat16 or weight.shape[1] % 16:
+        raise ValueError(
+            "DFlash2 selector quantization requires a BF16 [vocab, hidden] matrix "
+            "with hidden size divisible by 16"
+        )
+    import flashinfer
+    from flashinfer.quantization import SfLayout
+
+    maximum = weight.float().abs().nan_to_num().max()
+    quant_scale = torch.where(
+        maximum > 0,
+        maximum.new_tensor(448.0 * 6.0) / maximum,
+        maximum.new_tensor(1.0),
+    ).reshape(1)
+    packed, block_scales = flashinfer.nvfp4_quantize(
+        weight, quant_scale, sfLayout=SfLayout.layout_linear
+    )
+    packed = packed.view(torch.uint8).reshape(weight.shape[0], weight.shape[1] // 2)
+    block_scales = block_scales.view(FP8).reshape(
+        weight.shape[0], weight.shape[1] // 16
+    )
+    packed_t, scales_t = nvfp4_transpose_resident(packed, block_scales)
+    with torch.device("meta"):
+        head = Nvfp4LMHead(weight.shape[0], weight.shape[1])
+    head.weight = packed_t
+    head.weight_scale = scales_t
+    head.weight_global = quant_scale.reciprocal().to(torch.float16).expand(
+        weight.shape[0]
+    ).contiguous()
+    head._transposed = True
+    return head
+
+
 __all__ = [
     "FP8",
     "nvfp4_dense_linear",
@@ -946,4 +981,5 @@ __all__ = [
     "Nvfp4DenseLinear",
     "Nvfp4DenseColMerged",
     "Nvfp4LMHead",
+    "quantize_nvfp4_lm_head",
 ]

--- a/python/sparklab/models/config.py
+++ b/python/sparklab/models/config.py
@@ -326,6 +326,9 @@ class ModelConfig:
     # Runtime speculative-decoding selection injected after parsing.
     speculative_method: str = "none"
     speculative_tokens: int = 0
+    # External DFlash2 draft geometry, resolved by the engine before model creation.
+    # Kept opaque here so model-independent cache sizing can read its injected KV group.
+    dflash2_args: Any | None = None
     draft_sample_method: str = "greedy"
     dspark_confidence_threshold: float = 0.0
     # Generic execution-path capability flags (set by a model's parse_config) so the engine and

--- a/python/sparklab/models/qwen3_5_moe/__init__.py
+++ b/python/sparklab/models/qwen3_5_moe/__init__.py
@@ -1,6 +1,7 @@
 from .config import parse_config
 from .model import Qwen3_5MoEForCausalLM
 from .weight import (
+    iter_dflash2_weights,
     iter_weights,
     iter_weights_parallel,
     iter_speculative_weights,
@@ -12,6 +13,7 @@ from .weight import (
 __all__ = [
     "Qwen3_5MoEForCausalLM",
     "parse_config",
+    "iter_dflash2_weights",
     "iter_weights",
     "iter_weights_parallel",
     "iter_speculative_weights",

--- a/python/sparklab/models/qwen3_5_moe/dflash2.py
+++ b/python/sparklab/models/qwen3_5_moe/dflash2.py
@@ -1,0 +1,415 @@
+"""Native DFlash2 block drafter for dense Qwen3.8.
+
+The draft has no embedding or language-model head.  It consumes five captured
+target-layer features, reuses the target embedding/head, and predicts a masked
+block in parallel.  The architecture follows the MIT-licensed DGX Spark
+DFlash2 reference; the runtime integration and cache layout are SparkLab-native.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from sparklab.core import Batch, Req, get_global_ctx
+from sparklab.kernels.triton.nvfp4_linear import (
+    Nvfp4DenseColMerged,
+    Nvfp4DenseLinear,
+)
+from sparklab.layers import (
+    BaseOP,
+    LinearReplicated,
+    OPList,
+    RMSNorm,
+    silu_and_mul,
+)
+from sparklab.layers.rotary import get_rope
+
+try:
+    from flashinfer import top_k as _flashinfer_top_k
+except ImportError:  # pragma: no cover - exercised only in minimal installations
+    _flashinfer_top_k = None
+
+
+def _selector_topk(scores: torch.Tensor, k: int):
+    """Use FlashInfer's radix top-k for the selector's large vocabulary scan."""
+    if scores.is_cuda and _flashinfer_top_k is not None:
+        return _flashinfer_top_k(scores, k, sorted=True, deterministic=True)
+    return torch.topk(scores, k, dim=-1)
+
+
+@dataclass(frozen=True)
+class DFlash2Args:
+    draft_model_path: str
+    num_layers: int
+    hidden_size: int
+    intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    vocab_size: int
+    max_position_embeddings: int
+    rope_theta: float
+    rms_norm_eps: float
+    sliding_window: int
+    checkpoint_block_size: int
+    conv_kernel_size: int
+    conv_group_size: int
+    selector_rank: int
+    selector_top_k: int
+    target_layer_ids: tuple[int, ...]
+    mask_token_id: int
+
+
+def parse_dflash2_args(hf_config: Any, draft_model_path: str) -> DFlash2Args:
+    cfg = getattr(hf_config, "text_config", hf_config)
+    dflash = getattr(cfg, "dflash_config", None) or getattr(hf_config, "dflash_config", {})
+    if not isinstance(dflash, dict):
+        dflash = dflash.to_dict()
+    architectures = tuple(getattr(hf_config, "architectures", ()) or ())
+    if "DFlash2DraftModel" not in architectures:
+        raise ValueError(
+            "--speculative-method dflash2 requires a DFlash2DraftModel checkpoint"
+        )
+    layer_ids = tuple(int(x) for x in dflash.get("target_layer_ids", ()))
+    num_layers = int(getattr(cfg, "num_hidden_layers"))
+    if not layer_ids or len(layer_ids) != num_layers:
+        raise ValueError(
+            "DFlash2 target_layer_ids must contain one target feature per draft layer"
+        )
+    rope = getattr(cfg, "rope_parameters", None) or {}
+    return DFlash2Args(
+        draft_model_path=draft_model_path,
+        num_layers=num_layers,
+        hidden_size=int(getattr(cfg, "hidden_size")),
+        intermediate_size=int(getattr(cfg, "intermediate_size")),
+        num_attention_heads=int(getattr(cfg, "num_attention_heads")),
+        num_key_value_heads=int(getattr(cfg, "num_key_value_heads")),
+        head_dim=int(getattr(cfg, "head_dim")),
+        vocab_size=int(getattr(cfg, "vocab_size")),
+        max_position_embeddings=int(getattr(cfg, "max_position_embeddings")),
+        rope_theta=float(rope.get("rope_theta", getattr(cfg, "rope_theta", 10000.0))),
+        rms_norm_eps=float(getattr(cfg, "rms_norm_eps", 1e-6)),
+        sliding_window=int(getattr(cfg, "sliding_window", 0) or 0),
+        checkpoint_block_size=int(dflash.get("block_size", 0) or 0),
+        conv_kernel_size=int(dflash.get("conv_kernel_size", 0) or 0),
+        conv_group_size=int(dflash.get("conv_group_size", 0) or 0),
+        selector_rank=int(dflash.get("selector_rank", 0) or 0),
+        selector_top_k=int(dflash.get("selector_top_k", 0) or 0),
+        target_layer_ids=layer_ids,
+        mask_token_id=int(dflash["mask_token_id"]),
+    )
+
+
+class DFlashGroupedConv(BaseOP):
+    def __init__(self, args: DFlash2Args, block_size: int):
+        if args.hidden_size % args.conv_group_size:
+            raise ValueError("DFlash2 conv_group_size must divide hidden_size")
+        self.block_size = block_size
+        self.taps = args.conv_kernel_size
+        self.group_size = args.conv_group_size
+        self.num_groups = args.hidden_size // self.group_size
+        self.base_kernel = torch.empty(2, self.taps, args.hidden_size)
+        self.kernel_projection = LinearReplicated(
+            args.hidden_size, 2 * self.taps * self.num_groups, has_bias=False
+        )
+
+    def _convolve(
+        self, hidden: torch.Tensor, delta: torch.Tensor, side: int
+    ) -> torch.Tensor:
+        blocks = hidden.unflatten(-1, (self.num_groups, self.group_size))
+        base = self.base_kernel[side].view(
+            1, self.taps, self.num_groups, self.group_size
+        )
+        coefficients = base + delta.unsqueeze(-1)
+        out = coefficients[:, 0] * blocks
+        position = torch.arange(hidden.shape[0], device=hidden.device) % self.block_size
+        for tap in range(1, self.taps):
+            shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
+            out = out + coefficients[:, tap] * shifted * (
+                position >= tap
+            ).view(-1, 1, 1)
+        return out.flatten(-2)
+
+    def prepare(self, hidden: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        coefficients = self.kernel_projection.forward(hidden).reshape(
+            hidden.shape[0], 2, self.taps, self.num_groups
+        )
+        return self._convolve(hidden, coefficients[:, 0], 0), coefficients[:, 1]
+
+    def finish(self, hidden: torch.Tensor, coefficients: torch.Tensor) -> torch.Tensor:
+        return self._convolve(hidden, coefficients, 1)
+
+
+class DFlashAttention(BaseOP):
+    def __init__(self, args: DFlash2Args, layer_id: int):
+        self.layer_id = layer_id
+        self.num_q = args.num_attention_heads
+        self.num_kv = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.q_size = self.num_q * self.head_dim
+        self.kv_size = self.num_kv * self.head_dim
+        self.sliding_window = args.sliding_window
+        self.qkv_proj = Nvfp4DenseColMerged(
+            args.hidden_size, [self.q_size, self.kv_size, self.kv_size]
+        )
+        self.o_proj = Nvfp4DenseLinear(self.q_size, args.hidden_size)
+        self.q_norm = RMSNorm(self.head_dim, args.rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, args.rms_norm_eps)
+        self.rotary = get_rope(
+            head_dim=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=args.max_position_embeddings,
+            base=args.rope_theta,
+            rope_scaling=None,
+        )
+
+    def _project(
+        self, hidden: torch.Tensor, positions: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        qkv = self.qkv_proj.forward(hidden)
+        q, k, v = torch.split(qkv, [self.q_size, self.kv_size, self.kv_size], -1)
+        q = self.q_norm.forward(q.contiguous().view(-1, self.head_dim)).view_as(q)
+        k = self.k_norm.forward(k.contiguous().view(-1, self.head_dim)).view_as(k)
+        q, k = self.rotary.forward(positions, q, k)
+        return q, k, v.contiguous()
+
+    def materialize_context(
+        self, hidden: torch.Tensor, positions: torch.Tensor, out_loc: torch.Tensor
+    ) -> None:
+        qkv = self.qkv_proj.forward(hidden)
+        _, k, v = torch.split(qkv, [self.q_size, self.kv_size, self.kv_size], -1)
+        k = self.k_norm.forward(k.contiguous().view(-1, self.head_dim)).view_as(k)
+        dummy_q = torch.empty_like(k)
+        _, k = self.rotary.forward(positions, dummy_q, k)
+        get_global_ctx().kv_cache.store_kv(
+            k.view(-1, self.kv_size),
+            v.contiguous().view(-1, self.kv_size),
+            out_loc,
+            self.layer_id,
+        )
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        ctx = get_global_ctx()
+        batch = ctx.batch
+        if batch.size != 1:
+            raise RuntimeError("native DFlash2 currently supports batch size 1")
+        q, k, v = self._project(hidden, batch.positions)
+        req = batch.reqs[0]
+        block = hidden.shape[0]
+        prefix_keep = req.cached_len
+        if self.sliding_window:
+            prefix_keep = min(prefix_keep, max(0, self.sliding_window - block))
+        start = req.cached_len - prefix_keep
+        slots = ctx.page_table[req.table_idx, start : req.cached_len].to(torch.long)
+        k_cache = ctx.kv_cache.k_cache(self.layer_id).view(
+            -1, self.num_kv, self.head_dim
+        )
+        v_cache = ctx.kv_cache.v_cache(self.layer_id).view(
+            -1, self.num_kv, self.head_dim
+        )
+        prefix_k = k_cache.index_select(0, slots)
+        prefix_v = v_cache.index_select(0, slots)
+        all_k = torch.cat((prefix_k, k.view(-1, self.num_kv, self.head_dim)), 0)
+        all_v = torch.cat((prefix_v, v.view(-1, self.num_kv, self.head_dim)), 0)
+        q4 = q.view(block, self.num_q, self.head_dim).transpose(0, 1).unsqueeze(0)
+        k4 = all_k.transpose(0, 1).unsqueeze(0)
+        v4 = all_v.transpose(0, 1).unsqueeze(0)
+        output = F.scaled_dot_product_attention(
+            q4, k4, v4, is_causal=False, enable_gqa=True
+        )
+        output = output.squeeze(0).transpose(0, 1).reshape(block, self.q_size)
+        return self.o_proj.forward(output)
+
+
+class DFlashMLP(BaseOP):
+    def __init__(self, args: DFlash2Args):
+        self.gate_up_proj = Nvfp4DenseColMerged(
+            args.hidden_size, [args.intermediate_size, args.intermediate_size]
+        )
+        self.down_proj = Nvfp4DenseLinear(args.intermediate_size, args.hidden_size)
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        return self.down_proj.forward(silu_and_mul(self.gate_up_proj.forward(hidden)))
+
+
+class DFlashDecoderLayer(BaseOP):
+    def __init__(self, args: DFlash2Args, layer_id: int, block_size: int):
+        self.input_layernorm = RMSNorm(args.hidden_size, args.rms_norm_eps)
+        self.self_attn = DFlashAttention(args, layer_id)
+        self.post_attention_layernorm = RMSNorm(args.hidden_size, args.rms_norm_eps)
+        self.mlp = DFlashMLP(args)
+        self.attention_conv = DFlashGroupedConv(args, block_size)
+        self.mlp_conv = DFlashGroupedConv(args, block_size)
+
+    def forward(
+        self, hidden: torch.Tensor, residual: torch.Tensor | None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden
+            hidden = self.input_layernorm.forward(hidden)
+        else:
+            residual = residual + hidden
+            hidden = self.input_layernorm.forward(residual)
+        hidden, kernel = self.attention_conv.prepare(hidden)
+        hidden = self.attention_conv.finish(self.self_attn.forward(hidden), kernel)
+        residual = residual + hidden
+        hidden = self.post_attention_layernorm.forward(residual)
+        hidden, kernel = self.mlp_conv.prepare(hidden)
+        hidden = self.mlp_conv.finish(self.mlp.forward(hidden), kernel)
+        return hidden, residual
+
+
+class CandidateSelector(BaseOP):
+    def __init__(self, args: DFlash2Args):
+        self.predecessor_codebook = torch.empty(
+            args.vocab_size, args.selector_rank
+        )
+        self.successor_codebook = torch.empty(args.vocab_size, args.selector_rank)
+        self.hidden_projection = LinearReplicated(
+            args.hidden_size, args.selector_rank, has_bias=False
+        )
+        self.top_k = args.selector_top_k
+
+    def greedy_path(
+        self,
+        candidate_ids: torch.Tensor,
+        unary_logits: torch.Tensor,
+        hidden: torch.Tensor,
+        anchor: torch.Tensor,
+    ) -> torch.Tensor:
+        projected = self.hidden_projection.forward(hidden)
+        predecessor_ids = torch.cat(
+            (anchor.reshape(1, 1).expand(1, self.top_k), candidate_ids[:-1]), 0
+        )
+        predecessors = self.predecessor_codebook[predecessor_ids]
+        successors = self.successor_codebook[candidate_ids]
+        scores = unary_logits[:, None, :] + torch.einsum(
+            "lpr,lcr,lr->lpc", predecessors, successors, projected
+        )
+        if scores.is_cuda:
+            from sparklab.kernels.triton.dflash2 import greedy_selector_walk
+
+            return greedy_selector_walk(candidate_ids, scores).to(torch.int32)
+        index = scores[0, 0].argmax()
+        path = [candidate_ids[0, index]]
+        for edge in range(1, candidate_ids.shape[0]):
+            index = scores[edge, index].argmax()
+            path.append(candidate_ids[edge, index])
+        return torch.stack(path).to(torch.int32)
+
+
+class Qwen38DFlash2(BaseOP):
+    def __init__(self, args: DFlash2Args, target_num_layers: int, block_size: int):
+        if args.hidden_size <= 0 or args.selector_rank <= 0:
+            raise ValueError("invalid DFlash2 checkpoint geometry")
+        if any(layer < 0 or layer >= target_num_layers for layer in args.target_layer_ids):
+            raise ValueError("DFlash2 target layer id is outside the target tower")
+        self.args = args
+        self.block_size = block_size
+        first_layer_id = target_num_layers
+        self.layers = OPList(
+            [
+                DFlashDecoderLayer(args, first_layer_id + i, block_size)
+                for i in range(args.num_layers)
+            ]
+        )
+        self.norm = RMSNorm(args.hidden_size, args.rms_norm_eps)
+        self.fc = LinearReplicated(
+            len(args.target_layer_ids) * args.hidden_size,
+            args.hidden_size,
+            has_bias=False,
+        )
+        self.hidden_norm = RMSNorm(args.hidden_size, args.rms_norm_eps)
+        self.candidate_selector = CandidateSelector(args)
+        self._selector_lm_head = None
+
+    def prepare_for_runtime(self, target_lm_head) -> None:
+        """Use a compact proposal-only head while target verification stays exact."""
+        from sparklab.kernels.triton.nvfp4_linear import (
+            Nvfp4LMHead,
+            quantize_nvfp4_lm_head,
+        )
+
+        if isinstance(target_lm_head, Nvfp4LMHead):
+            self._selector_lm_head = target_lm_head
+            return
+        weight = getattr(target_lm_head, "weight", None)
+        if weight is None:
+            raise RuntimeError("DFlash2 selector requires a target language-model head")
+        try:
+            self._selector_lm_head = quantize_nvfp4_lm_head(weight)
+        except ImportError:
+            # FlashInfer also accelerates top-k, but keep the correctness-first
+            # BF16 proposal path usable in minimal installations.
+            self._selector_lm_head = target_lm_head
+
+    def materialize_target_hidden(
+        self,
+        captures: list[torch.Tensor],
+        positions: torch.Tensor,
+        out_loc: torch.Tensor,
+    ) -> None:
+        if len(captures) != len(self.args.target_layer_ids):
+            raise RuntimeError("DFlash2 target hidden capture count mismatch")
+        hidden = self.hidden_norm.forward(self.fc.forward(torch.cat(captures, -1)))
+        for layer in self.layers.op_list:
+            layer.self_attn.materialize_context(hidden, positions, out_loc)
+
+    def propose(self, target, batch: Batch, next_token: torch.Tensor) -> torch.Tensor | None:
+        if batch.size != 1 or not batch.reqs[0].sampling_params.is_greedy:
+            return None
+        req = batch.reqs[0]
+        block_size = min(self.block_size, max(1, req.max_device_len - req.device_len))
+        if block_size <= 1:
+            return None
+        ids = torch.full(
+            (block_size,),
+            self.args.mask_token_id,
+            dtype=torch.int32,
+            device=next_token.device,
+        )
+        ids[0].copy_(next_token.reshape(()).to(torch.int32))
+        prefix = req.device_len
+        draft_req = Req(
+            input_ids=torch.zeros(prefix + block_size, dtype=req.input_ids.dtype),
+            table_idx=req.table_idx,
+            cached_len=prefix,
+            output_len=1,
+            uid=req.uid,
+            sampling_params=req.sampling_params,
+            cache_handle=req.cache_handle,
+        )
+        draft_req.linear_slot_idx = req.linear_slot_idx
+        draft_batch = Batch(reqs=[draft_req], phase="decode")
+        draft_batch.padded_reqs = draft_batch.reqs
+        draft_batch.input_ids = ids
+        draft_batch.positions = torch.arange(
+            prefix, prefix + block_size, dtype=torch.int32, device=ids.device
+        )
+        draft_batch.out_loc = get_global_ctx().page_table[
+            req.table_idx, prefix : prefix + block_size
+        ]
+        draft_batch.return_all_logits = True
+        with get_global_ctx().forward_batch(draft_batch):
+            hidden = target.model.embed_tokens.forward(ids)
+            residual: torch.Tensor | None = None
+            for layer in self.layers.op_list:
+                hidden, residual = layer.forward(hidden, residual)
+            hidden = self.norm.forward(hidden + residual)
+            predictive = hidden[1:]
+            selector_head = self._selector_lm_head or target.lm_head
+            project = getattr(selector_head, "forward_all", selector_head.forward)
+            logits = project(predictive)
+            unary, candidates = _selector_topk(
+                logits.float(), self.candidate_selector.top_k
+            )
+            return self.candidate_selector.greedy_path(
+                candidates.to(torch.long), unary, predictive, ids[:1].to(torch.long)
+            )
+
+
+__all__ = ["DFlash2Args", "Qwen38DFlash2", "parse_dflash2_args"]

--- a/python/sparklab/models/qwen3_5_moe/gdn.py
+++ b/python/sparklab/models/qwen3_5_moe/gdn.py
@@ -198,6 +198,20 @@ class Qwen3_5GatedDeltaNet(BaseOP):
             q = qf.reshape(1, total, self.num_k_heads, self.head_k_dim).to(dtype)
             k = kf.reshape(1, total, self.num_k_heads, self.head_k_dim).to(dtype)
             v = vf.reshape(1, total, self.num_v_heads, self.head_v_dim).to(dtype)
+            cache_verify = batch.is_verify and batch.cache_verify_states
+            intermediate = None
+            intermediate_indices = None
+            if cache_verify:
+                if (
+                    pool.verify_recurrent_states is None
+                    or pool.verify_conv_inputs is None
+                    or pool.verify_state_indices is None
+                    or total > pool.verify_steps
+                ):
+                    raise RuntimeError("DFlash2 GDN verify buffers are not initialized")
+                pool.verify_conv_inputs[li, :total].copy_(conv_in)
+                intermediate = pool.verify_recurrent_states[li]
+                intermediate_indices = pool.verify_state_indices
             core_out = gdn_decode_fla(
                 q,
                 k,
@@ -210,6 +224,9 @@ class Qwen3_5GatedDeltaNet(BaseOP):
                 indices=fla.cache_indices,
                 cu_seqlens=fla.cu_seqlens,
                 scale=self.head_k_dim ** -0.5,
+                disable_state_update=cache_verify,
+                intermediate_states_buffer=intermediate,
+                intermediate_state_indices=intermediate_indices,
             )
         elif not batch.uses_prefill_kernels:
             # Fused fla decode kernel: gating + in-kernel l2norm + recurrent update +

--- a/python/sparklab/models/qwen3_5_moe/gdn_kernels.py
+++ b/python/sparklab/models/qwen3_5_moe/gdn_kernels.py
@@ -54,6 +54,9 @@ def gdn_decode_fla(
     indices: torch.Tensor,      # [num_seqs] int32 slot id per request
     cu_seqlens: torch.Tensor,   # [num_seqs+1] query indptr from FLAMetadata
     scale: float,
+    disable_state_update: bool = False,
+    intermediate_states_buffer: torch.Tensor | None = None,
+    intermediate_state_indices: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Fused sigmoid-gating gated-delta-rule decode (vendored fla triton kernel): gating +
     in-kernel l2norm + recurrent update + state read/write-by-index in one kernel, with no
@@ -69,6 +72,9 @@ def gdn_decode_fla(
         initial_state_source=state_source,
         initial_state_indices=indices,  # already int32 (built int32 in the scheduler)
         scale=scale, use_qk_l2norm_in_kernel=True, cu_seqlens=cu_seqlens,
+        disable_state_update=disable_state_update,
+        intermediate_states_buffer=intermediate_states_buffer,
+        intermediate_state_indices=intermediate_state_indices,
     )
     # kernel returns o = [NK, *v.shape] then squeeze(NK) ->
     # [1, total, num_v, V]. o[0] retains every packed token.

--- a/python/sparklab/models/qwen3_5_moe/model.py
+++ b/python/sparklab/models/qwen3_5_moe/model.py
@@ -78,12 +78,21 @@ class Qwen3_5Model(BaseOP):
             [Qwen3_5DecoderLayer(config, layer_id) for layer_id in range(config.num_layers)]
         )
         self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        dflash_args = getattr(config, "dflash2_args", None)
+        self._dflash_capture_ids = (
+            frozenset(dflash_args.target_layer_ids) if dflash_args is not None else frozenset()
+        )
+        self._dflash_captures: list[torch.Tensor] = []
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         x = self.embed_tokens.forward(input_ids)
         residual: torch.Tensor | None = None
-        for layer in self.layers.op_list:
+        captures: list[torch.Tensor] = []
+        for layer_id, layer in enumerate(self.layers.op_list):
             x, residual = layer.forward(x, residual)
+            if layer_id in self._dflash_capture_ids:
+                captures.append(x + residual)
+        self._dflash_captures = captures
         x, _ = self.norm.forward_add_residual(x, residual)
         return x
 
@@ -108,24 +117,56 @@ class Qwen3_5MoEForCausalLM(BaseLLMModel):
                 tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
             )
         self._mtp = None
+        self._dflash = None
         self._mtp_steps = int(getattr(config, "speculative_tokens", 0) or 0)
-        if self._mtp_steps:
+        if getattr(config, "speculative_method", "none") == "dflash2":
+            from .dflash2 import Qwen38DFlash2
+
+            self._dflash = Qwen38DFlash2(
+                config.dflash2_args, config.num_layers, self._mtp_steps
+            )
+        elif self._mtp_steps:
             from .mtp import Qwen3_5MultiTokenPredictor
 
             self._mtp = Qwen3_5MultiTokenPredictor(config)
         self._mtp_target_hidden: torch.Tensor | None = None
         super().__init__()
 
+    def prepare_for_runtime(self) -> None:
+        if self._dflash is not None:
+            self._dflash.prepare_for_runtime(self.lm_head)
+
     def forward(self) -> torch.Tensor:
-        output = self.model.forward(get_global_ctx().batch.input_ids)
+        batch = get_global_ctx().batch
+        output = self.model.forward(batch.input_ids)
+        if self._dflash is not None:
+            self._dflash.materialize_target_hidden(
+                self.model._dflash_captures, batch.positions, batch.out_loc
+            )
         if self._mtp is not None:
             self._mtp_target_hidden = output
         return self.lm_head.forward(output)
 
+    def replay_speculative_state(self) -> None:
+        """Rebuild target and DFlash caches without the unused vocabulary projection."""
+        if self._dflash is None:
+            self.model.forward(get_global_ctx().batch.input_ids)
+            return
+        batch = get_global_ctx().batch
+        self.model.forward(batch.input_ids)
+        self._dflash.materialize_target_hidden(
+            self.model._dflash_captures, batch.positions, batch.out_loc
+        )
+
     def speculative_state_dict(self):
+        if self._dflash is not None:
+            return self._dflash.state_dict()
         return {} if self._mtp is None else self._mtp.state_dict()
 
     def load_speculative_state_dict(self, state_dict) -> None:
+        if self._dflash is not None:
+            self._dflash.load_state_dict(state_dict)
+            return
         if self._mtp is None:
             if state_dict:
                 raise RuntimeError("received Qwen MTP weights while MTP is disabled")
@@ -133,6 +174,8 @@ class Qwen3_5MoEForCausalLM(BaseLLMModel):
         self._mtp.load_state_dict(state_dict)
 
     def propose_mtp(self, batch, next_token: torch.Tensor) -> torch.Tensor | None:
+        if self._dflash is not None:
+            return self._dflash.propose(self, batch, next_token)
         if self._mtp is None or self._mtp_target_hidden is None or batch.size != 1:
             return None
         from sparklab.core import Batch, Req

--- a/python/sparklab/models/qwen3_5_moe/weight.py
+++ b/python/sparklab/models/qwen3_5_moe/weight.py
@@ -230,6 +230,85 @@ def iter_speculative_weights(
         reader.close()
 
 
+_DFLASH2_FUSIONS: dict[str, tuple[str, ...]] = {
+    ".self_attn.qkv_proj": (
+        ".self_attn.q_proj",
+        ".self_attn.k_proj",
+        ".self_attn.v_proj",
+    ),
+    ".mlp.gate_up_proj": (".mlp.gate_proj", ".mlp.up_proj"),
+}
+
+
+def iter_dflash2_weights(
+    model_path: str, device: torch.device
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Stream a standalone ModelOpt-NVFP4 DFlash2 checkpoint.
+
+    Q/K/V and gate/up are fused along the output dimension exactly as in the
+    native target.  ModelOpt's scalar ``weight_scale_2`` is expanded per output
+    row for SparkLab's W4A16 kernels; the remaining draft/selector tensors stay
+    BF16 and retain their checkpoint names.
+    """
+    if not model_path:
+        raise ValueError("DFlash2 draft model path is required")
+    reader = ShardReader(model_path, device)
+    pending: dict[str, dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]] = {}
+    consumed_suffixes = (".weight_scale", ".weight_scale_2", ".input_scale")
+    try:
+        names = set(reader.names())
+        for name in sorted(names):
+            if name.endswith(consumed_suffixes):
+                continue
+            if name.endswith(".weight"):
+                base = name[: -len(".weight")]
+                if base + ".weight_scale_2" in names:
+                    weight = reader.get_tensor(name)
+                    scale = reader.get_tensor(base + ".weight_scale")
+                    scale_2 = reader.get_tensor(base + ".weight_scale_2")
+                    global_scale = (
+                        scale_2.reshape(1)
+                        .to(torch.float16)
+                        .expand(weight.shape[0])
+                        .contiguous()
+                    )
+                    fused = False
+                    for out_suffix, parts in _DFLASH2_FUSIONS.items():
+                        for index, suffix in enumerate(parts):
+                            if not base.endswith(suffix):
+                                continue
+                            out = base[: -len(suffix)] + out_suffix
+                            slots = pending.setdefault(out, {})
+                            slots[index] = (weight, scale, global_scale)
+                            if len(slots) == len(parts):
+                                ordered = [slots[i] for i in range(len(parts))]
+                                del pending[out]
+                                yield out + ".weight", torch.cat(
+                                    [part[0] for part in ordered], 0
+                                )
+                                yield out + ".weight_scale", torch.cat(
+                                    [part[1] for part in ordered], 0
+                                )
+                                yield out + ".weight_global", torch.cat(
+                                    [part[2] for part in ordered], 0
+                                )
+                            fused = True
+                            break
+                        if fused:
+                            break
+                    if fused:
+                        continue
+                    yield base + ".weight", weight
+                    yield base + ".weight_scale", scale
+                    yield base + ".weight_global", global_scale
+                    continue
+            yield name, reader.get_tensor(name)
+        if pending:
+            raise ValueError(f"incomplete DFlash2 projection groups: {sorted(pending)}")
+    finally:
+        reader.close()
+
+
 def _try_fuse(
     name: str, tensor: torch.Tensor, buf: dict[str, dict[int, torch.Tensor]]
 ) -> tuple[str, torch.Tensor] | tuple[()] | None:

--- a/python/sparklab/recipes/qwen3.8-27b.json
+++ b/python/sparklab/recipes/qwen3.8-27b.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.1.0",
+  "recipe_version": "0.3.0",
   "slug": "qwen3.8-27b",
   "name": "Qwen3.8 27B",
   "model": "Inferact/Qwen3.8-27B-NVFP4",
@@ -9,7 +9,7 @@
   "source_bytes": 26404418018,
   "prepared_bytes": 24640689529,
   "minimum_free_bytes": 80000000000,
-  "intended_tier": "frontier",
+  "intended_tier": "fast",
   "status": "experimental",
   "implementation": "available",
   "portfolio_role": "primary",
@@ -34,21 +34,24 @@
   "runtime_memory": {
     "total_bytes": 51539607552
   },
-  "description": "Resident text-only ModelOpt NVFP4 recipe for dense Qwen3.8 on one NVIDIA GB10.",
+  "description": "Experimental Fast-tier text-only ModelOpt NVFP4 recipe for dense Qwen3.8 on one NVIDIA GB10.",
   "performance": {
     "decode_tokens_per_second": 8.832997654771269,
     "warm_ttft_seconds": 0.14434478300245246,
     "context_tokens": 65536,
     "evidence": "GB10-QWEN38-27B-001",
-    "note": "The complete pinned checkpoint passed a three-trial greedy performance probe, exact 64K recall, and reasoning/tool/coding capability probes. The 60-minute endurance gate remains outstanding."
+    "note": "The complete pinned checkpoint passed a three-trial greedy performance probe, exact 64K recall, and reasoning/tool/coding capability probes. Opt-in DFlash2-8 reached 35.48 tok/s with exact target-output parity in a separate three-trial probe."
   },
   "evidence": [
-    "GB10-QWEN38-27B-001"
+    "GB10-QWEN38-27B-001",
+    "GB10-QWEN38-DFLASH-002",
+    "GB10-QWEN38-DFLASH-003"
   ],
   "limitations": [
     "The published checkpoint includes a vision tower; SparkLab serves its language model text-only.",
     "The exact 65,536-token recall gate passed; the checkpoint's declared 262,144-token maximum has not been validated on GB10.",
-    "The measured 8.833 tok/s clears Frontier but not Fast admission, and the 60-minute endurance gate remains outstanding.",
-    "The evidence host had about 209 MiB of pre-existing swap resident, although the 64K request produced zero swap growth, swap-in, or swap-out."
+    "The opt-in DFlash2-8 profile clears the Fast throughput and latency thresholds; full Fast certification remains outstanding, including a clean-revision 60-minute endurance run.",
+    "The evidence host had about 209 MiB of pre-existing swap resident, although the 64K request produced zero swap growth, swap-in, or swap-out.",
+    "Native DFlash2 is opt-in and limited to batch-one greedy serving. Its three-trial 128-token probe selected block size eight and did not rerun long-context, capability, sampled, concurrent, or endurance gates."
   ]
 }

--- a/python/sparklab/runtime/engine/config.py
+++ b/python/sparklab/runtime/engine/config.py
@@ -99,6 +99,8 @@ class EngineConfig:
     # DSpark head from checkpoint metadata. Zero tokens disables the path.
     speculative_method: str = "auto"
     speculative_tokens: int = 0
+    # Separate DFlash2 draft checkpoint (local path or Hugging Face repository id).
+    speculative_draft_model: str | None = None
     draft_sample_method: str = "greedy"
     # DSpark confidence-head probability floor. Zero keeps fixed-width verification.
     dspark_confidence_threshold: float = 0.0

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -16,7 +16,15 @@ from sparklab.models import create_model, load_weight
 from sparklab.moe import create_moe_backend, is_offload_moe_backend
 from sparklab.moe.expert_banks import load_expert_banks
 from sparklab.moe.offload_cache import OffloadMoeCache, attach_offload_moe_cache
-from sparklab.utils import align_ceil, init_logger, is_sm90_family, is_sm100_family, mem_GB, torch_dtype
+from sparklab.utils import (
+    align_ceil,
+    cached_load_hf_config,
+    init_logger,
+    is_sm90_family,
+    is_sm100_family,
+    mem_GB,
+    torch_dtype,
+)
 
 from .config import EngineConfig
 from .graph import GraphRunner, MTPVerificationGraphRunner, get_free_memory
@@ -273,8 +281,8 @@ def _validate_attention_backend_choice(config, override, required: frozenset[Att
 def _adjust_speculative_config(config: EngineConfig, override) -> None:
     """Resolve and inject checkpoint-native speculation before cache sizing."""
     speculative_tokens = int(getattr(config, "speculative_tokens", 0) or 0)
-    if speculative_tokens < 0 or speculative_tokens > 7:
-        raise ValueError("--speculative-tokens must be between 0 and 7")
+    if speculative_tokens < 0 or speculative_tokens > 16:
+        raise ValueError("--speculative-tokens must be between 0 and 16")
     if not speculative_tokens:
         return
 
@@ -297,8 +305,19 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         and tuple(getattr(dsv4_args, "dspark_target_layer_ids", ()) or ())
         and int(getattr(dsv4_args, "dspark_markov_rank", 0) or 0) > 0
     )
+    draft_model = getattr(config, "speculative_draft_model", None) or os.getenv(
+        "SPARKLAB_DFLASH2_PATH"
+    )
     if requested == "auto":
-        method = "dspark" if dsv4_dspark else "mtp" if (qwen_mtp or glm5_mtp) else "none"
+        method = (
+            "dflash2"
+            if draft_model
+            else "dspark"
+            if dsv4_dspark
+            else "mtp"
+            if (qwen_mtp or glm5_mtp)
+            else "none"
+        )
     else:
         method = requested
     if method == "none":
@@ -311,6 +330,8 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
             raise ValueError(
                 "--speculative-method dspark requires a fused DeepSeek-V4 DSpark checkpoint"
             )
+        if speculative_tokens > 7:
+            raise ValueError("DeepSeek-V4 DSpark supports at most 7 speculative tokens")
         if getattr(config, "draft_sample_method", "greedy") not in {
             "greedy", "probabilistic"
         }:
@@ -368,6 +389,54 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         override("speculative_method", "dspark")
         # Correctness-first verification is eager and batch one. The DSpark
         # query block itself is still parallel inside one model forward.
+        override("max_running_req", 1)
+        override("cache_type", "radix")
+        override("cuda_graph_bs", [])
+        override("cuda_graph_max_bs", 0)
+        return
+
+    if method == "dflash2":
+        if not draft_model:
+            raise ValueError(
+                "--speculative-method dflash2 requires --speculative-draft-model "
+                "or SPARKLAB_DFLASH2_PATH"
+            )
+        if not 2 <= speculative_tokens <= 16:
+            raise ValueError("Qwen3.8 DFlash2 block size must be between 2 and 16")
+        if getattr(config, "draft_sample_method", "greedy") != "greedy":
+            raise ValueError("native DFlash2 currently supports greedy decoding only")
+        if model_config.moe_enabled or model_config.num_layers != 64:
+            raise ValueError("native DFlash2 currently requires dense 64-layer Qwen3.8")
+        from sparklab.models.config import FullAttentionGroupConfig
+        from sparklab.models.qwen3_5_moe.dflash2 import parse_dflash2_args
+
+        draft_hf = cached_load_hf_config(draft_model)
+        args = parse_dflash2_args(draft_hf, draft_model)
+        if (
+            args.hidden_size != model_config.hidden_size
+            or args.vocab_size != model_config.vocab_size
+        ):
+            raise ValueError(
+                "DFlash2 draft hidden/vocabulary geometry does not match the target"
+            )
+        first = model_config.num_layers
+        draft_ids = tuple(range(first, first + args.num_layers))
+        draft_group = FullAttentionGroupConfig(
+            name="dflash2",
+            layer_ids=draft_ids,
+            num_kv_heads=args.num_key_value_heads,
+            head_dim=args.head_dim,
+            rotary_config=model_config.rotary_config,
+        )
+        groups = tuple(
+            group for group in model_config.attention_groups if group.name != "dflash2"
+        ) + (draft_group,)
+        object.__setattr__(model_config, "attention_groups", groups)
+        object.__setattr__(model_config, "dflash2_args", args)
+        object.__setattr__(model_config, "speculative_method", "dflash2")
+        object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
+        override("speculative_method", "dflash2")
+        override("speculative_draft_model", draft_model)
         override("max_running_req", 1)
         override("cache_type", "radix")
         override("cuda_graph_bs", [])
@@ -610,8 +679,11 @@ class Engine:
         self.cpu_moe_executor = None
         if is_offload_moe_backend(config.moe_backend):
             self._init_offload_moe_cache(config)
+        pre_runtime_free = self._sync_get_memory()[0]
         if hasattr(self.model, "prepare_for_runtime"):
             self.model.prepare_for_runtime()
+        post_runtime_free = self._sync_get_memory()[0]
+        self._weights_bytes += max(0, pre_runtime_free - post_runtime_free)
 
         # ======================= KV cache initialization ========================
         new_free = self._sync_get_memory()[1]
@@ -638,6 +710,10 @@ class Engine:
                 tp_size=config.tp_info.size,
             )
             self.ctx.linear_state_pool = self.linear_state_pool
+            if config.speculative_method == "dflash2":
+                self.linear_state_pool.enable_verify_transactions(
+                    config.speculative_tokens
+                )
         else:
             self.linear_state_pool = None
 
@@ -775,7 +851,13 @@ class Engine:
             return _make_dummy_weight_state_dict(model_state, device=self.device)
         from sparklab.checkpoint.ftw import is_ftw_checkpoint, iter_ftw_weights
 
-        if is_ftw_checkpoint(config.model_path):
+        if config.speculative_method == "dflash2":
+            from sparklab.models.register import _load_attr, get_model_spec
+
+            spec = get_model_spec(config.model_config.architectures[0])
+            loader = _load_attr(spec.module, "iter_dflash2_weights")
+            weights = loader(config.speculative_draft_model, torch.device("cpu"))
+        elif is_ftw_checkpoint(config.model_path):
             weights = iter_ftw_weights(
                 config.model_path, kinds=("speculative_weight",)
             )
@@ -1326,6 +1408,8 @@ class Engine:
                         scratch = pool.num_slots - 1
                     pool.copy_from(live, scratch)
                     state_snapshots.append((live, scratch))
+                if self.config.speculative_method == "dflash2":
+                    batch.cache_verify_states = True
         with self.ctx.forward_batch(batch):
             if (
                 batch.is_verify
@@ -1356,6 +1440,11 @@ class Engine:
             )
             self.mtp_stats["drafted"] += int(drafts.numel())
             self.mtp_stats["accepted"] += accepted
+            if self.config.speculative_method == "dflash2":
+                live, scratch = state_snapshots[0]
+                self.linear_state_pool.commit_verify_prefix(
+                    scratch, live, accepted + 1
+                )
             if accepted < drafts.numel():
                 if self.config.speculative_method == "dspark":
                     if accepted == 0:
@@ -1363,10 +1452,12 @@ class Engine:
                         self.mtp_stats["fast_carry_commits"] += 1
                     else:
                         self.kv_cache.restore_speculative(kv_snapshot)
-                else:
+                elif self.config.speculative_method != "dflash2":
                     live, scratch = state_snapshots[0]
                     self.linear_state_pool.copy_from(scratch, live)
-                if self.config.speculative_method != "dspark" or accepted > 0:
+                if self.config.speculative_method not in {"dspark", "dflash2"} or (
+                    self.config.speculative_method == "dspark" and accepted > 0
+                ):
                     self._replay_verified_prefix(batch, accepted + 1, start)
                     self.mtp_stats["replay_calls"] += 1
                     self.mtp_stats["replay_tokens"] += accepted + 1
@@ -1477,7 +1568,13 @@ class Engine:
             replay.fla_metadata = build_fla_metadata(replay, self.device)
         self.attn_backend.prepare_metadata(replay)
         with self.ctx.forward_batch(replay):
-            if self.config.speculative_method == "dspark":
+            if self.config.speculative_method == "dflash2":
+                replay_state = getattr(self.model, "replay_speculative_state", None)
+                if replay_state is None:
+                    self.model.forward()
+                else:
+                    replay_state()
+            elif self.config.speculative_method == "dspark":
                 self.model.forward()
             else:
                 self.model.model.forward(replay.input_ids)

--- a/python/sparklab/runtime/kvcache/__init__.py
+++ b/python/sparklab/runtime/kvcache/__init__.py
@@ -61,6 +61,12 @@ def resolve_pool_class(model_config: ModelConfig) -> type[BaseKVCachePool]:
         from .bsa_pool import BSAKVCache
 
         return BSAKVCache
+    paged_specs = [spec for spec in specs_fn() if spec.attn_type is AttnType.FULL]
+    geometries = {(spec.num_kv_heads, spec.head_dim) for spec in paged_specs}
+    if len(geometries) > 1:
+        from .grouped_mha_pool import GroupedMHAKVCache
+
+        return GroupedMHAKVCache
     from .mha_pool import MHAKVCache
 
     return MHAKVCache
@@ -141,7 +147,21 @@ def create_kvcache_pool(
     head_dim = model_config.head_dim
     if model_config.has_linear_attention:
         specs = [s for s in model_config.kv_cache_group_specs() if s.num_layers > 0]
-        assert len(specs) == 1, f"expected one paged-KV group, got {[s.name for s in specs]}"
+        if len({(s.num_kv_heads, s.head_dim) for s in specs}) > 1:
+            from .grouped_mha_pool import GroupedMHAKVCache
+
+            return GroupedMHAKVCache(
+                groups=specs,
+                num_layers=max(
+                    model_config.num_layers,
+                    max((layer for spec in specs for layer in spec.layer_ids), default=-1) + 1,
+                ),
+                num_pages=num_pages,
+                page_size=page_size,
+                dtype=dtype,
+                device=device,
+            )
+        assert len(specs) == 1, f"expected one paged-KV geometry, got {[s.name for s in specs]}"
         spec = specs[0]
         layer_ids = spec.layer_ids
         num_kv_heads = spec.num_kv_heads

--- a/python/sparklab/runtime/kvcache/grouped_mha_pool.py
+++ b/python/sparklab/runtime/kvcache/grouped_mha_pool.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+
+from .base import BaseKVCachePool, spec_kv_bytes_per_token
+from .mha_pool import MHAKVCache
+
+
+class GroupedMHAKVCache(BaseKVCachePool):
+    """Paged GQA caches for models with more than one KV geometry.
+
+    Target and draft towers can share the scheduler's physical token locations while
+    using different head counts and head dimensions.  Each geometry therefore owns a
+    compact :class:`MHAKVCache`; this facade routes global layer ids to the right one.
+    """
+
+    def __init__(
+        self,
+        *,
+        groups: Sequence,
+        num_layers: int,
+        num_pages: int,
+        page_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        self._groups: list[MHAKVCache] = []
+        self._layer_to_group: dict[int, MHAKVCache] = {}
+        self._num_layers = num_layers
+        self._device = device
+        self._dtype = dtype
+        for group in groups:
+            if not group.layer_ids:
+                continue
+            pool = MHAKVCache(
+                num_kv_heads=group.num_kv_heads,
+                num_layers=num_layers,
+                head_dim=group.head_dim,
+                num_pages=num_pages,
+                page_size=page_size,
+                dtype=dtype,
+                device=device,
+                layer_ids=group.layer_ids,
+            )
+            self._groups.append(pool)
+            for layer_id in group.layer_ids:
+                if layer_id in self._layer_to_group:
+                    raise ValueError(f"KV layer {layer_id} belongs to multiple groups")
+                self._layer_to_group[layer_id] = pool
+
+    @classmethod
+    def kv_cost(cls, config) -> tuple[int, int, int, int]:
+        per_token = sum(
+            spec_kv_bytes_per_token(spec, config)
+            for spec in config.model_config.kv_cache_group_specs()
+            if not spec.is_swa
+        )
+        return per_token * config.page_size, 0, config.page_size, 0
+
+    def rebuild_from_config(
+        self, config, num_pages: int, *, num_swa_pages: int | None = None
+    ) -> None:
+        for pool in self._groups:
+            pool.rebuild(num_pages + 1)
+
+    def unit_bytes(self) -> tuple[int, int]:
+        return sum(pool.unit_bytes()[0] for pool in self._groups), 0
+
+    def _pool(self, layer_id: int) -> MHAKVCache:
+        try:
+            return self._layer_to_group[layer_id]
+        except KeyError as exc:
+            raise KeyError(f"layer {layer_id} has no paged KV storage") from exc
+
+    def k_cache(self, index: int) -> torch.Tensor:
+        return self._pool(index).k_cache(index)
+
+    def v_cache(self, index: int) -> torch.Tensor:
+        return self._pool(index).v_cache(index)
+
+    def store_kv(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out_loc: torch.Tensor,
+        layer_id: int,
+    ) -> None:
+        self._pool(layer_id).store_kv(k, v, out_loc, layer_id)
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def num_layers(self) -> int:
+        return self._num_layers

--- a/python/sparklab/runtime/kvcache/linear_state_pool.py
+++ b/python/sparklab/runtime/kvcache/linear_state_pool.py
@@ -54,6 +54,10 @@ class LinearStatePool:
         self._conv_dtype = dtype
         self._aux_states: dict[str, torch.Tensor] = {}
         self._aux_specs: dict[str, tuple[tuple[int, ...], torch.dtype, float]] = {}
+        self._verify_steps = 0
+        self.verify_recurrent_states: torch.Tensor | None = None
+        self.verify_conv_inputs: torch.Tensor | None = None
+        self.verify_state_indices: torch.Tensor | None = None
 
         n_layers, local_conv_dim, local_v_heads = _linear_local_dims(group, tp_size)
 
@@ -79,9 +83,62 @@ class LinearStatePool:
         self.padding_slot = 0
         self._free_slots: list[int] = list(range(1, num_slots))
 
+    def enable_verify_transactions(self, steps: int) -> None:
+        """Allocate one batch-one intermediate-state lane for DFlash2 verification."""
+        steps = int(steps)
+        if steps <= 0 or steps == self._verify_steps:
+            return
+        if self._verify_steps:
+            raise ValueError(
+                f"verify transaction width is already {self._verify_steps}, got {steps}"
+            )
+        n_layers, _, conv_dim, _ = self.conv_states.shape
+        _, _, value_heads, key_dim, value_dim = self.recurrent_states.shape
+        self.verify_recurrent_states = torch.empty(
+            (n_layers, 1, steps, value_heads, key_dim, value_dim),
+            dtype=self.recurrent_states.dtype,
+            device=self._device,
+        )
+        self.verify_conv_inputs = torch.empty(
+            (n_layers, steps, conv_dim),
+            dtype=self._conv_dtype,
+            device=self._device,
+        )
+        self.verify_state_indices = torch.zeros(
+            1, dtype=torch.int32, device=self._device
+        )
+        self._verify_steps = steps
+
+    def commit_verify_prefix(self, snapshot_slot: int, live_slot: int, length: int) -> None:
+        """Commit GDN state after ``length`` verified inputs from cached intermediates."""
+        if (
+            self.verify_recurrent_states is None
+            or self.verify_conv_inputs is None
+            or not 1 <= length <= self._verify_steps
+        ):
+            raise RuntimeError("GDN verify transaction is not initialized for this length")
+        self.recurrent_states[:, live_slot].copy_(
+            self.verify_recurrent_states[:, 0, length - 1]
+        )
+        history = self.conv_states.shape[-1]
+        if length >= history:
+            conv = self.verify_conv_inputs[:, length - history : length].transpose(1, 2)
+            self.conv_states[:, live_slot].copy_(conv)
+        else:
+            self.conv_states[:, live_slot, :, : history - length].copy_(
+                self.conv_states[:, snapshot_slot, :, length:]
+            )
+            self.conv_states[:, live_slot, :, history - length :].copy_(
+                self.verify_conv_inputs[:, :length].transpose(1, 2)
+            )
+
     @property
     def num_free_slots(self) -> int:
         return len(self._free_slots)
+
+    @property
+    def verify_steps(self) -> int:
+        return self._verify_steps
 
     def alloc(self, n: int = 1) -> list[int]:
         """Pop ``n`` free slot ids (LIFO). Raises if the pool is exhausted."""
@@ -232,7 +289,24 @@ def linear_state_bytes_per_req(
     return int(n_layers * (conv_bytes + rec_bytes))
 
 
-__all__ = ["LinearStatePool", "linear_state_bytes_per_req"]
+def verify_transaction_bytes(
+    group: LinearGatedDeltaGroupConfig,
+    tp_size: int,
+    dtype: torch.dtype,
+    steps: int,
+) -> int:
+    """Batch-one DFlash2 per-token recurrent states plus raw convolution inputs."""
+    n_layers, local_conv_dim, local_v_heads = _linear_local_dims(group, tp_size)
+    recurrent = local_v_heads * group.key_head_dim * group.value_head_dim
+    per_step = recurrent * ssm_state_dtype().itemsize + local_conv_dim * dtype.itemsize
+    return int(n_layers * steps * per_step)
+
+
+__all__ = [
+    "LinearStatePool",
+    "linear_state_bytes_per_req",
+    "verify_transaction_bytes",
+]
 
 
 def state_pool_bytes(config, num_slots: int | None = None) -> int:
@@ -255,7 +329,15 @@ def state_pool_bytes(config, num_slots: int | None = None) -> int:
             * state_len
             * config.dtype.itemsize
         )
-    return per_slot * slots
+    total = per_slot * slots
+    if getattr(config, "speculative_method", "none") == "dflash2":
+        total += verify_transaction_bytes(
+            linear_group,
+            config.tp_info.size,
+            config.dtype,
+            int(getattr(config, "speculative_tokens", 0) or 0),
+        )
+    return total
 
 
 def _linear_pool_num_slots(config) -> int:

--- a/python/sparklab/runtime/scheduler/scheduler.py
+++ b/python/sparklab/runtime/scheduler/scheduler.py
@@ -843,7 +843,7 @@ class Scheduler(SchedulerIOMixin):
         # also removes page-boundary-dependent draft widths.
         lookahead = (
             int(getattr(self.config, "speculative_tokens", 0) or 0)
-            if getattr(self.config, "speculative_method", "none") == "mtp"
+            if getattr(self.config, "speculative_method", "none") in {"mtp", "dflash2"}
             else 0
         )
         if lookahead:

--- a/python/sparklab/serving/args.py
+++ b/python/sparklab/serving/args.py
@@ -322,16 +322,24 @@ def parse_args(
 
     parser.add_argument(
         "--speculative-method",
-        choices=("auto", "mtp", "dspark"),
+        choices=("auto", "mtp", "dspark", "dflash2"),
         default=ServerArgs.speculative_method,
         help="Speculative decoder (auto selects the checkpoint-native method).",
     )
     parser.add_argument(
         "--speculative-tokens",
         type=int,
-        choices=range(0, 8),
+        choices=range(0, 17),
         default=ServerArgs.speculative_tokens,
-        help="Draft length (0 disables; Qwen MTP supports 1-3, DSV4 DSpark 1-7).",
+        help=(
+            "Draft block size (0 disables; Qwen MTP supports 1-3, DSV4 DSpark "
+            "1-7, Qwen3.8 DFlash2 2-16)."
+        ),
+    )
+    parser.add_argument(
+        "--speculative-draft-model",
+        default=ServerArgs.speculative_draft_model,
+        help="Local path or Hugging Face id for an external DFlash2 draft checkpoint.",
     )
     parser.add_argument(
         "--draft-sample-method",

--- a/tests/models/test_glm5_next.py
+++ b/tests/models/test_glm5_next.py
@@ -560,7 +560,7 @@ def test_mhc_fused_cuda_path_matches_eager_reference():
 
 def test_mhc_runtime_prepares_mapping_once_in_fp32():
     hc = Glm5NextHyperConnection(8, 4, 1e-6, 20, 1e-5)
-    hc.fn = hc.fn.to(torch.bfloat16)
+    hc.fn = torch.randn_like(hc.fn).to(torch.bfloat16)
     expected = hc.fn.float()
     hc.prepare_for_runtime()
     assert hc.fn.dtype == torch.float32

--- a/tests/models/test_qwen3_5_dflash2.py
+++ b/tests/models/test_qwen3_5_dflash2.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+
+from sparklab.models.qwen3_5_moe.dflash2 import _selector_topk, parse_dflash2_args
+from sparklab.models.qwen3_5_moe.weight import iter_dflash2_weights
+
+
+def _draft_config():
+    return SimpleNamespace(
+        architectures=["DFlash2DraftModel"],
+        hidden_size=5120,
+        intermediate_size=17408,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,
+        num_hidden_layers=5,
+        vocab_size=248320,
+        max_position_embeddings=262144,
+        rms_norm_eps=1e-6,
+        sliding_window=2048,
+        rope_parameters={"rope_theta": 10_000_000},
+        dflash_config={
+            "block_size": 8,
+            "conv_kernel_size": 2,
+            "conv_group_size": 16,
+            "selector_rank": 256,
+            "selector_top_k": 16,
+            "target_layer_ids": [5, 19, 33, 47, 61],
+            "mask_token_id": 248070,
+        },
+    )
+
+
+def test_parse_dflash2_checkpoint_geometry():
+    args = parse_dflash2_args(_draft_config(), "draft")
+    assert args.num_layers == 5
+    assert args.target_layer_ids == (5, 19, 33, 47, 61)
+    assert args.num_key_value_heads == 8
+    assert args.head_dim == 128
+    assert args.selector_top_k == 16
+
+
+def test_dflash2_selector_topk_cpu_fallback():
+    scores = torch.tensor([[1.0, 5.0, 3.0, 4.0]])
+    values, indices = _selector_topk(scores, 2)
+    assert values.tolist() == [[5.0, 4.0]]
+    assert indices.tolist() == [[1, 3]]
+
+
+def test_dflash2_weight_iterator_fuses_native_nvfp4(tmp_path):
+    h, q, kv, intermediate = 16, 8, 4, 12
+    tensors = {
+        "fc.weight": torch.zeros((h, 5 * h), dtype=torch.bfloat16),
+        "layers.0.self_attn.q_proj.weight": torch.full((q, h // 2), 1, dtype=torch.uint8),
+        "layers.0.self_attn.k_proj.weight": torch.full((kv, h // 2), 2, dtype=torch.uint8),
+        "layers.0.self_attn.v_proj.weight": torch.full((kv, h // 2), 3, dtype=torch.uint8),
+        "layers.0.self_attn.q_proj.weight_scale": torch.ones((q, h // 16), dtype=torch.float8_e4m3fn),
+        "layers.0.self_attn.k_proj.weight_scale": torch.ones((kv, h // 16), dtype=torch.float8_e4m3fn),
+        "layers.0.self_attn.v_proj.weight_scale": torch.ones((kv, h // 16), dtype=torch.float8_e4m3fn),
+        "layers.0.self_attn.q_proj.weight_scale_2": torch.tensor(1.0),
+        "layers.0.self_attn.k_proj.weight_scale_2": torch.tensor(2.0),
+        "layers.0.self_attn.v_proj.weight_scale_2": torch.tensor(3.0),
+        "layers.0.mlp.gate_proj.weight": torch.zeros((intermediate, h // 2), dtype=torch.uint8),
+        "layers.0.mlp.up_proj.weight": torch.zeros((intermediate, h // 2), dtype=torch.uint8),
+        "layers.0.mlp.gate_proj.weight_scale": torch.ones((intermediate, h // 16), dtype=torch.float8_e4m3fn),
+        "layers.0.mlp.up_proj.weight_scale": torch.ones((intermediate, h // 16), dtype=torch.float8_e4m3fn),
+        "layers.0.mlp.gate_proj.weight_scale_2": torch.tensor(1.0),
+        "layers.0.mlp.up_proj.weight_scale_2": torch.tensor(1.0),
+    }
+    save_file(tensors, tmp_path / "model.safetensors")
+    loaded = dict(iter_dflash2_weights(str(tmp_path), torch.device("cpu")))
+    qkv = "layers.0.self_attn.qkv_proj"
+    assert loaded[qkv + ".weight"].shape == (q + 2 * kv, h // 2)
+    assert loaded[qkv + ".weight"][:, 0].tolist() == [1] * q + [2] * kv + [3] * kv
+    assert loaded[qkv + ".weight_global"].tolist() == [1.0] * q + [2.0] * kv + [3.0] * kv
+    assert loaded["layers.0.mlp.gate_up_proj.weight"].shape == (
+        2 * intermediate,
+        h // 2,
+    )
+    assert "fc.weight" in loaded
+
+
+def test_engine_injects_dflash2_kv_group(monkeypatch):
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+    from tests.models.test_qwen3_5_dense import _inferact_qwen38_27b_config
+    from sparklab.models.qwen3_5_moe.config import parse_config
+    import sparklab.runtime.engine.engine as engine_module
+
+    monkeypatch.setattr(engine_module, "cached_load_hf_config", lambda _: _draft_config())
+    model_config = parse_config(_inferact_qwen38_27b_config())
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="dflash2",
+        speculative_tokens=16,
+        speculative_draft_model="draft",
+        draft_sample_method="greedy",
+        max_running_req=4,
+        cache_type="naive",
+        cuda_graph_bs=[1, 2],
+        cuda_graph_max_bs=2,
+    )
+    _adjust_speculative_config(config, lambda name, value: setattr(config, name, value))
+    groups = {group.name: group for group in model_config.attention_groups}
+    assert model_config.speculative_method == "dflash2"
+    assert groups["dflash2"].layer_ids == (64, 65, 66, 67, 68)
+    assert groups["dflash2"].num_kv_heads == 8
+    assert groups["dflash2"].head_dim == 128
+    assert config.max_running_req == 1
+    assert config.cache_type == "radix"
+
+
+def test_dflash2_uses_separate_target_and_draft_kv_geometry(monkeypatch):
+    import sparklab.runtime.engine.engine as engine_module
+
+    from sparklab.models.qwen3_5_moe.config import parse_config
+    from sparklab.runtime.distributed import set_tp_info, try_get_tp_info
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+    from sparklab.runtime.kvcache import create_kvcache_pool, resolve_pool_class
+    from sparklab.runtime.kvcache.grouped_mha_pool import GroupedMHAKVCache
+    from tests.models.test_qwen3_5_dense import _inferact_qwen38_27b_config
+    if try_get_tp_info() is None:
+        set_tp_info(rank=0, size=1)
+    monkeypatch.setattr(engine_module, "cached_load_hf_config", lambda _: _draft_config())
+    model_config = parse_config(_inferact_qwen38_27b_config())
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="dflash2",
+        speculative_tokens=8,
+        speculative_draft_model="draft",
+        draft_sample_method="greedy",
+        max_running_req=1,
+        cache_type="radix",
+        cuda_graph_bs=[],
+        cuda_graph_max_bs=0,
+    )
+    _adjust_speculative_config(config, lambda name, value: setattr(config, name, value))
+    assert resolve_pool_class(model_config) is GroupedMHAKVCache
+    pool = create_kvcache_pool(
+        model_config,
+        num_pages=3,
+        page_size=1,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+    target = next(
+        spec
+        for spec in model_config.kv_cache_group_specs()
+        if spec.name != "dflash2" and spec.layer_ids
+    )
+    draft = next(
+        spec for spec in model_config.kv_cache_group_specs() if spec.name == "dflash2"
+    )
+    assert pool.k_cache(target.layer_ids[0]).shape[-2:] == (
+        target.num_kv_heads,
+        target.head_dim,
+    )
+    assert pool.k_cache(draft.layer_ids[0]).shape[-2:] == (8, 128)

--- a/tests/runtime/kvcache/test_linear_state_pool_alloc.py
+++ b/tests/runtime/kvcache/test_linear_state_pool_alloc.py
@@ -64,6 +64,39 @@ def test_copy_from_snapshot():
     assert torch.equal(pool.recurrent_states[:, dst], pool.recurrent_states[:, src])
 
 
+@pytest.mark.parametrize("length", [1, 2, 3, 4])
+def test_commit_verify_prefix(length):
+    pool = _pool(num_slots=6)
+    snapshot, live = pool.alloc(2)
+    pool.enable_verify_transactions(4)
+    pool.conv_states[:, snapshot] = torch.arange(
+        pool.conv_states[:, snapshot].numel(), dtype=torch.bfloat16
+    ).reshape_as(pool.conv_states[:, snapshot])
+    pool.verify_conv_inputs.copy_(
+        torch.arange(pool.verify_conv_inputs.numel(), dtype=torch.bfloat16).reshape_as(
+            pool.verify_conv_inputs
+        )
+        + 1000
+    )
+    pool.verify_recurrent_states.copy_(
+        torch.arange(
+            pool.verify_recurrent_states.numel(), dtype=pool.recurrent_states.dtype
+        ).reshape_as(pool.verify_recurrent_states)
+    )
+
+    old = pool.conv_states[:, snapshot].clone()
+    inputs = pool.verify_conv_inputs.clone()
+    expected_conv = torch.cat((old.transpose(1, 2), inputs), dim=1)[
+        :, length : length + old.shape[-1]
+    ].transpose(1, 2)
+    pool.commit_verify_prefix(snapshot, live, length)
+
+    assert torch.equal(pool.conv_states[:, live], expected_conv)
+    assert torch.equal(
+        pool.recurrent_states[:, live], pool.verify_recurrent_states[:, 0, length - 1]
+    )
+
+
 if __name__ == "__main__":
     test_alloc_free_roundtrip()
     test_alloc_exhaustion_raises()

--- a/tests/runtime/kvcache/test_pool_sizing_surface.py
+++ b/tests/runtime/kvcache/test_pool_sizing_surface.py
@@ -258,6 +258,12 @@ def test_linear_state_pool_prices_itself():
     per_req = linear_state_bytes_per_req(group, config.tp_info.size, config.dtype)
     assert state_pool_bytes(config) == per_req * _linear_pool_num_slots(config)
     assert state_pool_bytes(config, num_slots=7) == per_req * 7
+    config.speculative_method = "dflash2"
+    config.speculative_tokens = 4
+    expected_verify = 2 * 4 * (
+        4 * 16 * 16 * 4 + (2 * 2 * 16 + 4 * 16) * 2
+    )
+    assert state_pool_bytes(config, num_slots=7) == per_req * 7 + expected_verify
     # models without a linear group price to zero
     config.model_config.linear_attention_group = lambda: None
     assert state_pool_bytes(config) == 0

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -54,6 +54,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert get_recipe("kimi-k3").status == "experimental"
     assert {item.slug for item in select_recipes(load_catalog(), tier="fast")} == {
         "qwen3.6-35b-a3b",
+        "qwen3.8-27b",
     }
     qwen = get_recipe("qwen3.8-flash-next")
     assert qwen.recipe_version == "0.8.0"
@@ -149,7 +150,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     primary = select_recipes(load_catalog(), portfolio_role="primary")
     assert {(item.intended_tier, item.slug) for item in primary} == {
         ("fast", "qwen3.6-35b-a3b"),
-        ("frontier", "qwen3.8-27b"),
+        ("fast", "qwen3.8-27b"),
         ("frontier", "deepseek-v4"),
         ("frontier", "glm-5.3-flash"),
         ("frontier", "qwen3.8-flash-next"),
@@ -172,11 +173,15 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert qwen27.revision == "6128240ebaf4eaa7bad2b3d1c72c37d677c5f462"
     assert qwen27.source_bytes == 26404418018
     assert qwen27.prepared_bytes == 24640689529
-    assert qwen27.intended_tier == "frontier"
+    assert qwen27.intended_tier == "fast"
     assert qwen27.performance.decode_tokens_per_second == pytest.approx(8.832997654771269)
     assert qwen27.performance.warm_ttft_seconds == pytest.approx(0.14434478300245246)
     assert qwen27.performance.context_tokens == 65_536
-    assert qwen27.evidence == ("GB10-QWEN38-27B-001",)
+    assert qwen27.evidence == (
+        "GB10-QWEN38-27B-001",
+        "GB10-QWEN38-DFLASH-002",
+        "GB10-QWEN38-DFLASH-003",
+    )
     assert qwen27.deployment.execution_policy == "resident"
     assert qwen27.deployment.backend_options["num_tokens"] == 65_536
     assert qwen27.deployment.backend_options["max_seq_len_override"] == 65_536

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -36,9 +36,9 @@ def test_models_can_select_primary_portfolio(capsys):
     payload = json.loads(capsys.readouterr().out)
     assert [recipe["slug"] for recipe in payload["recipes"]] == [
         "qwen3.6-35b-a3b",
+        "qwen3.8-27b",
         "deepseek-v4",
         "glm-5.3-flash",
-        "qwen3.8-27b",
         "qwen3.8-flash-next",
         "kimi-k3",
     ]


### PR DESCRIPTION
## Summary
- add native Qwen3.8-27B DFlash2 support and optimized proposal/verification paths
- record the 35.48 tok/s, 0.153 s warm-TTFT benchmark evidence
- add Qwen3.8-27B to the Fast portfolio as Experimental pending full certification

## Validation
- `SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 .venv/bin/pytest -q --ignore=tests/test_document_query_demo.py`
- 1692 passed, 8 skipped