### PR TITLE
perf(qwen36): eliminate MTP rejection replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ a SparkLab support claim.
       <td>35B total / 3B active</td>
       <td>NVFP4 · FTW + optional MTP2</td>
       <td>Certified</td>
-      <td align="right">74.42</td>
-      <td align="right">0.368</td>
+      <td align="right">80.55</td>
+      <td align="right">0.367</td>
       <td><a href="docs/models/qwen3.6-35b-a3b.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -35,6 +35,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
 - `results/GB10-QWEN36-MTP-004.json` records the optimized native MTP path. Width two
   reached 74.42 tok/s versus its matched 45.38 tok/s eager control on the 256-token
   Triton-attention probe, a 64.0% gain and 10.60x the prior width-two implementation.
+- `results/GB10-QWEN36-MTP-005.json` records replay-free Qwen3.6 MTP2: a three-trial
+  median of 80.55 tok/s and 0.367 s warm TTFT, with exact output-hash parity against
+  the fresh eager target-only control on the measured prompt. Broader MTP
+  certification remains outstanding.
 - `results/GB10-QWEN38-27B-001.json` records the dense Qwen3.8-27B ModelOpt
   NVFP4 result: 8.83 decode tok/s, 0.144 s warm TTFT, exact 64K recall, and
   passing reasoning, tool-call, and coding-agent probes.

