### PR TITLE
docs: correct README links, performance labels, and setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">SparkLab</h1>
 
 <p align="center">
-  <a href="docs/">
+  <a href="#documentation">
     <img src="https://img.shields.io/badge/Documentation-Read%20the%20docs-2563EB" alt="Documentation">
   </a>
   <a href="https://github.com/sixteen-miles-labs/sparklab/releases">
@@ -46,13 +46,15 @@ SparkLab deliberately supports one narrow hardware profile:
 - NVIDIA GB10 Grace Blackwell Superchip (`SM121`)
 - 128 GB coherent unified memory
 - ARM64 Linux or DGX OS
+- Python 3.10 or newer
 - NVIDIA driver r580 or newer and CUDA 13 toolkit
 - Local NVMe storage for checkpoints, FTW artifacts, and disk-backed experts
 - One local DGX Spark; multi-node and high-concurrency serving are outside the Beta scope
 
-Platform, memory, swap, dependency, and storage requirements fail closed before a recipe
-launch. Unsupported hardware may still work through native runtime fallbacks, but it is not
-a SparkLab support claim.
+Recipe launch fails closed on failed platform, memory, swap, dependency, and storage
+checks. Storage whose NVMe backing cannot be established produces a warning requiring
+review; `sparklab doctor --strict` also returns non-zero for warnings. Unsupported hardware
+may still work through native runtime fallbacks, but it is not a SparkLab support claim.
 
 ## Why SparkLab
 
@@ -80,7 +82,7 @@ a SparkLab support claim.
       <th>Quantization</th>
       <th>Status</th>
       <th align="right">tok/s</th>
-      <th align="right">TTFT(s)</th>
+      <th align="right">Warm TTFT (s)</th>
       <th>Run</th>
     </tr>
   </thead>
@@ -92,9 +94,9 @@ a SparkLab support claim.
       <td><a href="https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW">Qwen3.6-35B-A3B</a></td>
       <td>35B total / 3B active</td>
       <td>NVFP4 · FTW + optional MTP2</td>
-      <td>Certified</td>
-      <td align="right">80.55</td>
-      <td align="right">0.367</td>
+      <td>Certified (target-only)</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-QWEN36-FAST-002.json">67.79</a></td>
+      <td align="right">0.329</td>
       <td><a href="docs/models/qwen3.6-35b-a3b.md">Instructions</a></td>
     </tr>
     <tr>
@@ -102,7 +104,7 @@ a SparkLab support claim.
       <td>27B dense</td>
       <td>NVFP4 · FTW + optional DFlash2-12</td>
       <td>Experimental</td>
-      <td align="right">45.88</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-QWEN38-DFLASH-004.json">45.88</a></td>
       <td align="right">0.152</td>
       <td><a href="docs/models/qwen3.8-27b.md">Instructions</a></td>
     </tr>
@@ -112,9 +114,9 @@ a SparkLab support claim.
     <tr>
       <td><a href="https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW">Qwen3.8-Flash-Next</a></td>
       <td>125B LM + 55B auxiliary / 6B active</td>
-      <td>NVFP4 · FTW + MTP3</td>
+      <td>NVFP4 · FTW + optional MTP3</td>
       <td>Experimental</td>
-      <td align="right">31.97</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-QWENNVIDIA-002.json">31.97</a></td>
       <td align="right">0.260</td>
       <td><a href="docs/models/qwen3.8-flash-next.md">Instructions</a></td>
     </tr>
@@ -123,7 +125,7 @@ a SparkLab support claim.
       <td>284B total / 13B active</td>
       <td>DS-FP4 · FTW + optional DSpark5</td>
       <td>Preview</td>
-      <td align="right">14.02</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-DSV4-PREFIX-006.json">14.02</a></td>
       <td align="right">0.515</td>
       <td><a href="docs/models/deepseek-v4.md">Instructions</a></td>
     </tr>
@@ -132,7 +134,7 @@ a SparkLab support claim.
       <td>320B total / 18B active</td>
       <td>NVFP4 + KDA FP8 · FTW + optional MTP3</td>
       <td>Experimental</td>
-      <td align="right">7.77</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-GLM53-OPT-006.json">7.77</a></td>
       <td align="right">6.395</td>
       <td><a href="docs/models/glm-5.3-flash.md">Instructions</a></td>
     </tr>
@@ -144,7 +146,7 @@ a SparkLab support claim.
       <td>753B total / 40B active</td>
       <td>NVFP4 + resident FP8 · FTW</td>
       <td>Experimental</td>
