### PR TITLE
docs: format profile metrics on separate lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ a SparkLab support claim.
       <td>27B dense</td>
       <td>NVFP4 · FTW + optional DFlash2-8</td>
       <td>Experimental</td>
-      <td align="right">8.83 target / 35.48 DFlash2-8</td>
-      <td align="right">0.144 target / 0.153 DFlash2-8</td>
+      <td align="right">8.83 target<br>35.48 DFlash2-8</td>
+      <td align="right">0.144 target<br>0.153 DFlash2-8</td>
       <td><a href="docs/models/qwen3.8-27b.md">Instructions</a></td>
     </tr>
     <tr>
@@ -132,8 +132,8 @@ a SparkLab support claim.
       <td>320B total / 18B active</td>
       <td>NVFP4 + KDA FP8 · FTW + optional MTP3</td>
       <td>Experimental</td>
-      <td align="right">6.27 target / 7.44 MTP3</td>
-      <td align="right">5.681 target / 6.330 MTP3</td>
+      <td align="right">6.27 target<br>7.44 MTP3</td>
+      <td align="right">5.681 target<br>6.330 MTP3</td>
       <td><a href="docs/models/glm-5.3-flash.md">Instructions</a></td>
     </tr>
     <tr>

--- a/docs/models.md
+++ b/docs/models.md
@@ -32,11 +32,11 @@ coding-agent task, and versioned benchmark evidence. Status means:
 |---|---|---|---|---|---:|---:|
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
-| [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW + optional DFlash2-8 | `qwen3.8-27b` | Experimental | 8.83 target / 35.48 DFlash2-8 | 0.144 target / 0.153 DFlash2-8 |
+| [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW + optional DFlash2-8 | `qwen3.8-27b` | Experimental | 8.83 target<br>35.48 DFlash2-8 | 0.144 target<br>0.153 DFlash2-8 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 30.67 | 0.258 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 13.15 | 0.518 |
-| [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 6.27 target / 7.44 MTP3 | 5.681 target / 6.330 MTP3 |
+| [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 6.27 target<br>7.44 MTP3 | 5.681 target<br>6.330 MTP3 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
 | [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |


### PR DESCRIPTION
## Summary
- render target and accelerated-profile throughput on separate lines
- render corresponding TTFT values on separate lines
- apply the format consistently to Qwen3.8-27B and GLM-5.3 Flash

## Validation
- `git diff --check`