--- a/benchmarks/gb10/results/GB10-QWEN36-MTP-005.json
+++ b/benchmarks/gb10/results/GB10-QWEN36-MTP-005.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN36-MTP-005",
+  "status": "measured",
+  "date": "2026-09-04",
+  "recipe": {
+    "slug": "qwen3.6-35b-a3b",
+    "recipe_version_at_run": "0.4.0",
+    "published_recipe_version": "0.5.0",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "git_revision": "22b3981ce022fc8a5ad0ddb32b4d3b1ac76ec432",
+    "git_tracked_dirty": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "os": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+    "unified_memory_gib": 128,
+    "python": "3.11.15",
+    "packages": {
+      "torch": "2.11.0+cu130",
+      "triton": "3.6.0",
+      "flashinfer-python": "0.6.15.post1",
+      "sglang-kernel": "0.4.5",
+      "transformers": "5.16.1"
+    },
+    "gpu_driver": "NVIDIA GB10, 580.126.09"
+  },
+  "checkpoint": {
+    "path": "$HOME/.sparklab/models/qwen3.6-35b-a3b/prepared/0.3.0-mtp",
+    "format": "ftw",
+    "bytes": 22580867072,
+    "fingerprint": "bda7268c3e0afd7b",
+    "quant_format": "nvfp4",
+    "source_model_path": "nvidia/Qwen3.6-35B-A3B-NVFP4@491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+    "external_artifacts": []
+  },
+  "workload": {
+    "name": "AIME25 problem 0",
+    "prompt_tokens": 54,
+    "completion_tokens": 256,
+    "sampling": "greedy",
+    "batch_size": 1,
+    "selected_trials": 3,
+    "old_mtp_control_trials": 1,
+    "target_only_control_trials": 1,
+    "warmup_requests_per_process": 1,
+    "client_path": "OpenAI-compatible streaming HTTP API"
+  },
+  "configuration": {
+    "storage": "ram",
+    "attention_backend": "triton",
+    "qsa_fused_selection": true,
+    "page_size": 1,
+    "cache_type": "radix",
+    "max_seq_len": 8448,
+    "nvfp4_backend": "triton",
+    "host_cache_gb": 0,
+    "requested_cache_size": 0,
+    "requested_cache_rate": 1,
+    "memory_ratio": 0.9,
+    "requested_num_tokens": 4096,
+    "speculative_method": "mtp",
+    "speculative_tokens": 2,
+    "speculative_draft_model": null,
+    "draft_sample_method": "greedy",
+    "dspark_confidence_threshold": 0,
+    "dspark_draft_cache_slots": 0,
+    "dspark_draft_cache_quotas": "",
+    "dsv4_kv_storage": "bf16",
+    "dsv4_index_storage": "bf16",
+    "qwen4_dense_storage": "bf16",
+    "cpu_threads": 0,
+    "hybrid_fetch": -1,
+    "disk_read_workers": 16,
+    "cache_policy": "lru",
+    "prefill_overlap": true,
+    "preload_all": false,
+    "prefill_hit_d2d": false,
+    "prefill_sparse_max_tokens": 0,
+    "shared_expert_overlap": false,
+    "startup_prefill_warmup": true,
+    "cuda_graph": false,
+    "request_timeout_s": 1800,
+    "prompt_padding_repeats": 0
+  },
+  "metrics": {
+    "decode_tokens_per_second_trials": [
+      81.36023840724415,
+      79.45766483095389,
+      80.54783159065867
+    ],
+    "decode_tokens_per_second_median": 80.54783159065867,
+    "warm_ttft_seconds_trials": [
+      0.3647906919941306,
+      0.3671433530107606,
+      0.371177394001279
+    ],
+    "warm_ttft_seconds_median": 0.3671433530107606,
+    "old_mtp_decode_tokens_per_second": 75.4328609566243,
+    "target_only_decode_tokens_per_second": 45.89344968573072,
+    "improvement_over_old_mtp_percent": 6.7808254508278765,
+    "improvement_over_eager_target_percent": 75.51051869544413,
+    "old_mtp_vram_gib": 21.75390625,
+    "selected_vram_gib": 21.9296875,
+    "selected_output_sha1": "dc94b09666a6",
+    "old_mtp_output_sha1": "ec3dcb059017",
+    "target_only_output_sha1": "dc94b09666a6"
+  },
+  "speculative": {
+    "selected": {
+      "steps": 2,
+      "accepted": 150,
+      "drafted": 174,
+      "acceptance_rate": 0.862,
+      "outputs": 256,
+      "target_forwards": 106,
+      "outputs_per_target_forward": 2.42,
+      "replay_calls": 0,
+      "replay_tokens": 0,
+      "fast_carry_commits": 0
+    },
+    "old": {
+      "steps": 2,
+      "accepted": 153,
+      "drafted": 173,
+      "acceptance_rate": 0.884,
+      "outputs": 256,
+      "target_forwards": 103,
+      "outputs_per_target_forward": 2.49,
+      "replay_calls": 15,
+      "replay_tokens": 25,
+      "fast_carry_commits": 0
+    }
+  },
+  "validation": {
+    "all_selected_trials_match_fresh_target_output_hash": true,
+    "all_selected_trials_complete": true,
+    "zero_selected_rejection_replays": true,
+    "selected_telemetry": [
+      {
+        "swap_growth_bytes": 0,
+        "swap_in_pages_delta": 0,
+        "swap_out_pages_delta": 0,
+        "oom_kill_delta": 0
+      },
+      {
+        "swap_growth_bytes": 0,
+        "swap_in_pages_delta": 0,
+        "swap_out_pages_delta": 0,
+        "oom_kill_delta": 0
+      },
+      {
+        "swap_growth_bytes": 0,
+        "swap_in_pages_delta": 0,
+        "swap_out_pages_delta": 0,
+        "oom_kill_delta": 0
+      }
+    ]
+  },
+  "source": {
+    "selected_trial_artifact": "/tmp/fast-mtp-transaction.jsonl",
+    "old_mtp_control_artifact": "/tmp/fast-mtp-baseline.jsonl",
+    "target_control_artifact": "/tmp/fast-mtp-target.jsonl",
+    "prior_evidence": "GB10-QWEN36-MTP-004"
+  },
+  "limitations": [
+    "Focused source-tree optimization evidence, not a clean-release certification result.",
+    "One greedy 54-token prompt and 256-token completion; long-context, sampled, concurrent, capability and endurance suites were not repeated.",
+    "The previous MTP path produces a different continuation. The improvement comparison uses the same prompt and output length, not identical old/new generated tokens.",
+    "The target-only control is eager; this does not measure improvement over the graph-enabled certified target-only recipe.",
+    "The installed kernel-cache wheel does not match the source release; SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 was used for these experiments.",
+    "The two Qwen3.8-27B DFlash kernel experiments yielded less than 1% end-to-end change and were reverted."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -50,8 +50,9 @@ single-stream profile; concurrent-serving results remain in model-specific evide
 
 Qwen3.6's published FTW artifact includes its native BF16 MTP weights, but the portfolio
 row continues to report the certified target-only profile. The optimized two-draft path
-measured 74.42 tok/s on a matched 256-token GB10 probe versus 45.38 tok/s target-only;
-it remains opt-in pending the full certification suite.
+measured 80.55 tok/s with 0.367 s warm TTFT on a 256-token GB10 probe and matched the
+fresh eager target-only output on that prompt; it remains opt-in pending the full
+certification suite.
 
 GLM-5.3 Flash similarly keeps its 6.27 tok/s, 5.681 s target-only result visible while
 also reporting the opt-in MTP3 probe. The optimized MTP3 path averaged 7.436 tok/s and
@@ -67,7 +68,7 @@ number because MTP is intentionally batch-one.
 
 | Model | Current result | Evidence |
 |---|---|---|
-| Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Optimized native MTP2 reached 74.42 tok/s versus its 45.38 tok/s eager control; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json) |
+| Qwen3.6-35B-A3B | Fast-certified target-only profile, including exact 32K recall and a 60-minute zero-swap run. Replay-free native MTP2 reached 80.55 tok/s and matched the eager target-only output on the focused prompt; it remains opt-in pending full certification. | [GB10-QWEN36-FAST-002](../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json), [original MTP sweep](../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json), [optimized MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json), [replay-free MTP](../benchmarks/gb10/results/GB10-QWEN36-MTP-005.json) |
 | Qwen3.8-27B | The opt-in DFlash2-8 profile reached 35.48 tok/s with exact target-output parity and clears the Fast performance thresholds; full Fast certification remains pending. | [target-only](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json), [DFlash2](../benchmarks/gb10/results/GB10-QWEN38-DFLASH-003.json) |
 | Qwen3.8-Flash-Next | The selected MTP3 profile measured 30.67 tok/s at 0.258 s warm TTFT. Separately, native batch-eight target-only serving reached 85.72 aggregate tok/s and 0.867 s p95 TTFT at C8. | [MTP3](../benchmarks/gb10/results/GB10-QWEN38-MTP-007.json), [batch eight](../benchmarks/gb10/results/GB10-QWEN38-CONC-009.json) |
 | DeepSeek V4 Flash | The selected three-trial DSpark5 burst profile reaches 13.15 tok/s. Target-only remains the default and wins the 256-token sustained control, 10.52 versus 9.31 tok/s. | [GB10-DSV4-SMALLM-005](../benchmarks/gb10/results/GB10-DSV4-SMALLM-005.json) |

