### PR TITLE
release: prepare 0.1.2

### DIFF
--- a/python/sparklab/version.py
+++ b/python/sparklab/version.py
@@ -1,5 +1,5 @@
 """SparkLab product version, independent of any runtime backend version."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- bump the SparkLab package version to 0.1.2
- prepare a performance release covering the current MTP and speculative-decoding improvements

## Validation
- `SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 .venv/bin/pytest -q --ignore=tests/test_document_query_demo.py`
- 1692 passed, 8 skipped
- package version assertion passed