### PR TITLE
docs(hf): standardize Qwen3.8 FTW cards and publishing

### DIFF
--- a/hf/models/qwen-3.8-27B-NVFP4-FTW/MODEL_CARD.md
+++ b/hf/models/qwen-3.8-27B-NVFP4-FTW/MODEL_CARD.md
@@ -1,0 +1,153 @@
+---
+pipeline_tag: text-generation
+base_model: Inferact/Qwen3.8-27B-NVFP4
+license: apache-2.0
+library_name: sparklab
+tags: [sparklab, ftw, nvfp4, dgx-spark, text-generation, modelopt]
+---
+
+# Qwen3.8-27B NVFP4 — SparkLab FTW
+
+This is an **experimental, text-only SparkLab FTW checkpoint** for Qwen3.8-27B
+on one NVIDIA DGX Spark with 128 GB coherent unified memory.
+
+[SparkLab](https://github.com/sixteen-miles-labs/sparklab) provides a GB10-native
+inference engine, model recipes, hardware checks, memory planning, artifact
+preparation, and OpenAI-/Anthropic-compatible serving APIs.
+
+## What this repository contains
+
+This repository does not introduce a newly trained model or a new quantization.
+It repackages [Inferact/Qwen3.8-27B-NVFP4](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4)
+into the native FreeToken Weight (FTW) layout used by SparkLab.
+
+- Base model: [Qwen/Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B), a dense 27B model.
+- Quantized source revision: `6128240ebaf4eaa7bad2b3d1c72c37d677c5f462`.
+- FTW fingerprint: `af78f7411817bb73`.
+- Three FTW weight shards, totaling **24,617,562,112 bytes** (24.62 GB).
+- `freetoken_weight.json`, configuration, tokenizer, chat template, generation settings, and upstream license.
+
+The conversion prepares the published ModelOpt NVFP4 weights for the native
+loader; non-quantized tensors remain in their runtime conversion layout. No
+additional model training is performed. This is a text-model artifact, not a
+standard Transformers/vLLM safetensors checkpoint. Inherited processor metadata
+does not enable images or video in SparkLab.
+
+The optional DFlash2 draft is **not included**. Download it separately as described
+below; its weights and license belong to its own repository.
+
+## Why use FTW?
+
+FTW performs tensor-layout preparation ahead of time for reproducible native
+loading. This dense model runs resident in unified memory; it does not require
+NVMe expert offloading. FTW by itself is not a claim of increased model quality
+or faster steady-state generation.
+
+## Run with SparkLab on NVIDIA DGX Spark
+
+Use ARM64 Linux / DGX OS, GB10/SM121, CUDA 13, and local NVMe. A current source
+installation is recommended, especially for the optimized DFlash2 path.
+
+```bash
+git clone https://github.com/sixteen-miles-labs/sparklab.git
+cd sparklab
+uv venv && source .venv/bin/activate
+uv pip install -e ".[accel]"
+
+hf download oakmindai/Qwen3.8-27B-NVFP4-FTW \
+  --local-dir /path/to/models/Qwen3.8-27B-NVFP4-FTW
+
+sparklab doctor --storage-path /path/to/models
+sparklab serve \
+  --model /path/to/models/Qwen3.8-27B-NVFP4-FTW \
+  --nvfp4-backend triton \
+  --cache-type radix --page-size 16 \
+  --cuda-graph-max-bs 1 --max-running-requests 1 \
+  --num-tokens 65536 --max-seq-len-override 65536 \
+  --host 127.0.0.1 --port 1919
+```
+
+Replace `/path/to/models` with your local model directory. These instructions
+download the prebuilt target directly; the current catalog recipe may still
+prepare it from Inferact rather than download this Hub repository.
+
+Once ready, check the model ID and send a request:
+
+```bash
+curl http://127.0.0.1:1919/health
+curl http://127.0.0.1:1919/v1/models
+curl http://127.0.0.1:1919/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen3.8-27B-NVFP4-FTW","messages":[{"role":"user","content":"Hello!"}],"temperature":0,"max_tokens":128,"stream":true}'
+```
+
+### Optional DFlash2 single-stream profile
+
+Download the pinned draft:
+
+```bash
+hf download maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal \
+  --revision bd7a934213c47a9e7ef69eef36bb3325f47fd1f1 \
+  --local-dir /path/to/models/qwen3.8-27b-dflash2
+```
+
+Instead of the target-only server, launch the measured 16K-capacity configuration:
+
+```bash
+sparklab serve \
+  --model /path/to/models/Qwen3.8-27B-NVFP4-FTW \
+  --nvfp4-backend triton --attention-backend triton \
+  --cache-type radix --page-size 16 \
+  --cuda-graph-max-bs 1 --max-running-requests 1 \
+  --num-tokens 16384 --max-seq-len-override 16384 \
+  --speculative-method dflash2 --speculative-tokens 12 \
+  --speculative-draft-model /path/to/models/qwen3.8-27b-dflash2 \
+  --host 127.0.0.1 --port 1919
+```
+
+## Performance and validation limits
+
+All numbers below are **single-stream**, not aggregate concurrent throughput.
+
+| Profile / workload | Decode | Warm TTFT |
+|---|---:|---:|
+| Recorded target-only baseline | 8.83 tok/s | 0.144 s |
+| Optimized DFlash2-12, 128-token probe | 45.88 tok/s | 0.152 s |
+
+The DFlash2 result is a three-trial median and reproduced the original target-only
+output on that short probe. Against a fresh matched DFlash2-8 control (37.69 tok/s),
+the improvement was 21.7%. A separate 512-token, thinking-off sweep measured
+59.58 tok/s for math, 37.51 for coding, and 19.26 for prose. These are individual
+workloads, not general task-suite averages. Full longer traces can differ due to
+floating-point rounding from verification grouping.
+
+See [DFlash2 evidence](https://github.com/sixteen-miles-labs/sparklab/blob/main/benchmarks/gb10/results/GB10-QWEN38-DFLASH-004.json)
+and [target-only evidence](https://github.com/sixteen-miles-labs/sparklab/blob/main/benchmarks/gb10/results/GB10-QWEN38-27B-001.json).
+
+- Target-only exact 65,536-token recall and reasoning/tool/coding probes passed.
+- The declared upstream 262K context has not been validated on this GB10 path.
+- DFlash2 is opt-in and batch-one greedy; 64K speculative context, sampling,
+  concurrency, and endurance certification remain outstanding.
+- Short output parity does not establish broad quality equivalence. Full Fast-tier
+  certification, including a clean-revision 60-minute endurance run, remains pending.
+- This upload reuses the previously tested artifact; it is not a new GPU benchmark.
+
+See the [SparkLab model guide](https://github.com/sixteen-miles-labs/sparklab/blob/main/docs/models/qwen3.8-27b.md)
+for current instructions and limitations.
+
+## Credits and license
+
+- Model architecture and base weights: [Qwen](https://huggingface.co/Qwen/Qwen3.8-27B).
+- Published NVFP4 checkpoint: [Inferact](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4), using the ModelOpt format.
+- Quantization tooling: [NVIDIA Model Optimizer](https://github.com/NVIDIA/Model-Optimizer).
+- Native inference, conversion, GB10 optimization, and deployment: [SparkLab](https://github.com/sixteen-miles-labs/sparklab).
+- Original FTW format and upstream runtime foundations: [FreeToken](https://github.com/FlashML-org/FreeToken); see SparkLab's [NOTICE](https://github.com/sixteen-miles-labs/sparklab/blob/main/NOTICE).
+- FTW publishing: [OakMind AI](https://huggingface.co/oakmindai).
+- Optional external draft: [maurienne-ai](https://huggingface.co/maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal).
+
+The pinned source declares Apache License 2.0; its `LICENSE` is included unchanged.
+Refer to the [source model card](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4/blob/6128240ebaf4eaa7bad2b3d1c72c37d677c5f462/README.md)
+and [Qwen documentation](https://huggingface.co/Qwen/Qwen3.8-27B) for upstream model
+information, limitations, and intended-use guidance. Upstream multimodal results
+are not SparkLab deployment certification. Evaluate generated answers for
+correctness and suitability for your application.

--- a/hf/models/qwen-3.8-27B-NVFP4-FTW/README.md
+++ b/hf/models/qwen-3.8-27B-NVFP4-FTW/README.md
@@ -1,0 +1,22 @@
+# Qwen3.8-27B NVFP4 FTW publishing
+
+`MODEL_CARD.md` is the canonical Hub README for
+`oakmindai/Qwen3.8-27B-NVFP4-FTW`.
+
+Validate the prepared target without network writes:
+
+```bash
+python hf/models/qwen-3.8-27B-NVFP4-FTW/push_weights.py \
+  /path/to/prepared/qwen3.8-27b --validate-only
+```
+
+Omit `--validate-only` to publish to the empty destination. The publisher checks
+the pinned fingerprint, shard sizes, tensor bounds, required metadata, and model
+card before uploading. It publishes all files in one Hub commit with a parent
+revision guard, then checks remote sizes and LFS hashes. An existing populated
+destination is refused to prevent accidental artifact replacement.
+
+The public index replaces the workstation-local source path with upstream
+provenance. Source-safetensors checksum files are excluded because they do not
+describe the FTW payload. The prepared local weights and metadata are not modified.
+The optional DFlash2 draft is documented but is not uploaded here.

--- a/hf/models/qwen-3.8-27B-NVFP4-FTW/push_weights.py
+++ b/hf/models/qwen-3.8-27B-NVFP4-FTW/push_weights.py
@@ -1,0 +1,83 @@
+"""Validate and atomically publish the pinned Qwen3.8-27B FTW and canonical card."""
+import argparse
+import json
+from pathlib import Path
+
+from huggingface_hub import CommitOperationAdd, HfApi, ModelCard
+
+REPO = "oakmindai/Qwen3.8-27B-NVFP4-FTW"
+CARD = Path(__file__).with_name("MODEL_CARD.md")
+METADATA = (
+    "LICENSE", "config.json", "chat_template.jinja", "generation_config.json",
+    "hf_quant_config.json", "merges.txt", "preprocessor_config.json",
+    "tokenizer.json", "tokenizer_config.json", "video_preprocessor_config.json", "vocab.json",
+)
+
+
+def validate(root):
+    index = json.loads((root / "freetoken_weight.json").read_text())
+    assert index["format"] == "freetoken_weight" and index["version"] == 1
+    assert index["fingerprint"] == "af78f7411817bb73"
+    assert index["total_bytes"] == 24_617_562_112
+    assert len(index["shards"]) == 3
+    offset = 0
+    for number, shard in enumerate(index["shards"]):
+        assert shard["file"] == f"freetoken-{number:05d}.ftw"
+        assert shard["global_off"] == offset
+        assert (root / shard["file"]).stat().st_size == shard["nbytes"]
+        offset += shard["nbytes"]
+    assert offset == index["total_bytes"]
+    names = set()
+    for tensor in index["tensors"]:
+        assert tensor["name"] not in names
+        names.add(tensor["name"])
+        assert tensor["global_off"] >= 0 and tensor["nbytes"] > 0
+        assert tensor["global_off"] % index["align"] == 0
+        assert tensor["global_off"] + tensor["nbytes"] <= offset
+    for name in METADATA:
+        assert (root / name).is_file(), name
+    card = ModelCard.load(str(CARD))
+    assert card.data.pipeline_tag == "text-generation"
+    assert index["fingerprint"] in card.text
+    # Remove workstation paths and obsolete checksums for the source safetensors.
+    index["source_model_path"] = "Inferact/Qwen3.8-27B-NVFP4"
+    index["source_revision"] = "6128240ebaf4eaa7bad2b3d1c72c37d677c5f462"
+    index["copied_metadata"] = list(METADATA) + ["README.md"]
+    return index
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("weights_dir", type=Path)
+    parser.add_argument("--validate-only", action="store_true")
+    args = parser.parse_args()
+    root = args.weights_dir.resolve()
+    index = validate(root)
+    print(f"Validated {len(index['tensors'])} tensors, three shards, {index['total_bytes']} weight bytes", flush=True)
+    if args.validate_only:
+        return
+    api = HfApi()
+    before = api.model_info(REPO)
+    assert {s.rfilename for s in before.siblings} <= {".gitattributes"}, "Destination not empty; review before overwriting"
+    files = list(METADATA) + [s["file"] for s in index["shards"]]
+    operations = [CommitOperationAdd(path_in_repo=name, path_or_fileobj=str(root / name)) for name in files]
+    operations += [
+        CommitOperationAdd(path_in_repo="README.md", path_or_fileobj=CARD.read_bytes()),
+        CommitOperationAdd(path_in_repo="freetoken_weight.json", path_or_fileobj=(json.dumps(index, indent=2) + "\n").encode()),
+    ]
+    commit = api.create_commit(repo_id=REPO, parent_commit=before.sha, operations=operations,
+        commit_message="Publish pinned Qwen3.8-27B NVFP4 FTW weights and SparkLab model card")
+    print(commit.commit_url, flush=True)
+    after = api.model_info(REPO, revision=commit.oid, files_metadata=True)
+    remote = {s.rfilename: s for s in after.siblings}
+    assert set(remote) == set(files) | {".gitattributes", "README.md", "freetoken_weight.json"}
+    for op in operations:
+        entry = remote[op.path_in_repo]
+        assert entry.size == op.upload_info.size
+        if entry.lfs:
+            assert entry.lfs.sha256 == op.upload_info.sha256.hex()
+    print("Verified remote file inventory, sizes, and LFS SHA-256 hashes.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/hf/models/qwen-3.8-Flash-Next-NVFP4-FTW/MODEL_CARD.md
+++ b/hf/models/qwen-3.8-Flash-Next-NVFP4-FTW/MODEL_CARD.md
@@ -1,0 +1,152 @@
+---
+pipeline_tag: text-generation
+license: other
+license_name: nvidia-open-model-license
+license_link: https://huggingface.co/nvidia/Qwen3.8-Flash-Next-NVFP4#licenseterms-of-use
+base_model: nvidia/Qwen3.8-Flash-Next-NVFP4
+library_name: sparklab
+tags: [sparklab, ftw, nvfp4, dgx-spark, text-generation, modelopt]
+---
+
+# Qwen3.8-Flash-Next NVFP4 — SparkLab FTW
+
+This repository packages Qwen3.8-Flash-Next as an **experimental, text-only
+SparkLab FTW artifact** for one NVIDIA DGX Spark with 128 GB coherent unified
+memory. It is not a standard Transformers or vLLM safetensors checkpoint.
+
+[SparkLab](https://github.com/sixteen-miles-labs/sparklab) provides GB10-native
+inference, model recipes, hardware checks, memory planning, artifact preparation,
+and OpenAI-/Anthropic-compatible serving APIs.
+
+## What this repository contains
+
+This is a repackaging, not a newly trained model or an additional quantization:
+
+1. [Qwen](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) developed the base model.
+2. [NVIDIA](https://huggingface.co/nvidia/Qwen3.8-Flash-Next-NVFP4) published the mixed-precision checkpoint using Model Optimizer.
+3. SparkLab packages the tensors for its native FTW loader and GB10 execution path.
+4. [OakMind AI](https://huggingface.co/oakmindai) published this conversion.
+
+The pinned NVIDIA source revision is `fab0aecb760cec45227f6656abcaafa11abca87a`.
+The FTW fingerprint is `94e1ee0daa442357`. Total weight payload is
+**131,931,279,080 bytes**, excluding tokenizer and metadata files.
+
+| Component | Published layout and precision |
+|---|---|
+| Target weights | Ten `freetoken-*.ftw` shards and `freetoken_weight.json`; native NVFP4 routed experts, BF16 resident projections |
+| PLE n-gram bank | Approximately 51.2 GB FP8 `qwen4_ngram.bin`, with its published global scale in `qwen4_ngram.json` |
+| Native MTP module | `nvfp4_experts_mtp.safetensors`; despite the legacy filename, draft experts are 128-by-128 block-scaled FP8 and remaining draft tensors retain their published precision |
+| Runtime metadata | Configuration, tokenizer, chat template, and generation configuration |
+
+Conversion preserves published weight precision and scales without conversion-time
+requantization. The complete indexed MTP module is assembled from the source shards.
+Inherited image/video processor metadata does not enable multimodal serving here.
+
+## Why use FTW?
+
+FTW prepares tensor layouts ahead of time and stores routed experts in addressable
+banks for SparkLab's native loader. This deployment preloads all **24,576 target
+routed experts** into immutable unified-memory slots, eliminating steady-state
+routed-expert disk reads. The PLE bank remains disk-backed on local NVMe.
+
+The artifact's disk size is not its resident-memory requirement. FTW alone is
+not a claim of better model quality or higher steady-state decode throughput.
+
+## Run with SparkLab on NVIDIA DGX Spark
+
+Requires ARM64 Linux / DGX OS, GB10/SM121, CUDA 13, and fast local NVMe.
+Use a current SparkLab source build with NVIDIA mixed-precision loading, scaled
+FP8 PLE, indexed MTP extraction, and accepted-prefix commits. **The previously
+released 0.1.2 wheel is not sufficient.**
+
+```bash
+git clone https://github.com/sixteen-miles-labs/sparklab.git
+cd sparklab
+uv venv && source .venv/bin/activate
+uv pip install -e ".[accel]"
+
+sparklab doctor --storage-path /path/to/models
+sparklab plan qwen3.8-flash-next --root /path/to/models --prepare
+sparklab pull qwen3.8-flash-next --root /path/to/models --prepare
+sparklab run qwen3.8-flash-next --root /path/to/models
+```
+
+Replace `/path/to/models` with your local NVMe directory. Recipe 0.9.0 downloads
+this prebuilt artifact at immutable revision
+`f547c96e86d0e50908c1415f4525c4325555691e` and verifies its identity. A later
+documentation-only Hub revision does not require changing that weight pin.
+The catalog budgets approximately 402 GB free disk, including preparation and
+safety allowance; `plan` is authoritative.
+
+Once the server is ready:
+
+```bash
+curl http://127.0.0.1:1919/health
+curl http://127.0.0.1:1919/v1/models
+curl http://127.0.0.1:1919/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen3.8-flash-next","messages":[{"role":"user","content":"Hello!"}],"max_tokens":128,"temperature":0,"stream":true}'
+```
+
+### Optional single-stream MTP
+
+Instead of the target-only launch above, enable three draft tokens:
+
+```bash
+sparklab run qwen3.8-flash-next --root /path/to/models -- --speculative-tokens 3
+```
+
+Native MTP is opt-in and limited to batch-one greedy requests. Dense-QSA
+verification uses a fixed-shape CUDA graph; sparse-QSA verification runs eagerly.
+The target-only recipe's admission limit is not a claim of concurrent MTP support.
+
+## Performance and validation limits
+
+The selected NVIDIA MTP3 accepted-prefix profile measured **31.97 tok/s** and
+**0.260 s warm TTFT**, three-trial medians on a short 128-token greedy
+single-stream probe. This was 13.9% faster than its NVIDIA MTP3 baseline and
+performed no rejection replay. See
+[GB10-QWENNVIDIA-002](https://github.com/sixteen-miles-labs/sparklab/blob/main/benchmarks/gb10/results/GB10-QWENNVIDIA-002.json).
+
+The three selected runs reproduced the same output, but differed from target-only
+and pre-optimization MTP. This does not establish general quality equivalence.
+Quality and endurance certification remain outstanding. The configured
+131,072-token KV pool is a capacity setting, not a certified context length.
+
+The NVIDIA artifact does **not** inherit the previous Inferact artifact's quality,
+64K recall, concurrency, or endurance evidence. No quality advantage over Inferact
+has been established. Experimental reduced-vocabulary drafting is not enabled
+by the commands above and is not the selected portfolio profile.
+
+See the [model guide](https://github.com/sixteen-miles-labs/sparklab/blob/main/docs/models/qwen3.8-flash-next.md)
+for current runtime limitations and separately labeled experiments.
+
+## Previous artifact compatibility
+
+The NVIDIA artifact replaced the Inferact-derived artifact on `main` on September
+5, 2026. The previous artifact remains available at immutable revision
+`5ab790b83f149a96594237a35905d84be24599a3`; existing revision-pinned recipes
+continue to resolve it. Do not mix its shards or sidecars with the NVIDIA artifact.
+
+## Credits and license
+
+- Base model: [Qwen](https://huggingface.co/Qwen/Qwen3.8-Flash-Next).
+- Quantized source: [NVIDIA](https://huggingface.co/nvidia/Qwen3.8-Flash-Next-NVFP4) and [Model Optimizer](https://github.com/NVIDIA/Model-Optimizer).
+- Native runtime, GB10 optimization, conversion, and deployment workflow: [SparkLab](https://github.com/sixteen-miles-labs/sparklab).
+- Original FreeToken Weight format and upstream runtime foundations: [FreeToken](https://github.com/FlashML-org/FreeToken); see SparkLab's [NOTICE](https://github.com/sixteen-miles-labs/sparklab/blob/main/NOTICE).
+- FTW conversion publishing: [OakMind AI](https://huggingface.co/oakmindai).
+
+The upstream NVIDIA Open Model License and additional Qwen Community License
+terms apply; see the [upstream license/terms](https://huggingface.co/nvidia/Qwen3.8-Flash-Next-NVFP4#licenseterms-of-use).
+The existing `LICENSE` file contains Qwen's additional terms and is not a
+substitute for the NVIDIA license. SparkLab's software license does not replace
+the model's governing terms.
+
+## Upstream model information
+
+Consult the [pinned NVIDIA model card](https://huggingface.co/nvidia/Qwen3.8-Flash-Next-NVFP4/blob/fab0aecb760cec45227f6656abcaafa11abca87a/README.md)
+and [Qwen model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) for architecture,
+training and calibration information, upstream evaluations, and intended-use
+limitations. Upstream multimodal and long-context results are not SparkLab
+certification. Generated answers can be incorrect or biased; evaluate the
+deployed artifact on your intended tasks before relying on it.

--- a/hf/models/qwen-3.8-Flash-Next-NVFP4-FTW/README.md
+++ b/hf/models/qwen-3.8-Flash-Next-NVFP4-FTW/README.md
@@ -8,7 +8,7 @@ SparkLab source: <https://github.com/sixteen-miles-labs/sparklab>
 The default source is SparkLab's prepared artifact:
 
 ```text
-~/.sparklab/models/qwen3.8-flash-next/prepared/0.5.0
+~/.sparklab/models/qwen3.8-flash-next/prepared/0.9.0
 ```
 
 Upload it with:
@@ -22,3 +22,8 @@ HF_XET_HIGH_PERFORMANCE=1 \
 Pass a directory as the first argument to upload a different copy. The uploader
 checks for the FTW index, shards, and n-gram artifacts before starting, and its
 upload state is resumable when the same command is run again.
+
+`MODEL_CARD.md` is the canonical public model card. The uploader requires it,
+checks the NVIDIA artifact fingerprint, excludes any prepared-directory README,
+and publishes this card as the Hub README after the weights finish uploading.
+Keep its provenance, commands, and validation claims synchronized with the recipe.

--- a/hf/models/qwen-3.8-Flash-Next-NVFP4-FTW/push_weights.py
+++ b/hf/models/qwen-3.8-Flash-Next-NVFP4-FTW/push_weights.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -13,13 +14,16 @@ from huggingface_hub.errors import HfHubHTTPError
 
 DEFAULT_REPO_ID = "oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW"
 DEFAULT_WEIGHTS_DIR = Path(
-    "~/.sparklab/models/qwen3.8-flash-next/prepared/0.5.0"
+    "~/.sparklab/models/qwen3.8-flash-next/prepared/0.9.0"
 ).expanduser()
+PUBLIC_CARD = Path(__file__).with_name("MODEL_CARD.md")
+EXPECTED_FINGERPRINT = "94e1ee0daa442357"
 REQUIRED_FILES = (
     "config.json",
     "freetoken_weight.json",
     "qwen4_ngram.bin",
     "qwen4_ngram.json",
+    "nvfp4_experts_mtp.safetensors",
 )
 DEFAULT_IGNORE_PATTERNS = [
     ".git/**",
@@ -27,6 +31,7 @@ DEFAULT_IGNORE_PATTERNS = [
     "__pycache__/**",
     "*.pyc",
     "*.tmp",
+    "README.md",  # Publish the version-controlled card after the weight transfer.
 ]
 
 
@@ -63,6 +68,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def validate_args(args: argparse.Namespace) -> Path:
+    if not PUBLIC_CARD.is_file():
+        raise ValueError(f"public model card is missing: {PUBLIC_CARD}")
     weights_dir = args.weights_dir.expanduser().resolve()
     if not weights_dir.is_dir():
         raise ValueError(f"weights directory does not exist: {weights_dir}")
@@ -71,6 +78,10 @@ def validate_args(args: argparse.Namespace) -> Path:
         raise ValueError(f"FTW artifact is missing: {', '.join(missing)}")
     if not list(weights_dir.glob("freetoken-*.ftw")):
         raise ValueError("FTW artifact has no freetoken-*.ftw shards")
+    index = json.loads((weights_dir / "freetoken_weight.json").read_text())
+    if (index.get("format") != "freetoken_weight" or index.get("version") != 1
+            or index.get("fingerprint") != EXPECTED_FINGERPRINT):
+        raise ValueError("artifact does not match the NVIDIA model card")
     if args.workers is not None and args.workers < 1:
         raise ValueError("--workers must be at least 1")
     if args.private and not args.create:
@@ -110,6 +121,14 @@ def main() -> int:
             ignore_patterns=DEFAULT_IGNORE_PATTERNS,
             num_workers=args.workers,
             print_report=True,
+        )
+        api.upload_file(
+            repo_id=args.repo_id,
+            repo_type="model",
+            path_or_fileobj=str(PUBLIC_CARD),
+            path_in_repo="README.md",
+            revision=args.revision,
+            commit_message="Publish canonical SparkLab Qwen3.8 NVIDIA FTW model card",
         )
     except HfHubHTTPError as error:
         print(f"Hugging Face upload failed: {error}", file=sys.stderr)

--- a/tests/test_qwen38_hf_publish.py
+++ b/tests/test_qwen38_hf_publish.py
@@ -1,0 +1,77 @@
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_DIR = ROOT / "hf/models/qwen-3.8-Flash-Next-NVFP4-FTW"
+spec = importlib.util.spec_from_file_location("qwen38_publish", PUBLISH_DIR / "push_weights.py")
+publisher = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(publisher)
+
+
+def artifact(tmp_path, fingerprint):
+    for name in publisher.REQUIRED_FILES:
+        (tmp_path / name).touch()
+    (tmp_path / "freetoken-00000.ftw").touch()
+    (tmp_path / "freetoken_weight.json").write_text(json.dumps({
+        "format": "freetoken_weight", "version": 1, "fingerprint": fingerprint,
+    }))
+    return argparse.Namespace(weights_dir=tmp_path, workers=None, private=False, create=False)
+
+
+def test_nvidia_identity(tmp_path):
+    args = artifact(tmp_path, publisher.EXPECTED_FINGERPRINT)
+    assert publisher.validate_args(args) == tmp_path
+
+
+def test_old_artifact_rejected(tmp_path):
+    with pytest.raises(ValueError, match="does not match"):
+        publisher.validate_args(artifact(tmp_path, "47e11ddb878adf4c"))
+
+
+def test_missing_card_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(publisher, "PUBLIC_CARD", tmp_path / "absent.md")
+    with pytest.raises(ValueError, match="public model card is missing"):
+        publisher.validate_args(artifact(tmp_path, publisher.EXPECTED_FINGERPRINT))
+
+
+def test_card_structure_and_recipe_identity():
+    from huggingface_hub import ModelCard
+
+    card = ModelCard.load(str(publisher.PUBLIC_CARD))
+    assert card.data.pipeline_tag == "text-generation"
+    assert card.data.library_name == "sparklab"
+    recipe = json.loads((ROOT / "python/sparklab/recipes/qwen3.8-flash-next.json").read_text())
+    for value in (recipe["revision"], recipe["runtime_artifact"]["fingerprint"]):
+        assert value in card.text
+    for heading in ("What this repository contains", "Why use FTW?",
+                    "Run with SparkLab on NVIDIA DGX Spark", "Credits and license",
+                    "Performance and validation limits"):
+        assert f"## {heading}" in card.text
+    assert "README.md" in publisher.DEFAULT_IGNORE_PATTERNS
+
+
+def test_uploader_publishes_canonical_card_after_weights(tmp_path, monkeypatch):
+    args = artifact(tmp_path, publisher.EXPECTED_FINGERPRINT)
+    args.repo_id = publisher.DEFAULT_REPO_ID
+    args.revision = "test-branch"
+    calls = []
+
+    class FakeApi:
+        def upload_large_folder(self, **kwargs):
+            calls.append(("weights", kwargs))
+
+        def upload_file(self, **kwargs):
+            calls.append(("card", kwargs))
+
+    monkeypatch.setattr(publisher, "parse_args", lambda: args)
+    monkeypatch.setattr(publisher, "HfApi", FakeApi)
+    assert publisher.main() == 0
+    assert [name for name, _ in calls] == ["weights", "card"]
+    assert calls[1][1]["path_or_fileobj"] == str(publisher.PUBLIC_CARD)
+    assert calls[1][1]["path_in_repo"] == "README.md"
+    assert calls[1][1]["revision"] == "test-branch"


### PR DESCRIPTION
## Summary

- Restore the standard SparkLab model-card structure for the NVIDIA Qwen3.8 Flash Next artifact while retaining compatibility, precision, and validation caveats.
- Add the Qwen3.8-27B FTW canonical model card and guarded publisher, including target-only and separately labeled single-stream DFlash2 instructions.
- Require the canonical Flash Next card, check the NVIDIA fingerprint, and prevent a prepared upstream README from replacing it.
- Keep model weights outside Git and preserve existing recipe revision pins.

## Validation

- Five publishing regression tests passed; git diff --check passed.
- Validated 1,027 Qwen3.8-27B tensor entries and three shard sizes against the recorded fingerprint.
- Both documented Qwen3.8-27B serving configurations passed argument parsing.
- Published the Flash Next README-only correction and verified all other Hub files unchanged.
- Published Qwen3.8-27B weights and README; independently verified every uploaded file against local content using Git blob or LFS SHA-256 hashes.

No new GPU benchmarks were run. Unrelated local assets and tests are excluded.