--- a/docs/models/qwen3.6-35b-a3b.md
+++ b/docs/models/qwen3.6-35b-a3b.md
@@ -1,7 +1,8 @@
 # Run Qwen3.6-35B-A3B
 
 Qwen3.6-35B-A3B is SparkLab's Fast-tier NVFP4 recipe. It uses a pinned, prebuilt FTW
-artifact and runs resident on one NVIDIA DGX Spark. Recipe 0.4.0 is Fast-certified on
+artifact and runs resident on one NVIDIA DGX Spark. Recipe 0.5.0 retains the Fast
+certification established by its target-only profile on
 one NVIDIA GB10: 67.79 decode tok/s, 0.329 s warm TTFT, exact 32K recall, and a stable
 60-minute zero-swap run. See the
 [versioned evidence](../../benchmarks/gb10/results/GB10-QWEN36-FAST-002.json).
@@ -70,6 +71,15 @@ numerical path selected a different close greedy continuation than single-token 
 decode. The complete context, quality, agent, and endurance certification suite has not
 been rerun. See [the original sweep](../../benchmarks/gb10/results/GB10-QWEN36-MTP-003.json)
 and [the optimized result](../../benchmarks/gb10/results/GB10-QWEN36-MTP-004.json).
+
+The latest source-tree optimization saves the GDN state at each verified token and
+commits the accepted prefix directly, eliminating rejection replay. Three 256-token
+trials measured a median **80.55 tok/s** and **0.367 s warm TTFT**, versus a fresh
+75.43 tok/s MTP2 control. All three matched the fresh eager target-only output hash
+on this prompt; the old MTP control selected a different continuation. Reported
+server memory increased from 21.75 to 21.93 GiB. This focused result does not extend
+the target-only certification to MTP or establish general output parity. See
+[the replay-free evidence](../../benchmarks/gb10/results/GB10-QWEN36-MTP-005.json).
 
 MTP currently applies to one running greedy request. Sampled requests fall back to target
 decoding, and target verification runs eagerly.

