### PR TITLE
docs: add Qwen3.8 vLLM performance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ a SparkLab support claim.
       <td>125B LM + 55B auxiliary / 6B active</td>
       <td>NVFP4 · FTW + MTP3</td>
       <td>Experimental</td>
-      <td align="right">30.67</td>
-      <td align="right">0.258</td>
+      <td align="right">30.67 single<br>90.52 C8 vLLM</td>
+      <td align="right">0.258 warm<br>1.699 p95 C8</td>
       <td><a href="docs/models/qwen3.8-flash-next.md">Instructions</a></td>
     </tr>
     <tr>
@@ -167,6 +167,10 @@ Status meanings:
 - **Preview:** a bounded supported path exists, but the full release promise is incomplete.
 - **Certified:** the exact recipe, revision, artifact, and release environment passed all
   required correctness, parser, agent, context, latency, memory, NVMe, and endurance gates.
+
+Qwen3.8-Flash-Next's 90.52 tok/s entry is a separately measured concurrency-eight
+vLLM reference profile; 30.67 tok/s remains SparkLab's comparable single-stream result.
+The [model notes](docs/models/qwen3.8-flash-next.md) link both evidence records.
 
 Run `sparklab models --json` for exact recipe versions, checkpoint revisions, artifact
 fingerprints, implementation state, evidence IDs, and known constraints.

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -59,6 +59,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
   three-draft profile measured 30.67 decode tok/s and 0.258 s warm TTFT, a 55.35%
   improvement over its controlled target-only run; all three selected-profile trials
   reproduced the same 128-token output hash.
+- `results/GB10-QWEN38-VLLM-008.json` records a separate vLLM QSA optimization on the
+  Mia-AiLab NVFP4 checkpoint. Scale-hoisted FP8 KV dequantization and an 8-sequence
+  scheduler raised concurrency-eight aggregate decode from 60.16 to 90.52 tok/s and
+  reduced p95 TTFT from 13.874 to 1.699 seconds.
 - `results/GB10-GLM53-NVFP4-001.json` records the GLM-5.3 Flash NVFP4
   complete-checkpoint probe: 4.46 decode tok/s and 5.760 s warm TTFT. Its corrected
   greedy probe reaches the reference answer; the broader quality gates remain outstanding.

