### PR TITLE
docs: show selected portfolio profile metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ a SparkLab support claim.
       <td>27B dense</td>
       <td>NVFP4 · FTW + optional DFlash2-8</td>
       <td>Experimental</td>
-      <td align="right">8.83 target<br>35.48 DFlash2-8</td>
-      <td align="right">0.144 target<br>0.153 DFlash2-8</td>
+      <td align="right">35.48</td>
+      <td align="right">0.153</td>
       <td><a href="docs/models/qwen3.8-27b.md">Instructions</a></td>
     </tr>
     <tr>
@@ -132,8 +132,8 @@ a SparkLab support claim.
       <td>320B total / 18B active</td>
       <td>NVFP4 + KDA FP8 · FTW + optional MTP3</td>
       <td>Experimental</td>
-      <td align="right">6.27 target<br>7.44 MTP3</td>
-      <td align="right">5.681 target<br>6.330 MTP3</td>
+      <td align="right">7.44</td>
+      <td align="right">6.330</td>
       <td><a href="docs/models/glm-5.3-flash.md">Instructions</a></td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary
- show only the selected DFlash2 profile metrics for Qwen3.8-27B on the main page
- show only the selected MTP3 profile metrics for GLM-5.3 Flash on the main page
- keep target/profile comparisons in detailed documentation

## Validation
- `git diff --check`