--- a/python/sparklab/models/qwen3_5_moe/gdn.py
+++ b/python/sparklab/models/qwen3_5_moe/gdn.py
@@ -208,7 +208,7 @@ class Qwen3_5GatedDeltaNet(BaseOP):
                     or pool.verify_state_indices is None
                     or total > pool.verify_steps
                 ):
-                    raise RuntimeError("DFlash2 GDN verify buffers are not initialized")
+                    raise RuntimeError("GDN verify transaction buffers are not initialized")
                 pool.verify_conv_inputs[li, :total].copy_(conv_in)
                 intermediate = pool.verify_recurrent_states[li]
                 intermediate_indices = pool.verify_state_indices

--- a/python/sparklab/recipes/qwen3.6-35b-a3b.json
+++ b/python/sparklab/recipes/qwen3.6-35b-a3b.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.4.0",
+  "recipe_version": "0.5.0",
   "slug": "qwen3.6-35b-a3b",
   "name": "Qwen3.6 35B A3B",
   "model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
@@ -43,17 +43,18 @@
     "decode_tokens_per_second": 67.7870954092827,
     "warm_ttft_seconds": 0.32882933877408504,
     "evidence": "GB10-QWEN36-FAST-002",
-    "note": "The target-only profile passed the Fast gate with exact 32K recall, complete capability probes, bounded resident memory, and a zero-swap 60-minute endurance run. The artifact also includes an opt-in native BF16 MTP shard; the optimized width-two GB10 profile measured 74.42 tok/s on a 256-token probe, but has not repeated the full certification suite."
+    "note": "The target-only profile passed the Fast gate with exact 32K recall, complete capability probes, bounded resident memory, and a zero-swap 60-minute endurance run. The artifact also includes an opt-in native BF16 MTP shard; the replay-free width-two GB10 profile measured 80.55 tok/s with 0.367 s warm TTFT on a 256-token probe, but has not repeated the full certification suite."
   },
   "evidence": [
     "GB10-QWEN36-FAST-001",
     "GB10-QWEN36-FAST-002",
     "GB10-QWEN36-MTP-003",
-    "GB10-QWEN36-MTP-004"
+    "GB10-QWEN36-MTP-004",
+    "GB10-QWEN36-MTP-005"
   ],
   "limitations": [
     "The fixed five-problem AIME sample scored 0/5 because all five sampled runs exhausted the 2,048-token reasoning budget before emitting a final answer; Fast certification establishes serving correctness and operational behavior, not benchmark-quality certification.",
     "Certification covers text inference at batch one on one NVIDIA GB10.",
-    "Native MTP remains opt-in: optimized width two measured 74.42 tok/s versus its 45.38 tok/s eager control, but its multi-token numerical path did not reproduce the single-token greedy output hash and the full certification suite has not been rerun."
+    "Native MTP remains opt-in: replay-free width two measured 80.55 tok/s and reproduced the fresh eager target-only output hash on the focused prompt, but the full certification suite has not been rerun."
   ]
 }

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -33,7 +33,10 @@ from sparklab.runtime.kvcache import create_kv_pool, resolve_pool_class
 from sparklab.runtime.kvcache.base import CacheRebuildRejected
 from sparklab.runtime.kvcache.cache_status import _supports_swa_ratio
 from sparklab.runtime.kvcache.linear_state_pool import (
-    _linear_pool_min_slots, _linear_pool_num_slots, state_pool_bytes,
+    _linear_pool_min_slots,
+    _linear_pool_num_slots,
+    state_pool_bytes,
+    verify_transaction_steps,
 )
 
 logger = init_logger(__name__)