--- a/benchmarks/gb10/results/GB10-QWEN38-VLLM-008.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-VLLM-008.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-VLLM-008",
+  "status": "measured",
+  "date": "2026-09-04",
+  "engine": {
+    "name": "vLLM Qwen3.8 Flash Next DGX Spark image",
+    "version": "0.1.dev20073+g8e685d198",
+    "implementation_repository": "MiaAI-Lab/Qwen3.8-Flash-Next-Single-DGX-Spark",
+    "baseline_revision": "5af8abd",
+    "optimized_revision": "5218435",
+    "pull_request": "https://github.com/MiaAI-Lab/Qwen3.8-Flash-Next-Single-DGX-Spark/pull/2"
+  },
+  "hardware": {
+    "platform": "NVIDIA DGX Spark",
+    "device": "NVIDIA GB10",
+    "compute_capability": "12.1",
+    "unified_memory_gib": 121.69
+  },
+  "checkpoint": {
+    "repository": "Mia-AiLab/Qwen3.8-Flash-Next-NVFP4",
+    "revision": "925d7be6c14c6c9442ef83e8f05b5a3c39304f69",
+    "format": "safetensors-nvfp4",
+    "complete_checkpoint_loaded": true
+  },
+  "workload": {
+    "client_path": "OpenAI-compatible streaming HTTP API",
+    "thinking": false,
+    "completion_tokens_per_request": 192,
+    "requests_at_concurrency_eight": 16,
+    "prefix_cache_hits": "prevented with salted prompts",
+    "prefill_prompt_tokens": 32781
+  },
+  "configuration": {
+    "attention_backend": "qsa",
+    "kv_cache_dtype": "fp8",
+    "speculative_tokens": 3,
+    "baseline_max_num_batched_tokens": 2048,
+    "baseline_max_num_seqs": 4,
+    "optimized_max_num_batched_tokens": 8192,
+    "optimized_max_num_seqs": 8
+  },
+  "metrics": {
+    "baseline": {
+      "prefill_tokens_per_second": 1827.0077634468157,
+      "concurrency_one_aggregate_tokens_per_second": 24.064385748536793,
+      "concurrency_four_aggregate_tokens_per_second": 56.44462876321519,
+      "concurrency_eight_aggregate_tokens_per_second": 60.16381135345002,
+      "concurrency_eight_ttft_p95_seconds": 13.874419236009999,
+      "concurrency_eight_e2e_p95_seconds": 26.083667622500798,
+      "kv_cache_tokens": 1323445
+    },
+    "optimized": {
+      "prefill_tokens_per_second": 2166.7669454354455,
+      "concurrency_one_aggregate_tokens_per_second": 24.29474845759242,
+      "concurrency_four_aggregate_tokens_per_second": 57.42096288757168,
+      "concurrency_eight_aggregate_tokens_per_second": 90.52231643376244,
+      "concurrency_eight_ttft_p95_seconds": 1.699271208504797,
+      "concurrency_eight_e2e_p95_seconds": 18.252524474264646,
+      "kv_cache_tokens": 1249637
+    },
+    "change_percent": {
+      "prefill_throughput": 18.5987,
+      "concurrency_eight_aggregate_throughput": 50.4565,
+      "concurrency_eight_ttft_p95": -87.7525,
+      "concurrency_eight_e2e_p95": -30.0232,
+      "kv_cache_tokens": -5.5769
+    }
+  },
+  "kernel_microbenchmark": {
+    "shape": "512 query rows, top-k 2048",
+    "baseline_sparse_qsa_milliseconds": 2.984,
+    "optimized_sparse_qsa_milliseconds": 1.772,
+    "latency_change_percent": -40.6166,
+    "baseline_selector_milliseconds": 0.1392,
+    "optimized_selector_milliseconds": 0.1008,
+    "selector_latency_change_percent": -27.5862
+  },
+  "validation": {
+    "bf16_path_bit_identical": true,
+    "maximum_sparse_attention_absolute_difference": 0.0000152587890625,
+    "maximum_difference_interpretation": "one BF16 ULP",
+    "checkpoint_index_completeness_checked": true,
+    "oom_count": 0
+  },
+  "source": {
+    "summary": "Matched baseline and optimized GB10 sweep using the committed benchmark harness.",
+    "raw_artifact": "$HOME/results/qwen38-vllm-opt-20260904",
+    "implementation": "https://github.com/lidaiqing/Qwen3.8-Flash-Next-Single-DGX-Spark/commit/5218435"
+  },
+  "limitations": [
+    "This result uses a separate vLLM engine and checkpoint package and is not directly comparable to SparkLab's single-stream MTP3 result.",
+    "The end-to-end values are one-run workload measurements; generated content changes MTP acceptance and decode speed.",
+    "Repeated identical requests did not reproduce exact text hashes on the unchanged baseline server, so tensor-level numerical comparison is reported instead.",
+    "The one-ULP tensor comparison does not replace a long-reasoning quality evaluation."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -34,7 +34,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW + optional DFlash2-8 | `qwen3.8-27b` | Experimental | 8.83 target<br>35.48 DFlash2-8 | 0.144 target<br>0.153 DFlash2-8 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
-| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 30.67 | 0.258 |
+| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 30.67 single<br>90.52 C8 vLLM | 0.258 warm<br>1.699 p95 C8 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 13.15 | 0.518 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 6.27 target<br>7.44 MTP3 | 5.681 target<br>6.330 MTP3 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
@@ -44,8 +44,13 @@ coding-agent task, and versioned benchmark evidence. Status means:
 Model links point to the selected source or published FTW checkpoint. Qwen3.6, GLM-5.3,
 and Kimi K3 use pinned prebuilt artifacts with reproducible source-conversion paths.
 Parameter counts come from model publishers, and performance values come from the
-evidence attached to each recipe. Certification applies only to that exact checkpoint
-and recipe version.
+evidence attached to each recipe unless the profile is explicitly labeled as an external
+reference. Certification applies only to that exact checkpoint and recipe version.
+
+Qwen3.8-Flash-Next keeps its 30.67 tok/s SparkLab single-stream MTP3 result as the
+comparable recipe metric. A separately measured vLLM profile reached 90.52 aggregate
+tok/s at concurrency eight and 1.699 s p95 TTFT; the engine, checkpoint packaging,
+scheduler, and workload differ, so that number is labeled rather than substituted.
 
 Qwen3.6's published FTW artifact includes its native BF16 MTP weights, but the portfolio
 row continues to report the certified target-only profile. The optimized two-draft path
@@ -63,7 +68,7 @@ output parity. It remains optimization evidence rather than certification.
 |---|---|---|
 | Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Optimized native MTP2 reached 74.42 tok/s versus its 45.38 tok/s eager control; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json) |
 | Qwen3.8-27B | The opt-in DFlash2-8 profile reached 35.48 tok/s with exact target-output parity and clears the Fast performance thresholds; full Fast certification remains pending. | [target-only](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json), [DFlash2](../benchmarks/gb10/results/GB10-QWEN38-DFLASH-003.json) |