-      <td align="right">0.81</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json">0.81</a></td>
       <td align="right">2.530</td>
       <td><a href="docs/models/glm-5.3.md">Instructions</a></td>
     </tr>
@@ -153,7 +155,7 @@ a SparkLab support claim.
       <td>2.8T total / 16 of 896 experts</td>
       <td>ModelOpt NVFP4/FP8 · FTW</td>
       <td>Experimental</td>
-      <td align="right">0.16</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-KIMI-001.json">0.16</a></td>
       <td align="right">395.405</td>
       <td><a href="docs/models/kimi-k3.md">Instructions</a></td>
     </tr>
@@ -168,13 +170,26 @@ Status meanings:
 - **Certified:** the exact recipe, revision, artifact, and release environment passed all
   required correctness, parser, agent, context, latency, memory, NVMe, and endurance gates.
 
-Portfolio performance and warm-TTFT values report each recipe's selected single-stream
-profile. Concurrent-serving measurements remain in the linked model evidence.
+Throughput is decode tokens per second; warm TTFT is time to first token in seconds.
+Values report selected single-stream probes, with configurations and validation limits
+in the linked evidence. Qwen3.8-27B, Qwen3.8-Flash-Next, DeepSeek V4 Flash, and GLM-5.3
+Flash report opt-in speculative profiles; target-only serving remains their default.
+Concurrent-serving measurements remain in the linked model evidence.
+
+Qwen3.6's row reports its certified target-only profile. Its optional MTP2 path measured
+[80.55 tok/s and 0.367 s warm TTFT](benchmarks/gb10/results/GB10-QWEN36-MTP-005.json),
+but full MTP certification remains pending. GLM-5.3 and Kimi K3 measurements establish
+bounded execution; answer correctness remains unproven.
 
 Run `sparklab models --json` for exact recipe versions, checkpoint revisions, artifact
 fingerprints, implementation state, evidence IDs, and known constraints.
 
 ## Documentation