@@ -710,9 +713,10 @@ class Engine:
                 tp_size=config.tp_info.size,
             )
             self.ctx.linear_state_pool = self.linear_state_pool
-            if config.speculative_method == "dflash2":
+            transaction_steps = verify_transaction_steps(config)
+            if transaction_steps:
                 self.linear_state_pool.enable_verify_transactions(
-                    config.speculative_tokens
+                    transaction_steps
                 )
         else:
             self.linear_state_pool = None
@@ -1408,7 +1412,7 @@ class Engine:
                         scratch = pool.num_slots - 1
                     pool.copy_from(live, scratch)
                     state_snapshots.append((live, scratch))
-                if self.config.speculative_method == "dflash2":
+                if getattr(pool, "verify_steps", 0):
                     batch.cache_verify_states = True
         with self.ctx.forward_batch(batch):
             if (
@@ -1440,7 +1444,7 @@ class Engine:
             )
             self.mtp_stats["drafted"] += int(drafts.numel())
             self.mtp_stats["accepted"] += accepted
-            if self.config.speculative_method == "dflash2":
+            if batch.cache_verify_states:
                 live, scratch = state_snapshots[0]
                 self.linear_state_pool.commit_verify_prefix(
                     scratch, live, accepted + 1
@@ -1452,10 +1456,13 @@ class Engine:
                         self.mtp_stats["fast_carry_commits"] += 1
                     else:
                         self.kv_cache.restore_speculative(kv_snapshot)
-                elif self.config.speculative_method != "dflash2":
+                elif not batch.cache_verify_states:
                     live, scratch = state_snapshots[0]
                     self.linear_state_pool.copy_from(scratch, live)
-                if self.config.speculative_method not in {"dspark", "dflash2"} or (
+                if (
+                    self.config.speculative_method != "dspark"
+                    and not batch.cache_verify_states
+                ) or (
                     self.config.speculative_method == "dspark" and accepted > 0
                 ):
                     self._replay_verified_prefix(batch, accepted + 1, start)

--- a/python/sparklab/runtime/kvcache/linear_state_pool.py
+++ b/python/sparklab/runtime/kvcache/linear_state_pool.py
@@ -84,7 +84,7 @@ class LinearStatePool:
         self._free_slots: list[int] = list(range(1, num_slots))
 
     def enable_verify_transactions(self, steps: int) -> None:
-        """Allocate one batch-one intermediate-state lane for DFlash2 verification."""
+        """Allocate one batch-one intermediate-state lane for GDN verification."""
         steps = int(steps)
         if steps <= 0 or steps == self._verify_steps:
             return
@@ -295,7 +295,7 @@ def verify_transaction_bytes(
     dtype: torch.dtype,
     steps: int,
 ) -> int:
-    """Batch-one DFlash2 per-token recurrent states plus raw convolution inputs."""
+    """Batch-one per-token recurrent states plus raw convolution inputs."""
     n_layers, local_conv_dim, local_v_heads = _linear_local_dims(group, tp_size)
     recurrent = local_v_heads * group.key_head_dim * group.value_head_dim
     per_step = recurrent * ssm_state_dtype().itemsize + local_conv_dim * dtype.itemsize
@@ -307,6 +307,21 @@ __all__ = [
     "linear_state_bytes_per_req",
     "verify_transaction_bytes",
 ]
+
+
+def verify_transaction_steps(config) -> int:
+    """Width of the batch-one GDN transaction for supported speculative paths."""
+    steps = int(getattr(config, "speculative_tokens", 0) or 0)
+    method = getattr(config, "speculative_method", "none")
+    if method == "dflash2":
+        return steps
+    if (
+        steps > 0
+        and method == "mtp"
+        and getattr(config.model_config, "model_type", "") in {"qwen3_5", "qwen3_5_moe"}
+    ):
+        return steps + 1  # anchor plus the proposed tokens
+    return 0
 
 
 def state_pool_bytes(config, num_slots: int | None = None) -> int:
@@ -330,12 +345,13 @@ def state_pool_bytes(config, num_slots: int | None = None) -> int:
             * config.dtype.itemsize
         )
     total = per_slot * slots
-    if getattr(config, "speculative_method", "none") == "dflash2":
+    steps = verify_transaction_steps(config)
+    if steps:
         total += verify_transaction_bytes(
             linear_group,
             config.tp_info.size,
             config.dtype,
-            int(getattr(config, "speculative_tokens", 0) or 0),
+            steps,
         )
     return total
 

--- a/tests/runtime/kvcache/test_pool_sizing_surface.py
+++ b/tests/runtime/kvcache/test_pool_sizing_surface.py
@@ -264,6 +264,18 @@ def test_linear_state_pool_prices_itself():
         4 * 16 * 16 * 4 + (2 * 2 * 16 + 4 * 16) * 2
     )
     assert state_pool_bytes(config, num_slots=7) == per_req * 7 + expected_verify