-| Qwen3.8-Flash-Next | The selected MTP3 profile measured a three-trial median 30.67 tok/s at 0.258 s warm TTFT. The clean-revision endurance gate remains outstanding. | [GB10-QWEN38-MTP-007](../benchmarks/gb10/results/GB10-QWEN38-MTP-007.json) |
+| Qwen3.8-Flash-Next | The selected SparkLab MTP3 profile measured a three-trial median 30.67 tok/s at 0.258 s warm TTFT. The optimized external vLLM QSA profile measured 90.52 aggregate tok/s and 1.699 s p95 TTFT at concurrency eight, up 50.5% and down 87.8% respectively versus its matched baseline. | [SparkLab MTP3](../benchmarks/gb10/results/GB10-QWEN38-MTP-007.json), [vLLM QSA C8](../benchmarks/gb10/results/GB10-QWEN38-VLLM-008.json) |
 | DeepSeek V4 Flash | The selected three-trial DSpark5 burst profile reaches 13.15 tok/s. Target-only remains the default and wins the 256-token sustained control, 10.52 versus 9.31 tok/s. | [GB10-DSV4-SMALLM-005](../benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json) |
 | GLM-5.3 Flash | Target-only reaches 6.27 tok/s. The opt-in optimized MTP3 path averaged 7.436 tok/s with 87.9% acceptance and exact target-only output parity; NVMe sensitivity and the remaining certification gates keep it Experimental. | [target-only](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json), [MTP sweep](../benchmarks/gb10/results/GB10-GLM53-MTP-004.json), [optimized MTP3](../benchmarks/gb10/results/GB10-GLM53-OPT-005.json) |
 | GLM-5.2 | Below Frontier speed and recorded swap growth, so it remains Experimental. | [Experiment](../exps/exp_glm5_2_gb10.md) |

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -55,6 +55,15 @@ contexts; no command-line switch is required. The recipe admits up to four concu
 requests. On the measured GB10, aggregate decode throughput was 16.94, 36.78, and 61.79
 tok/s at concurrency 1, 2, and 4 respectively.
 
+For a separate vLLM deployment of the Mia-AiLab NVFP4 checkpoint, a QSA scale-hoist
+and scheduler optimization measured 90.52 aggregate tok/s at concurrency eight, with
+1.699 s p95 TTFT. Its matched baseline measured 60.16 tok/s and 13.874 s p95 TTFT.
+Because the engine, checkpoint packaging, scheduler, and concurrent workload differ,
+this is a portfolio reference rather than a replacement for SparkLab's 30.67 tok/s
+single-stream MTP3 result. See
+[`GB10-QWEN38-VLLM-008`](../../benchmarks/gb10/results/GB10-QWEN38-VLLM-008.json)
+and the [upstream implementation PR](https://github.com/MiaAI-Lab/Qwen3.8-Flash-Next-Single-DGX-Spark/pull/2).
+
 The default hybrid radix cache also snapshots the complete recurrent state: GDN state,
 PLE convolution history, paged QSA K/V, and pooled index keys. In a controlled repeated
 96-token prompt, it reused 64 tokens and lowered warm TTFT from 404 ms to 306 ms without


### PR DESCRIPTION
## Summary

- add the measured 90.52 tok/s concurrency-eight vLLM profile to the Qwen3.8 Flash Next portfolio entry
- preserve and label the existing 30.67 tok/s SparkLab single-stream metric so unlike workloads are not conflated
- add a versioned GB10 evidence record with exact checkpoint, engine, workload, baseline, optimized metrics, and limitations
- link the upstream implementation PR

## Measured improvement

| Metric | Baseline | Optimized | Change |
|---|---:|---:|---:|
| C8 aggregate decode | 60.16 tok/s | 90.52 tok/s | +50.5% |
| C8 TTFT p95 | 13.874 s | 1.699 s | -87.8% |
| 32K prefill | 1,827.0 tok/s | 2,166.8 tok/s | +18.6% |

## Validation

- 22 catalog and CLI tests passed
- evidence JSON parsed successfully
- whitespace validation passed