+
+Start with installation, then follow the quick start or a model's run instructions.
+The current Qwen3.8-Flash-Next recipe requires a
+[source installation](docs/install.md#method-2-install-from-source); the released 0.1.2
+wheel does not include its required runtime support.
 
 - [Installation](docs/install.md)
 - [Quick start](docs/quickstart.md)
@@ -190,6 +205,8 @@ backing, legal stewardship, and commercial support.
 - [Contributing guide](CONTRIBUTING.md)
 - [Governance](GOVERNANCE.md)
 - [Release and package policy](RELEASING.md)
+- [Security policy](SECURITY.md)
+- [Code of conduct](CODE_OF_CONDUCT.md)
 
 ## Credits and citation
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
       <td><a href="https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW">Qwen3.6-35B-A3B</a></td>
       <td>35B total / 3B active</td>
       <td>NVFP4 · FTW + optional MTP2</td>
-      <td>Certified (target-only)</td>
-      <td align="right"><a href="benchmarks/gb10/results/GB10-QWEN36-FAST-002.json">67.79</a></td>
-      <td align="right">0.329</td>
+      <td>Target-only certified; MTP2 certification pending</td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-QWEN36-MTP-005.json">80.55</a></td>
+      <td align="right">0.367</td>
       <td><a href="docs/models/qwen3.6-35b-a3b.md">Instructions</a></td>
     </tr>
     <tr>
-      <td><a href="https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4">Qwen3.8-27B</a></td>
+      <td><a href="https://huggingface.co/oakmindai/Qwen3.8-27B-NVFP4-FTW">Qwen3.8-27B</a></td>
       <td>27B dense</td>
       <td>NVFP4 · FTW + optional DFlash2-12</td>
       <td>Experimental</td>
@@ -172,13 +172,13 @@ Status meanings:
 
 Throughput is decode tokens per second; warm TTFT is time to first token in seconds.
 Values report selected single-stream probes, with configurations and validation limits
-in the linked evidence. Qwen3.8-27B, Qwen3.8-Flash-Next, DeepSeek V4 Flash, and GLM-5.3
+in the linked evidence. Qwen3.6-35B-A3B, Qwen3.8-27B, Qwen3.8-Flash-Next, DeepSeek V4 Flash, and GLM-5.3
 Flash report opt-in speculative profiles; target-only serving remains their default.
 Concurrent-serving measurements remain in the linked model evidence.
 
-Qwen3.6's row reports its certified target-only profile. Its optional MTP2 path measured
-[80.55 tok/s and 0.367 s warm TTFT](benchmarks/gb10/results/GB10-QWEN36-MTP-005.json),
-but full MTP certification remains pending. GLM-5.3 and Kimi K3 measurements establish
+Qwen3.6's row reports its optional MTP2 profile; full MTP certification remains pending.
+Its certified target-only profile measured
+[67.79 tok/s and 0.329 s warm TTFT](benchmarks/gb10/results/GB10-QWEN36-FAST-002.json). GLM-5.3 and Kimi K3 measurements establish
 bounded execution; answer correctness remains unproven.
 
 Run `sparklab models --json` for exact recipe versions, checkpoint revisions, artifact

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,6 +13,7 @@ sparklab <command> [args]
 | `sparklab run` | Launch a prepared recipe after fail-closed GB10 admission |
 | `sparklab gate` | Evaluate versioned full-model evidence against product tier gates |
 | `sparklab status` | Show the persistent engine status |
+| `sparklab daemon` | Run or control the persistent engine supervisor; see the [supervisor guide](../python/sparklab/daemon/README.md) |
 | `sparklab serve` | Start the API server (OpenAI `/v1/*`, Anthropic `/v1/messages`, Responses) |
 | `sparklab shell` | Chat with a server in the terminal |
 | `sparklab ctl` | Query and manage a running server over HTTP |
@@ -139,6 +140,8 @@ the model-portfolio context behind offloaded execution.
 | Flag | Default | Meaning |
 |---|---|---|
 | `--moe-backend` | auto | `fused`/`offload`/`cpu`/`hybrid`; auto → offload, or hybrid with a `sparklab bench bw` profile |
+| `--moe-storage` | ram | Keep routed experts in host RAM, or use `disk` to fetch FTW expert rows on demand |
+| `--moe-host-cache-gb` | 1 | Disk-mode host expert-LRU budget in GiB; fixed staging buffers are additional |
 | `--moe-cache-size` / `--moe-cache-rate` / `--moe-cache-auto` | auto | GPU expert-cache size as slots / fraction of all experts / sized from free VRAM (mutually exclusive; auto is enabled by default for offload-family backends) |
 | `--moe-preload-all` | off | Disk FTW mode: preload every routed expert into a complete immutable GPU cache; forces GPU offload, disables prefill overlap, and fails if the full expert bank does not fit |
 | `--moe-cache-policy` | `lru` | `lru`, or borrowable `layer_lru` protection applied to both the GPU slot cache and disk host LRU |
@@ -165,9 +168,11 @@ the model-portfolio context behind offloaded execution.
 ```bash
 sparklab shell                                    # attach to a running server
 sparklab shell --model ~/models/Qwen3.6-35B-A3B   # serve + chat in one process
+sparklab shell --documents /path/to/documents     # attach with local .txt/.md retrieval
 ```
 
 - Attach mode talks to `--server URL` (default `http://127.0.0.1:1919`)
+- `--documents` requires an already running server and cannot be combined with `--model`.
 - `/help` inside the shell lists the commands (`/think`, `/cache`, `/reset`).
 
 ## sparklab ctl

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,6 +9,11 @@
 
 ## Method 1: Install from PyPI
 
+Use this for the published release. For the current Qwen3.8-Flash-Next recipe and
+unreleased runtime changes documented in this checkout, use
+[Method 2](#method-2-install-from-source). The released 0.1.2 wheel lacks the current
+Qwen3.8-Flash-Next checkpoint support.
+
 ```bash
 uv venv && source .venv/bin/activate
 uv pip install "sparklab[accel]"
@@ -33,12 +38,10 @@ source .venv/bin/activate
 sparklab --version
 sparklab doctor --storage-path ~/models
 sparklab models
-sparklab serve --model ~/path/to/Qwen3.6-35B-A3B
-curl http://127.0.0.1:1919/v1/chat/completions -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen3.6-35B-A3B","messages":[{"role":"user","content":"hi"}]}'
 ```
 
-Then head to [quickstart.md](quickstart.md).
+Then follow the [quick start](quickstart.md) to plan, download, and launch a recipe
+before sending an API request.
 
 ## Optional persistent supervisor
 
@@ -47,10 +50,18 @@ The source tree includes a SparkLab systemd user unit.
 ```bash
 mkdir -p ~/.config/systemd/user
 cp python/sparklab/daemon/sparklab.service ~/.config/systemd/user/
+```
+
+Before enabling the service, edit `~/.config/systemd/user/sparklab.service` so
+`ExecStart` uses the absolute path to your environment's `sparklab` executable
+(shown by `command -v sparklab` after activation). The reference unit defaults to
+`~/.local/bin/sparklab`, which `install.sh` provides; the virtual-environment installs
+above do not create that link.
+
+```bash
 systemctl --user daemon-reload
 systemctl --user enable --now sparklab
 systemctl --user status sparklab
 ```
 
-The packaged installer links `sparklab` into `~/.local/bin` by default. If you install
-into a checkout-local virtual environment, edit the unit's `ExecStart` first.
+See the [supervisor guide](../python/sparklab/daemon/README.md) for configuration.

--- a/docs/models.md
+++ b/docs/models.md
@@ -34,7 +34,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
 | [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW + optional DFlash2-12 | `qwen3.8-27b` | Experimental | 45.88 | 0.152 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
-| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + MTP3 | `qwen3.8-flash-next` | Experimental | 31.97 | 0.260 |
+| [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + optional MTP3 | `qwen3.8-flash-next` | Experimental | 31.97 | 0.260 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 14.02 | 0.515 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 7.77 | 6.395 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
@@ -43,6 +43,10 @@ coding-agent task, and versioned benchmark evidence. Status means:
 
 Model links point to the selected source or published FTW checkpoint. Qwen3.6, GLM-5.3,
 and Kimi K3 use pinned prebuilt artifacts with reproducible source-conversion paths.
+The current Qwen3.8-Flash-Next recipe requires a
+[source installation](install.md#method-2-install-from-source); the released 0.1.2 wheel
+lacks its required runtime support.
+
 Parameter counts come from model publishers, and performance values come from the
 evidence attached to each recipe. Certification applies only to that exact checkpoint
 and recipe version. Portfolio performance and warm-TTFT columns use the selected
@@ -87,9 +91,27 @@ sparklab run <recipe>
 ```
 
 `--prepare` uses a pinned prebuilt FTW artifact when one is available. Use
-`--from-source` to reproduce conversion locally. FTW preserves the source checkpoint's
-precision while arranging weights for fast loading; separately quantized artifacts do
-not inherit the source recipe's certification.
+`--from-source` to reproduce conversion locally. FTW arranges weights for fast loading;
+the recipe defines any precision conversions. Separately quantized artifacts do not
+inherit the source recipe's certification.
+
+## FTW and NVMe execution
+
+FTW is SparkLab's self-contained fast-load checkpoint format. It stores model metadata,
+resident tensors, and routed-expert banks in indexed shards. Preparation can repack
+existing quantized weights or apply recipe-specific conversions, such as resident FP8
+storage. Check the exact recipe and artifact fingerprint before reusing a prepared model.
+
+In disk mode (`--moe-storage disk`), the runtime reads routed expert rows from local
+NVMe into bounded host staging buffers and a GPU expert cache. Resident weights, expert
+caches, KV and recurrent state, and workspaces still need to fit the unified-memory
+budget. `--moe-preload-all` instead requires the entire routed-expert bank to fit in
+memory. Swap is not counted as usable model capacity.
+
+Use `sparklab plan <recipe> --prepare` to check storage and memory requirements before
+downloading. Source conversion may need space for both the source checkpoint and the
+prepared artifact; prebuilt FTW downloads avoid that conversion. Disk-backed throughput
+and TTFT depend on NVMe performance and expert-cache residency.
 
 SparkLab can load additional uncataloged architectures, but only recipes returned by
 `sparklab models` are part of the supported GB10 portfolio. Direct conversion and serving

--- a/docs/models.md
+++ b/docs/models.md
@@ -31,8 +31,8 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | Model | Parameter | Quantization | Recipe | Status | tok/s | TTFT(s) |
 |---|---|---|---|---|---:|---:|
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
-| [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Certified | 67.79 | 0.329 |
-| [Qwen3.8-27B](https://huggingface.co/Inferact/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FTW + optional DFlash2-12 | `qwen3.8-27b` | Experimental | 45.88 | 0.152 |
+| [Qwen3.6-35B-A3B](https://huggingface.co/oakmindai/Qwen3.6-35B-A3B-NVFP4-FTW) | 35B total / 3B active | NVFP4 · FTW + optional MTP2 | `qwen3.6-35b-a3b` | Target-only certified; MTP2 certification pending | 80.55 | 0.367 |
+| [Qwen3.8-27B](https://huggingface.co/oakmindai/Qwen3.8-27B-NVFP4-FTW) | 27B dense | NVFP4 · FTW + optional DFlash2-12 | `qwen3.8-27b` | Experimental | 45.88 | 0.152 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + optional MTP3 | `qwen3.8-flash-next` | Experimental | 31.97 | 0.260 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 14.02 | 0.515 |
@@ -52,11 +52,11 @@ evidence attached to each recipe. Certification applies only to that exact check
 and recipe version. Portfolio performance and warm-TTFT columns use the selected
 single-stream profile; concurrent-serving results remain in model-specific evidence.
 
-Qwen3.6's published FTW artifact includes its native BF16 MTP weights, but the portfolio
-row continues to report the certified target-only profile. The optimized two-draft path
-measured 80.55 tok/s with 0.367 s warm TTFT on a 256-token GB10 probe and matched the
-fresh eager target-only output on that prompt; it remains opt-in pending the full
-certification suite.
+Qwen3.6's published FTW artifact includes its native BF16 MTP weights. The portfolio
+row reports the opt-in MTP2 profile: 80.55 tok/s with 0.367 s warm TTFT on a 256-token
+GB10 probe, matching the fresh eager target-only output on that prompt. Full MTP
+certification remains pending; the certified target-only profile measured 67.79 tok/s
+and 0.329 s warm TTFT.
 
 GLM-5.3 Flash's selected opt-in MTP3 profile measured a three-trial median of 7.77 tok/s
 and 6.395 s warm TTFT after eliminating rejection replay. All three trials reproduced

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,8 @@
 # SparkLab quick start
 
-Install the SparkLab distribution first; see [install.md](install.md). The supported
+Install SparkLab first; see [install.md](install.md). The Qwen3.8-Flash-Next recipe
+used below requires a [source installation](install.md#method-2-install-from-source);
+the released 0.1.2 wheel lacks its current checkpoint support. The supported
 production target is one NVIDIA GB10.
 
 ## 1. Inspect the machine
@@ -60,13 +62,16 @@ sparklab serve --model /path/to/checkpoint
 
 ## 4. Send a request
 
+Keep the server running and open a second terminal. The recipe above serves as
+`nvidia/Qwen3.8-Flash-Next-NVFP4`; for another recipe, use the ID returned by `/v1/models`.
+
 ```bash
 curl http://127.0.0.1:1919/v1/models
 
 curl http://127.0.0.1:1919/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
-    "model": "served-model-id",
+    "model": "nvidia/Qwen3.8-Flash-Next-NVFP4",
     "messages": [{"role": "user", "content": "Explain unified memory."}],
     "max_tokens": 256,
     "stream": true
@@ -78,7 +83,8 @@ Anthropic Messages API.
 
 ## 5. Use the terminal or a coding agent
 
-Use SparkLab's built-in terminal chat:
+In the second terminal, activate the same virtual environment, then use SparkLab's
+built-in terminal chat:
 
 ```bash
 sparklab shell


### PR DESCRIPTION
## Outcome

Correct README and linked setup guides so users can select the current source installation, follow working FTW documentation links, and send requests with the recipe’s actual served model ID. Clarify systemd executable setup and document disk-cache and document-chat options.

Keep Qwen3.6’s selected MTP2 result at 80.55 tok/s and 0.367 s warm TTFT, explicitly label its certification as pending, and distinguish the certified target-only profile. Link performance rows to versioned evidence and Qwen3.8-27B to the published Oakmind FTW model.

## Validation

- Checked all 27 README external URLs and external links in directly linked guides; the new Qwen3.8-27B FTW URL returns HTTP 200.
- Validated 95 local links and anchors across the README and directly linked Markdown guides.
- Parsed 22 concrete Bash examples and validated quick-start request JSON against the recipe’s served model ID.
- Passed CLI smoke checks for version, JSON catalog, and doctor/plan/pull/run/shell help.
- `git diff --check` passes. GPU inference was not rerun for these documentation changes.

## Checklist

- [x] The change is focused and contains no unrelated generated files or credentials.
- [x] Behavior changes include tests and relevant documentation. (Documentation only.)
- [x] Model, performance, or certification claims link exact versioned evidence.
- [x] Public API, package, artifact-format, or compatibility changes have a design issue. (Not applicable; documents existing behavior.)
- [x] Every commit includes a DCO `Signed-off-by` line.
- [x] I have the right to submit all code, data, and documentation in this pull request.