+    # MTP uses an anchor plus N drafts; reserve all N+1 intermediate states.
+    config.speculative_method = "mtp"
+    config.speculative_tokens = 3
+    config.model_config.model_type = "qwen3_5_moe"
+    assert state_pool_bytes(config, num_slots=7) == per_req * 7 + expected_verify
+    # Other MTP families retain their existing rollback paths and memory costs.
+    for model_type in ("qwen4_exp", "glm5_next"):
+        config.model_config.model_type = model_type
+        assert state_pool_bytes(config, num_slots=7) == per_req * 7
+    config.model_config.model_type = "qwen3_5_moe"
+    config.speculative_tokens = 0
+    assert state_pool_bytes(config, num_slots=7) == per_req * 7
     # models without a linear group price to zero
     config.model_config.linear_attention_group = lambda: None
     assert state_pool_bytes(config) == 0

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -134,7 +134,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
     assert deepseek.deployment.backend_options["moe_host_cache_gb"] == 0
     assert deepseek.deployment.backend_options["moe_prefill_overlap"] is False
     qwen36 = get_recipe("qwen3.6-35b-a3b")
-    assert qwen36.recipe_version == "0.4.0"
+    assert qwen36.recipe_version == "0.5.0"
     assert qwen36.status == "certified"
     assert qwen36.runtime_memory == {"total_bytes": 34359738368}
     assert qwen36.performance.decode_tokens_per_second == pytest.approx(67.7870954092827)
@@ -144,6 +144,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
         "GB10-QWEN36-FAST-002",
         "GB10-QWEN36-MTP-003",
         "GB10-QWEN36-MTP-004",
+        "GB10-QWEN36-MTP-005",
     )
     assert qwen36.runtime_artifact is not None
     assert qwen36.runtime_artifact.repo_id == "oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW"


### PR DESCRIPTION
## Summary

- cache Qwen3.6 GDN verification state and commit the accepted prefix directly
- account for the replay-free transaction buffer in runtime memory sizing
- publish the 80.55 tok/s, 0.367 s warm-TTFT MTP2 result and recipe 0.5.0 metadata

## Validation

- `env SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 .venv/bin/pytest -q --ignore=tests/test_document_query_demo.py` (1694 passed, 8 skipped)
- focused runtime, model, and catalog suite (140 passed)
- `git diff --check`
- recipe and evidence JSON validation