### PR TITLE
perf(qwen38): add opt-in full-vocabulary MTP acceleration

### DIFF
--- a/benchmarks/bench_single_stream.py
+++ b/benchmarks/bench_single_stream.py
@@ -13,6 +13,8 @@ PROMPTS = {
     "math": "Find the sum of all integer bases b > 9 for which 17_b is a divisor of 97_b. Explain your reasoning and put the final answer in \\boxed{}.",
     "code": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
     "prose": "Explain how ocean navigation developed from coastal landmarks to celestial navigation and modern satellite systems. Write continuous prose with concrete examples of the limitations of each approach.",
+    "hashmap": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+    "chinese": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
 }
 
 def generate(base_url, prompt, tokens, thinking, model="qwen3.8-27b"):
@@ -67,7 +69,7 @@ def main():
 
         PROMPTS["aime"], _ = load_problem(None, 0)
     if any(name not in PROMPTS for name in workloads):
-        p.error("--workloads must contain math, code, prose, or aime")
+        p.error("--workloads must contain math, code, prose, hashmap, chinese, or aime")
     report = {"label": args.label, "model": args.model, "tokens": args.tokens,
               "thinking": args.thinking, "workloads": {}}
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/gb10/results/GB10-QWENNVIDIA-004.json
+++ b/benchmarks/gb10/results/GB10-QWENNVIDIA-004.json
@@ -1,0 +1,2442 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWENNVIDIA-004",
+  "status": "measured",
+  "platform": {
+    "device": "NVIDIA GB10",
+    "memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "driver": "580.126.09"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "revision": "80acbe5aee9548a6dae9f244dfa6d851f61fab42",
+    "git_tracked_dirty": true,
+    "kernel_cache_version_check_disabled": true,
+    "note": "Isolated development worktree. Existing pinned/radix extensions reused with source/cache version check bypass; not clean-revision certification."
+  },
+  "model": {
+    "repository": "nvidia/Qwen3.8-Flash-Next-NVFP4",
+    "revision": "fab0aecb760cec45227f6656abcaafa11abca87a",
+    "checkpoint_format": "ftw-nvfp4 + native FP8 MTP/PLE",
+    "fingerprint": "94e1ee0daa442357",
+    "payload_bytes": 131931279080
+  },
+  "workload": {
+    "date": "2026-09-06",
+    "concurrency": 1,
+    "trials_per_workload": 5,
+    "warmups_per_workload": 1,
+    "order": [
+      "aime",
+      "hashmap",
+      "code",
+      "chinese"
+    ],
+    "sampling": "temperature=0, ignore_eos=true for fixed-length speed only; thinking on only for aime",
+    "metric": "(completion_tokens - 1) / (last content chunk time - first content chunk time)",
+    "configuration": {
+      "speculative_method": "mtp",
+      "speculative_tokens": 3,
+      "draft_vocabulary": "full, 248320 tokens",
+      "target_resident_projections": "bf16",
+      "qsa_kv": "bf16",
+      "gdn_recurrent_state": "float32",
+      "expert_preload": 24576,
+      "nvfp4_backend": "triton",
+      "kv_token_capacity": 131072,
+      "max_seq_len_override": 8792,
+      "page_size": 16,
+      "cache_type": "radix resolves hybrid_radix",
+      "host_cache_gb": 0,
+      "prefill_overlap": false
+    },
+    "comparison_boundary": "Same native NVIDIA checkpoint and workload per baseline/candidate. Not a direct comparison to MiaAI/vLLM with a different checkpoint, precision and long-prose protocol."
+  },
+  "metrics": {
+    "profiles": {
+      "baseline-fixed-repeat": {
+        "environment": {
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "bf16",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "0",
+          "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+        },
+        "workloads": {
+          "aime": {
+            "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+            "thinking": true,
+            "trials": [
+              {
+                "decode_tokens_per_second": 31.87419594821494,
+                "ttft_seconds": 0.25808785000117496,
+                "elapsed_seconds": 4.242850212962367,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 32.64531679646092,
+                "ttft_seconds": 0.24800753605086356,
+                "elapsed_seconds": 4.138587275054306,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 32.57276241682192,
+                "ttft_seconds": 0.24781310296384618,
+                "elapsed_seconds": 4.1470628989627585,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 32.53798226495312,
+                "ttft_seconds": 0.25334098003804684,
+                "elapsed_seconds": 4.156751647009514,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 32.625727191979344,
+                "ttft_seconds": 0.2560439989902079,
+                "elapsed_seconds": 4.148967016953975,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              }
+            ],
+            "decode_tok_s_median": 32.57276241682192,
+            "ttft_seconds_median": 0.25334098003804684
+          },
+          "hashmap": {
+            "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 26.445192123702707,
+                "ttft_seconds": 0.2543626780388877,
+                "elapsed_seconds": 22.905248996044975,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "16bb5dcb93aac36fac7569acc8fa2d1ba9c778881f4f647c3fa106a8b54c6964"
+              },
+              {
+                "decode_tokens_per_second": 27.579718927315117,
+                "ttft_seconds": 0.2538366370135918,
+                "elapsed_seconds": 21.97387222200632,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "1a32c13daae3949669cc77b8d987dab276b8b262550b2833005bc5f3b3479a58"
+              },
+              {
+                "decode_tokens_per_second": 29.016145621379195,
+                "ttft_seconds": 0.261887147964444,
+                "elapsed_seconds": 20.90628147800453,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "a5e4832719b78059e0f67358a45ad1a08fece13da33e3c284496db5450881a71"
+              },
+              {
+                "decode_tokens_per_second": 28.175016617100713,
+                "ttft_seconds": 0.2546484599588439,
+                "elapsed_seconds": 21.51558521098923,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "3b9ab58f8ac0d13acda989f722437b668f7fd3bbb2f6f3b2f0d8454aef9fae0d"
+              },
+              {
+                "decode_tokens_per_second": 25.86414368569954,
+                "ttft_seconds": 0.2612059310195036,
+                "elapsed_seconds": 23.421312863996718,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "0f0f3492426558f255207ce4971240e71d5e5c79b459196033ce810b1232537e"
+              }
+            ],
+            "decode_tok_s_median": 27.579718927315117,
+            "ttft_seconds_median": 0.2546484599588439
+          },
+          "code": {
+            "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 32.359555837310005,
+                "ttft_seconds": 0.2914684659917839,
+                "elapsed_seconds": 16.08377811597893,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "8b287299df69fc58463df8b1795101bf3325927ff95a281d8c87472603be326e"
+              },
+              {
+                "decode_tokens_per_second": 33.66575733785229,
+                "ttft_seconds": 0.2858614280121401,
+                "elapsed_seconds": 15.464831769000739,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "6bf18939e3f722419559109c068ef51276ea2b6783a86ae50d22bcb25d160d80"
+              },
+              {
+                "decode_tokens_per_second": 32.24807709460173,
+                "ttft_seconds": 0.2834688799921423,
+                "elapsed_seconds": 16.129508549987804,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "22c294f497317ec83657eecb48ae665b3d7c4a040d0e122a9bb84b741484923f"
+              },
+              {
+                "decode_tokens_per_second": 34.06737583135861,
+                "ttft_seconds": 0.2887543370015919,
+                "elapsed_seconds": 15.288716380018741,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "0ece2eed94b79b54bc5321dfb7405ac87dd3ef0eba462cbc8d296ea9954705fe"
+              },
+              {
+                "decode_tokens_per_second": 33.923571271552206,
+                "ttft_seconds": 0.2837308539892547,
+                "elapsed_seconds": 15.348009623994585,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "8b287299df69fc58463df8b1795101bf3325927ff95a281d8c87472603be326e"
+              }
+            ],
+            "decode_tok_s_median": 33.66575733785229,
+            "ttft_seconds_median": 0.2858614280121401
+          },
+          "chinese": {
+            "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 30.966475237099303,
+                "ttft_seconds": 0.2402805809979327,
+                "elapsed_seconds": 19.58446137601277,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "385f2f6650104800a683c7ec0e34bba74669e15708b8ab51f89793e5a8ca9ecd"
+              },
+              {
+                "decode_tokens_per_second": 29.282915624018937,
+                "ttft_seconds": 0.2460845570312813,
+                "elapsed_seconds": 20.702462883025873,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "f0cd5fa36c86339161b90e7da5391c2b373195db67c61c95cb6bf338e60a0e46"
+              },
+              {
+                "decode_tokens_per_second": 29.276771131422834,
+                "ttft_seconds": 0.24210049799876288,
+                "elapsed_seconds": 20.702929279999807,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "b03d79830facfbd1944c41826ae3d4c497a4c60b29eec1240b21ff799addd893"
+              },
+              {
+                "decode_tokens_per_second": 28.33077404708815,
+                "ttft_seconds": 0.2448836750118062,
+                "elapsed_seconds": 21.388999483024236,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "9f00bb17884aefdcdd9b81dde402959707eb448208073819a3bba424ec1e4594"
+              },
+              {
+                "decode_tokens_per_second": 28.935627731104717,
+                "ttft_seconds": 0.24306816700845957,
+                "elapsed_seconds": 20.94502729200758,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "d88ee33f785481e2a5d4dcdf19a5d10af52f2e7c6fb955b161b535ec84ee50ec"
+              }
+            ],
+            "decode_tok_s_median": 29.276771131422834,
+            "ttft_seconds_median": 0.24306816700845957
+          }
+        },
+        "telemetry": {
+          "samples": 1447,
+          "duration_s": 1527.8764585150057,
+          "swap_start_bytes": 746127360,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 744251392,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 79888384,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 78192640,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -1695744
+            }
+          },
+          "power_w_avg": 45.61962681409814,
+          "power_w_peak": 67.88,
+          "temperature_c_peak": 69,
+          "utilization_pct_avg": 86.53559087767796,
+          "request_energy_j_est": 69701.15385550045,
+          "mem_available_gib_min": 29.46820831298828,
+          "nvme_temperature_c_peak": 54.85,
+          "swap_in_pages_delta": 589,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 31092267,
+          "major_faults_delta": 593,
+          "oom_kill_delta": 0
+        }
+      },
+      "candidate-fp8-light": {
+        "environment": {
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+        },
+        "workloads": {
+          "aime": {
+            "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+            "thinking": true,
+            "trials": [
+              {
+                "decode_tokens_per_second": 41.980871729905736,
+                "ttft_seconds": 0.2537983920192346,
+                "elapsed_seconds": 3.2792632289929315,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.147880467006786,
+                "ttft_seconds": 0.24442370096221566,
+                "elapsed_seconds": 3.2580076350132003,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.15413820014292,
+                "ttft_seconds": 0.24402077100239694,
+                "elapsed_seconds": 3.2571731749922037,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.13908026419058,
+                "ttft_seconds": 0.24309964600251988,
+                "elapsed_seconds": 3.2573178880265914,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.13150080591395,
+                "ttft_seconds": 0.24058199900900945,
+                "elapsed_seconds": 3.255353165033739,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              }
+            ],
+            "decode_tok_s_median": 42.13908026419058,
+            "ttft_seconds_median": 0.24402077100239694
+          },
+          "hashmap": {
+            "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 34.833356232854875,
+                "ttft_seconds": 0.24770654499297962,
+                "elapsed_seconds": 17.444849078019615,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "770d56434acb4f22b5242261b06843a17a3521e9e86762b14b53849ebe86c76b"
+              },
+              {
+                "decode_tokens_per_second": 34.81657172085351,
+                "ttft_seconds": 0.24692775402218103,
+                "elapsed_seconds": 17.452075896027964,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "bf38ee4d3951a95efa310c513ac5eb18c1ea54391d184377ed9b086ceeeab25c"
+              },
+              {
+                "decode_tokens_per_second": 32.8038439542053,
+                "ttft_seconds": 0.24653050198685378,
+                "elapsed_seconds": 18.50725737499306,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "e464c216fcc193ae85508e1df5d597c5ae1d732d7e60315bbd707608b0fe6110"
+              },
+              {
+                "decode_tokens_per_second": 34.13557685574901,
+                "ttft_seconds": 0.24612880003405735,
+                "elapsed_seconds": 17.794488960003946,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "1d60a0b0157f5b868c250fd2612b1fa44b5d58a9c7b35582535f1452c61f9c4d"
+              },
+              {
+                "decode_tokens_per_second": 34.2068268816413,
+                "ttft_seconds": 0.2480149359907955,
+                "elapsed_seconds": 17.759425649011973,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "9386cc23493c524fed45454a5acb9a1bd4d185dbaf571d6a1789770da6e3502e"
+              }
+            ],
+            "decode_tok_s_median": 34.2068268816413,
+            "ttft_seconds_median": 0.24692775402218103
+          },
+          "code": {
+            "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 37.95410311553864,
+                "ttft_seconds": 0.28026722703361884,
+                "elapsed_seconds": 13.744873741001356,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "8fe32fb6e0cae570184ab0f49cd06a525e7bb8fc28c6a1f0dc0f40fdaf256d70"
+              },
+              {
+                "decode_tokens_per_second": 38.15153110286989,
+                "ttft_seconds": 0.2778474680380896,
+                "elapsed_seconds": 13.672479254018981,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "df0f9f32cfd8e0f558f04bc6bf5a77ad8d21db88686981c9ab20f3612a2840c3"
+              },
+              {
+                "decode_tokens_per_second": 38.64305771006826,
+                "ttft_seconds": 0.2796721800114028,
+                "elapsed_seconds": 13.503909439023118,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "d34d898a0e3201516658b7d6f756ecd9cfcd1d2fb39bc657c29945f44d9beb25"
+              },
+              {
+                "decode_tokens_per_second": 39.76936868625414,
+                "ttft_seconds": 0.2793967839679681,
+                "elapsed_seconds": 13.128743162960745,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "3e2b617fe13792b015cc8822c24647895fd0210d102f7afe393283f2f62f0d37"
+              },
+              {
+                "decode_tokens_per_second": 40.632129793486676,
+                "ttft_seconds": 0.28030817897524685,
+                "elapsed_seconds": 12.856885209970642,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "6526842fe35198c8c00171a2aabd8f30e58542284a75c849edf8e55c6b88f8d3"
+              }
+            ],
+            "decode_tok_s_median": 38.64305771006826,
+            "ttft_seconds_median": 0.2796721800114028
+          },
+          "chinese": {
+            "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 37.303455302496964,
+                "ttft_seconds": 0.23178651503985748,
+                "elapsed_seconds": 16.289357295027003,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "8e78a4c488ca0a0a334bca5ae6cdd6416d0ee2ba4874d20e30dcfcd420c9a485"
+              },
+              {
+                "decode_tokens_per_second": 36.18014089792002,
+                "ttft_seconds": 0.23859181202715263,
+                "elapsed_seconds": 16.794917157036252,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "ea746693e8dde6d9943a72b96e79a8b650e138ab8223e7293fbb0ffd2983da3c"
+              },
+              {
+                "decode_tokens_per_second": 36.772210881848316,
+                "ttft_seconds": 0.23813968000467867,
+                "elapsed_seconds": 16.52774294099072,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "e14cd636c6935628bd7e4243624cd38b00261a98747a9583a54dc0a1bf404474"
+              },
+              {
+                "decode_tokens_per_second": 33.25913794336448,
+                "ttft_seconds": 0.23160724400077015,
+                "elapsed_seconds": 18.242604302009568,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "b36d3d65daaa7abd96654930be5c54ddeec0e841112175bfc9e306ebd0aafaea"
+              },
+              {
+                "decode_tokens_per_second": 35.63585015634741,
+                "ttft_seconds": 0.2352549889474176,
+                "elapsed_seconds": 17.044996723998338,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "f0cd5fa36c86339161b90e7da5391c2b373195db67c61c95cb6bf338e60a0e46"
+              }
+            ],
+            "decode_tok_s_median": 36.18014089792002,
+            "ttft_seconds_median": 0.2352549889474176
+          }
+        },
+        "telemetry": {
+          "samples": 1211,
+          "duration_s": 1276.343527133984,
+          "swap_start_bytes": 744116224,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 738041856,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 78061568,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 72044544,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -6017024
+            }
+          },
+          "power_w_avg": 48.364698596201485,
+          "power_w_peak": 68.68,
+          "temperature_c_peak": 71,
+          "utilization_pct_avg": 86.36746490503715,
+          "request_energy_j_est": 61729.969995047846,
+          "mem_available_gib_min": 28.667007446289062,
+          "nvme_temperature_c_peak": 54.85,
+          "swap_in_pages_delta": 1603,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 30073711,
+          "major_faults_delta": 899,
+          "oom_kill_delta": 0
+        }
+      },
+      "candidate-bf16-light": {
+        "environment": {
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "bf16",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+        },
+        "workloads": {
+          "aime": {
+            "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+            "thinking": true,
+            "trials": [
+              {
+                "decode_tokens_per_second": 36.57806073659535,
+                "ttft_seconds": 0.25723332504276186,
+                "elapsed_seconds": 3.729612220020499,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 36.571158805114145,
+                "ttft_seconds": 0.2455480580101721,
+                "elapsed_seconds": 3.7186433830065653,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 36.551706273870764,
+                "ttft_seconds": 0.24955954402685165,
+                "elapsed_seconds": 3.7244953390327282,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 36.55590591088905,
+                "ttft_seconds": 0.24990208802046254,
+                "elapsed_seconds": 3.724455696006771,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 36.563874967345434,
+                "ttft_seconds": 0.24751790601294488,
+                "elapsed_seconds": 3.7212895629927516,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              }
+            ],
+            "decode_tok_s_median": 36.563874967345434,
+            "ttft_seconds_median": 0.24955954402685165
+          },
+          "hashmap": {
+            "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 32.10362545720543,
+                "ttft_seconds": 0.2542849989840761,
+                "elapsed_seconds": 18.913082379032858,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "770d56434acb4f22b5242261b06843a17a3521e9e86762b14b53849ebe86c76b"
+              },
+              {
+                "decode_tokens_per_second": 31.854497950050263,
+                "ttft_seconds": 0.25705233501503244,
+                "elapsed_seconds": 19.06160658900626,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "bf38ee4d3951a95efa310c513ac5eb18c1ea54391d184377ed9b086ceeeab25c"
+              },
+              {
+                "decode_tokens_per_second": 30.07110603438496,
+                "ttft_seconds": 0.2553533799946308,
+                "elapsed_seconds": 20.175085912982468,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "e464c216fcc193ae85508e1df5d597c5ae1d732d7e60315bbd707608b0fe6110"
+              },
+              {
+                "decode_tokens_per_second": 31.416284261952654,
+                "ttft_seconds": 0.2583981570205651,
+                "elapsed_seconds": 19.32572797499597,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "1d60a0b0157f5b868c250fd2612b1fa44b5d58a9c7b35582535f1452c61f9c4d"
+              },
+              {
+                "decode_tokens_per_second": 30.96254969598645,
+                "ttft_seconds": 0.2547900369972922,
+                "elapsed_seconds": 19.601453075010795,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "8bebe13037494a99b1bceef9401be658191ddc2e4309b6408e4183a3ee552517"
+              }
+            ],
+            "decode_tok_s_median": 31.416284261952654,
+            "ttft_seconds_median": 0.2553533799946308
+          },
+          "code": {
+            "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 34.43380891062808,
+                "ttft_seconds": 0.28467867797007784,
+                "elapsed_seconds": 15.12551371898735,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "7d6de58ae6e974caf1feb6744bf586d9d154b14b8489d10886d4cbb133821e2c"
+              },
+              {
+                "decode_tokens_per_second": 35.55831130906167,
+                "ttft_seconds": 0.28649144899100065,
+                "elapsed_seconds": 14.658315362990834,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "6bf18939e3f722419559109c068ef51276ea2b6783a86ae50d22bcb25d160d80"
+              },
+              {
+                "decode_tokens_per_second": 35.95865763266887,
+                "ttft_seconds": 0.290481086994987,
+                "elapsed_seconds": 14.502242512011435,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "8fe32fb6e0cae570184ab0f49cd06a525e7bb8fc28c6a1f0dc0f40fdaf256d70"
+              },
+              {
+                "decode_tokens_per_second": 35.91721589311251,
+                "ttft_seconds": 0.2846632240107283,
+                "elapsed_seconds": 14.511956082016695,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "df0f9f32cfd8e0f558f04bc6bf5a77ad8d21db88686981c9ab20f3612a2840c3"
+              },
+              {
+                "decode_tokens_per_second": 35.46890670851492,
+                "ttft_seconds": 0.2856705680023879,
+                "elapsed_seconds": 14.692960655025672,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "d34d898a0e3201516658b7d6f756ecd9cfcd1d2fb39bc657c29945f44d9beb25"
+              }
+            ],
+            "decode_tok_s_median": 35.55831130906167,
+            "ttft_seconds_median": 0.2856705680023879
+          },
+          "chinese": {
+            "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 31.269736569298534,
+                "ttft_seconds": 0.23926448699785396,
+                "elapsed_seconds": 19.3955715369666,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "ec08f277313328881e228e88db8eb0be4115967c984eee603f821bf7ec1a85c9"
+              },
+              {
+                "decode_tokens_per_second": 33.6428914456407,
+                "ttft_seconds": 0.25081041996600106,
+                "elapsed_seconds": 18.056077359011397,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "9a6b8f4d9b1a25479bb275ef79baf23fbe460dea6877da14a4d93833fc873d10"
+              },
+              {
+                "decode_tokens_per_second": 32.0188370861574,
+                "ttft_seconds": 0.2488359980052337,
+                "elapsed_seconds": 18.957287478027865,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "74696235a9d9397c004dde150d65f89d63714f6b34b226384bc039102deded55"
+              },
+              {
+                "decode_tokens_per_second": 32.080939928296765,
+                "ttft_seconds": 0.2484172180411406,
+                "elapsed_seconds": 18.920716287044343,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "a043228d4eb678feea33609425e51104e2232b4c722dd0692b3b0aefb984a174"
+              },
+              {
+                "decode_tokens_per_second": 33.20455610529323,
+                "ttft_seconds": 0.24027228500926867,
+                "elapsed_seconds": 18.280780653003603,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "e13c77e444056732506d294931c1dc6e0c9ee4a9c2a34c9355428882de7211e3"
+              }
+            ],
+            "decode_tok_s_median": 32.080939928296765,
+            "ttft_seconds_median": 0.2484172180411406
+          }
+        },
+        "telemetry": {
+          "samples": 1245,
+          "duration_s": 1316.0011705289944,
+          "swap_start_bytes": 737812480,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 727400448,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 71815168,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 63676416,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -8138752
+            }
+          },
+          "power_w_avg": 47.165734939759034,
+          "power_w_peak": 67.88,
+          "temperature_c_peak": 70,
+          "utilization_pct_avg": 86.514859437751,
+          "request_energy_j_est": 62070.16238958318,
+          "mem_available_gib_min": 28.801387786865234,
+          "nvme_temperature_c_peak": 54.85,
+          "swap_in_pages_delta": 1674,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 29807483,
+          "major_faults_delta": 993,
+          "oom_kill_delta": 0
+        }
+      },
+      "baseline-schedule-fp8": {
+        "environment": {
+          "SPARKLAB_QWEN4_FAST_QSA_METADATA": "1",
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "0",
+          "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+        },
+        "workloads": {
+          "aime": {
+            "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+            "thinking": true,
+            "trials": [
+              {
+                "decode_tokens_per_second": 35.31167544607591,
+                "ttft_seconds": 0.254218433983624,
+                "elapsed_seconds": 3.8515286179608665,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 35.97053394093177,
+                "ttft_seconds": 0.2399942459887825,
+                "elapsed_seconds": 3.771277010033373,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 36.02114255448676,
+                "ttft_seconds": 0.23497660999419168,
+                "elapsed_seconds": 3.7614714719820768,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 36.07415126238872,
+                "ttft_seconds": 0.2427262340206653,
+                "elapsed_seconds": 3.7638753590290435,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 35.97553086382846,
+                "ttft_seconds": 0.23565785103710368,
+                "elapsed_seconds": 3.7665682950173505,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              }
+            ],
+            "decode_tok_s_median": 35.97553086382846,
+            "ttft_seconds_median": 0.2399942459887825
+          },
+          "hashmap": {
+            "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 29.40278775004706,
+                "ttft_seconds": 0.24735584802692756,
+                "elapsed_seconds": 20.619709883001633,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "a9ddd1ac906ce18f2a5c0692ce0cc98a1a0418e96be1a1d557cedf327f8c4878"
+              },
+              {
+                "decode_tokens_per_second": 30.185071876816345,
+                "ttft_seconds": 0.24927547702100128,
+                "elapsed_seconds": 20.094170283991843,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "57fc78e2c710fe4b529c179deed8a6246caeff026a2bcb32718bf124875d0b30"
+              },
+              {
+                "decode_tokens_per_second": 30.379495397643442,
+                "ttft_seconds": 0.2548227090155706,
+                "elapsed_seconds": 19.97307492600521,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "50975c98da941f2c8e5ce66a97386e8e2997432adfb267479f18106d5d1c2b9f"
+              },
+              {
+                "decode_tokens_per_second": 30.042533770927143,
+                "ttft_seconds": 0.25101106002693996,
+                "elapsed_seconds": 20.19048400101019,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "675393c6cbc310820dbc608ab9803d14856021399063cf3b7edf7367f7971d73"
+              },
+              {
+                "decode_tokens_per_second": 30.518249606213598,
+                "ttft_seconds": 0.2504001109628007,
+                "elapsed_seconds": 19.878684347961098,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "9f4e76d1c6cf850fb09251ae4ddad92af381caffab3d77e6676dd04a55f9a0bd"
+              }
+            ],
+            "decode_tok_s_median": 30.185071876816345,
+            "ttft_seconds_median": 0.2504001109628007
+          },
+          "code": {
+            "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 36.97170058714564,
+                "ttft_seconds": 0.2848039090167731,
+                "elapsed_seconds": 14.106976079987362,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "9238098138d7f719f10d8ae3e487e877f64ca4ce5ad920725457e0740ce6fbec"
+              },
+              {
+                "decode_tokens_per_second": 35.69801859279974,
+                "ttft_seconds": 0.27684327703900635,
+                "elapsed_seconds": 14.59165805001976,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "28cccb1a4d78a1bcc2ce1a59c5a913f957b7bb68e5acd6a49afa237b3783aacc"
+              },
+              {
+                "decode_tokens_per_second": 35.577499040372814,
+                "ttft_seconds": 0.28291764797177166,
+                "elapsed_seconds": 14.646741910954006,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "baa669f3cbabb48bf99a32e3976d86b8bde263c46692d3fddba6a826802c96f2"
+              },
+              {
+                "decode_tokens_per_second": 35.29791742818087,
+                "ttft_seconds": 0.27679852896835655,
+                "elapsed_seconds": 14.7539284430095,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "6bf18939e3f722419559109c068ef51276ea2b6783a86ae50d22bcb25d160d80"
+              },
+              {
+                "decode_tokens_per_second": 36.82241785622221,
+                "ttft_seconds": 0.28097530599916354,
+                "elapsed_seconds": 14.159205137984827,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "f4603a28ebd401d6c829f66a16c957fdc7f047d57d37b33e865bc2c5fcf5b552"
+              }
+            ],
+            "decode_tok_s_median": 35.69801859279974,
+            "ttft_seconds_median": 0.28097530599916354
+          },
+          "chinese": {
+            "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 34.211751519983125,
+                "ttft_seconds": 0.23457250895444304,
+                "elapsed_seconds": 17.743909599957988,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "a811c3e8815052a2af162a12b3b643ba4c84d7f35e3aacc8610a6a7ad5e110a8"
+              },
+              {
+                "decode_tokens_per_second": 30.051107976035894,
+                "ttft_seconds": 0.23154357902240008,
+                "elapsed_seconds": 20.164696262974758,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "ad2c4a9e8ef5665a0713f2d8c7435e4be28f1a70054213c3997344b294ddff9a"
+              },
+              {
+                "decode_tokens_per_second": 32.10797705426346,
+                "ttft_seconds": 0.23201424395665526,
+                "elapsed_seconds": 18.88899757398758,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "9f00bb17884aefdcdd9b81dde402959707eb448208073819a3bba424ec1e4594"
+              },
+              {
+                "decode_tokens_per_second": 30.954922008937405,
+                "ttft_seconds": 0.23576709697954357,
+                "elapsed_seconds": 19.587205018964596,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "af9a33898fc281c03bc58655a4748612aca980e7c437ba1109c62fcb115d0c3f"
+              },
+              {
+                "decode_tokens_per_second": 33.122348421545524,
+                "ttft_seconds": 0.23307372600538656,
+                "elapsed_seconds": 18.31835321499966,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "a19a874686922626e90ab0b1cc24c17641a9a5d045afcff048985584c9918072"
+              }
+            ],
+            "decode_tok_s_median": 32.10797705426346,
+            "ttft_seconds_median": 0.23307372600538656
+          }
+        },
+        "telemetry": {
+          "samples": 1280,
+          "duration_s": 1348.385806331993,
+          "swap_start_bytes": 726388736,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 724901888,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 62676992,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 61857792,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -819200
+            }
+          },
+          "power_w_avg": 46.5297421875,
+          "power_w_peak": 68,
+          "temperature_c_peak": 69,
+          "utilization_pct_avg": 85.38984375,
+          "request_energy_j_est": 62740.04393791194,
+          "mem_available_gib_min": 29.017868041992188,
+          "nvme_temperature_c_peak": 54.85,
+          "swap_in_pages_delta": 791,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 30065022,
+          "major_faults_delta": 866,
+          "oom_kill_delta": 0
+        }
+      },
+      "relaxed-fp8-fast-screen": {
+        "environment": {
+          "SPARKLAB_QWEN4_FAST_QSA_METADATA": "1",
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+        },
+        "speculative_tokens": 3,
+        "workloads": {
+          "aime": {
+            "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+            "thinking": true,
+            "trials": [
+              {
+                "decode_tokens_per_second": 42.10580437342033,
+                "ttft_seconds": 0.24705164297483861,
+                "elapsed_seconds": 3.263882503961213,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.24419737356593,
+                "ttft_seconds": 0.23453243501717225,
+                "elapsed_seconds": 3.241722034988925,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.30077942906403,
+                "ttft_seconds": 0.2435939809656702,
+                "elapsed_seconds": 3.2468662440078333,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.24511498628312,
+                "ttft_seconds": 0.24173708603484556,
+                "elapsed_seconds": 3.248736618028488,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 42.23704041345348,
+                "ttft_seconds": 0.2419134540250525,
+                "elapsed_seconds": 3.249723653018009,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              }
+            ],
+            "decode_tok_s_median": 42.24419737356593,
+            "ttft_seconds_median": 0.2419134540250525
+          },
+          "hashmap": {
+            "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 34.99472968875662,
+                "ttft_seconds": 0.2474206379847601,
+                "elapsed_seconds": 17.365270756999962,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "770d56434acb4f22b5242261b06843a17a3521e9e86762b14b53849ebe86c76b"
+              },
+              {
+                "decode_tokens_per_second": 35.01262651637658,
+                "ttft_seconds": 0.25437185500049964,
+                "elapsed_seconds": 17.36324296600651,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "bf38ee4d3951a95efa310c513ac5eb18c1ea54391d184377ed9b086ceeeab25c"
+              },
+              {
+                "decode_tokens_per_second": 32.87645374892128,
+                "ttft_seconds": 0.24501999700441957,
+                "elapsed_seconds": 18.46509122295538,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "e464c216fcc193ae85508e1df5d597c5ae1d732d7e60315bbd707608b0fe6110"
+              },
+              {
+                "decode_tokens_per_second": 34.29606692310371,
+                "ttft_seconds": 0.2530032299691811,
+                "elapsed_seconds": 17.719381299975794,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "1d60a0b0157f5b868c250fd2612b1fa44b5d58a9c7b35582535f1452c61f9c4d"
+              },
+              {
+                "decode_tokens_per_second": 34.37240893517388,
+                "ttft_seconds": 0.2484218419995159,
+                "elapsed_seconds": 17.675260771007743,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "9386cc23493c524fed45454a5acb9a1bd4d185dbaf571d6a1789770da6e3502e"
+              }
+            ],
+            "decode_tok_s_median": 34.37240893517388,
+            "ttft_seconds_median": 0.2484218419995159
+          },
+          "code": {
+            "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 38.11670910286664,
+                "ttft_seconds": 0.2802951880148612,
+                "elapsed_seconds": 13.686845046002418,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "8fe32fb6e0cae570184ab0f49cd06a525e7bb8fc28c6a1f0dc0f40fdaf256d70"
+              },
+              {
+                "decode_tokens_per_second": 38.241738122207735,
+                "ttft_seconds": 0.2780904700048268,
+                "elapsed_seconds": 13.640744749980513,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "df0f9f32cfd8e0f558f04bc6bf5a77ad8d21db88686981c9ab20f3612a2840c3"
+              },
+              {
+                "decode_tokens_per_second": 38.701592394048625,
+                "ttft_seconds": 0.28007489000447094,
+                "elapsed_seconds": 13.48392662301194,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "d34d898a0e3201516658b7d6f756ecd9cfcd1d2fb39bc657c29945f44d9beb25"
+              },
+              {
+                "decode_tokens_per_second": 39.834810562935495,
+                "ttft_seconds": 0.28204156196443364,
+                "elapsed_seconds": 13.110794451960828,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "3e2b617fe13792b015cc8822c24647895fd0210d102f7afe393283f2f62f0d37"
+              },
+              {
+                "decode_tokens_per_second": 40.65871292515796,
+                "ttft_seconds": 0.2771716709830798,
+                "elapsed_seconds": 12.845949737005867,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "6526842fe35198c8c00171a2aabd8f30e58542284a75c849edf8e55c6b88f8d3"
+              }
+            ],
+            "decode_tok_s_median": 38.701592394048625,
+            "ttft_seconds_median": 0.28007489000447094
+          },
+          "chinese": {
+            "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 37.427045096480065,
+                "ttft_seconds": 0.234739453997463,
+                "elapsed_seconds": 16.24001462099841,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "8e78a4c488ca0a0a334bca5ae6cdd6416d0ee2ba4874d20e30dcfcd420c9a485"
+              },
+              {
+                "decode_tokens_per_second": 36.17161470549137,
+                "ttft_seconds": 0.2305651560309343,
+                "elapsed_seconds": 16.79129683302017,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "ea746693e8dde6d9943a72b96e79a8b650e138ab8223e7293fbb0ffd2983da3c"
+              },
+              {
+                "decode_tokens_per_second": 36.87382318560467,
+                "ttft_seconds": 0.23657503398135304,
+                "elapsed_seconds": 16.48197203996824,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "e14cd636c6935628bd7e4243624cd38b00261a98747a9583a54dc0a1bf404474"
+              },
+              {
+                "decode_tokens_per_second": 33.69202106254814,
+                "ttft_seconds": 0.23331254097865894,
+                "elapsed_seconds": 18.012860172020737,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "b36d3d65daaa7abd96654930be5c54ddeec0e841112175bfc9e306ebd0aafaea"
+              },
+              {
+                "decode_tokens_per_second": 35.87818780729111,
+                "ttft_seconds": 0.23186315799830481,
+                "elapsed_seconds": 16.927535771974362,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "f0cd5fa36c86339161b90e7da5391c2b373195db67c61c95cb6bf338e60a0e46"
+              }
+            ],
+            "decode_tok_s_median": 36.17161470549137,
+            "ttft_seconds_median": 0.23331254097865894
+          }
+        },
+        "telemetry": {
+          "samples": 434,
+          "duration_s": 455.325093461026,
+          "swap_start_bytes": 724164608,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 720785408,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 61120512,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 57753600,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -3366912
+            }
+          },
+          "power_w_avg": 44.93841013824885,
+          "power_w_peak": 69.01,
+          "temperature_c_peak": 74,
+          "utilization_pct_avg": 77.27649769585254,
+          "request_energy_j_est": 20461.585796188076,
+          "mem_available_gib_min": 29.001483917236328,
+          "nvme_temperature_c_peak": 54.85,
+          "swap_in_pages_delta": 882,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 26320518,
+          "major_faults_delta": 543,
+          "oom_kill_delta": 0
+        }
+      },
+      "relaxed-fp8-mtp4-screen": {
+        "environment": {
+          "SPARKLAB_QWEN4_FAST_QSA_METADATA": "0",
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_MTP4": "1",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+        },
+        "speculative_tokens": 4,
+        "workloads": {
+          "aime": {
+            "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+            "thinking": true,
+            "trials": [
+              {
+                "decode_tokens_per_second": 41.010868144366384,
+                "ttft_seconds": 0.25331589503912255,
+                "elapsed_seconds": 3.3503209420014173,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 41.635505632531135,
+                "ttft_seconds": 0.24090824101585895,
+                "elapsed_seconds": 3.2914547999971546,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 41.631687894504246,
+                "ttft_seconds": 0.24225293897325173,
+                "elapsed_seconds": 3.2930857929750346,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 41.724153077460365,
+                "ttft_seconds": 0.24501194700133055,
+                "elapsed_seconds": 3.2888761749491096,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              },
+              {
+                "decode_tokens_per_second": 41.63837923546566,
+                "ttft_seconds": 0.24547198601067066,
+                "elapsed_seconds": 3.2958301629987545,
+                "usage": {
+                  "prompt_tokens": 96,
+                  "completion_tokens": 128,
+                  "total_tokens": 224
+                },
+                "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+              }
+            ],
+            "decode_tok_s_median": 41.635505632531135,
+            "ttft_seconds_median": 0.24501194700133055
+          },
+          "hashmap": {
+            "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 34.53142366402502,
+                "ttft_seconds": 0.2501445359666832,
+                "elapsed_seconds": 17.597351698961575,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "770d56434acb4f22b5242261b06843a17a3521e9e86762b14b53849ebe86c76b"
+              },
+              {
+                "decode_tokens_per_second": 35.38627220210816,
+                "ttft_seconds": 0.24987537902779877,
+                "elapsed_seconds": 17.177990230033174,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "bf38ee4d3951a95efa310c513ac5eb18c1ea54391d184377ed9b086ceeeab25c"
+              },
+              {
+                "decode_tokens_per_second": 32.74652665697882,
+                "ttft_seconds": 0.2514326759846881,
+                "elapsed_seconds": 18.54374704399379,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "e464c216fcc193ae85508e1df5d597c5ae1d732d7e60315bbd707608b0fe6110"
+              },
+              {
+                "decode_tokens_per_second": 34.44447073324469,
+                "ttft_seconds": 0.2552756490185857,
+                "elapsed_seconds": 17.64647249697009,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "740b122731dcca817f2f0b56716d9083f7a84a603969a0d15494e2636ba43480"
+              },
+              {
+                "decode_tokens_per_second": 37.35924103866278,
+                "ttft_seconds": 0.25042976799886674,
+                "elapsed_seconds": 16.284076737007126,
+                "usage": {
+                  "prompt_tokens": 39,
+                  "completion_tokens": 600,
+                  "total_tokens": 639
+                },
+                "output_sha256": "d5e11ba01fb3d6a411e4c949d0445b7fb7f502870818715f256cb37076322e0a"
+              }
+            ],
+            "decode_tok_s_median": 34.53142366402502,
+            "ttft_seconds_median": 0.25042976799886674
+          },
+          "code": {
+            "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 40.78274946203318,
+                "ttft_seconds": 0.2836237109731883,
+                "elapsed_seconds": 12.81368693796685,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "ecf3e1b3787fc8cdfd78dee46e0a718d1278117448080e28e79a3ef787dac199"
+              },
+              {
+                "decode_tokens_per_second": 40.6286301711546,
+                "ttft_seconds": 0.2875852040015161,
+                "elapsed_seconds": 12.865610682987608,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "a4c00b27d9b1934d6e4b482499da14fb2d834ba847ab3058e0e66396aeea97fe"
+              },
+              {
+                "decode_tokens_per_second": 41.128388254539914,
+                "ttft_seconds": 0.28512431698618457,
+                "elapsed_seconds": 12.710464862990193,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "df0f9f32cfd8e0f558f04bc6bf5a77ad8d21db88686981c9ab20f3612a2840c3"
+              },
+              {
+                "decode_tokens_per_second": 42.01714887672902,
+                "ttft_seconds": 0.28557689796434715,
+                "elapsed_seconds": 12.447970153996721,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "d34d898a0e3201516658b7d6f756ecd9cfcd1d2fb39bc657c29945f44d9beb25"
+              },
+              {
+                "decode_tokens_per_second": 41.69068379119147,
+                "ttft_seconds": 0.28420914901653305,
+                "elapsed_seconds": 12.54194661701331,
+                "usage": {
+                  "prompt_tokens": 53,
+                  "completion_tokens": 512,
+                  "total_tokens": 565
+                },
+                "output_sha256": "8b287299df69fc58463df8b1795101bf3325927ff95a281d8c87472603be326e"
+              }
+            ],
+            "decode_tok_s_median": 41.128388254539914,
+            "ttft_seconds_median": 0.28512431698618457
+          },
+          "chinese": {
+            "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+            "thinking": false,
+            "trials": [
+              {
+                "decode_tokens_per_second": 35.24676937514336,
+                "ttft_seconds": 0.24009086895966902,
+                "elapsed_seconds": 17.23543759097811,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "8b7449635ebb9c3b600d2558db1ed607bba65b3b698380a60a8765f8e22468e1"
+              },
+              {
+                "decode_tokens_per_second": 34.92542252197742,
+                "ttft_seconds": 0.23808369401376694,
+                "elapsed_seconds": 17.389597920991946,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "d2810996c3f40715cf4dffe41dd0ba9cd12d59fd7a1efaac97d98ac59c1f7103"
+              },
+              {
+                "decode_tokens_per_second": 39.01275264970333,
+                "ttft_seconds": 0.23695591499563307,
+                "elapsed_seconds": 15.591748265956994,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "8e78a4c488ca0a0a334bca5ae6cdd6416d0ee2ba4874d20e30dcfcd420c9a485"
+              },
+              {
+                "decode_tokens_per_second": 34.69409153681887,
+                "ttft_seconds": 0.23555509303696454,
+                "elapsed_seconds": 17.50087008299306,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "8349a42e2cd551800d2d2969c54d0eaab4edfc0db5293ad43803cab1b226a52b"
+              },
+              {
+                "decode_tokens_per_second": 35.305256247031245,
+                "ttft_seconds": 0.24253668100573123,
+                "elapsed_seconds": 17.209699948027264,
+                "usage": {
+                  "prompt_tokens": 37,
+                  "completion_tokens": 600,
+                  "total_tokens": 637
+                },
+                "output_sha256": "12926f62092d7e8a73e9faacf00ce7a29818c23a977f7f3e63c059ac83c11752"
+              }
+            ],
+            "decode_tok_s_median": 35.24676937514336,
+            "ttft_seconds_median": 0.23808369401376694
+          }
+        },
+        "telemetry": {
+          "samples": 454,
+          "duration_s": 477.5964148279745,
+          "swap_start_bytes": 720670720,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 716472320,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 57638912,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 53444608,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -4194304
+            }
+          },
+          "power_w_avg": 46.497797356828194,
+          "power_w_peak": 68.35,
+          "temperature_c_peak": 70,
+          "utilization_pct_avg": 77.99339207048457,
+          "request_energy_j_est": 22207.181315018814,
+          "mem_available_gib_min": 29.432151794433594,
+          "nvme_temperature_c_peak": 55.85,
+          "swap_in_pages_delta": 938,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 26154785,
+          "major_faults_delta": 561,
+          "oom_kill_delta": 0
+        }
+      }
+    },
+    "candidate_improvement_percent": {
+      "aime": 29.36907138839482,
+      "hashmap": 24.028917668782523,
+      "code": 14.784459836344489,
+      "chinese": 23.579682798721556
+    },
+    "fp8_draft_copy_gib": 0.5929660797119141,
+    "bf16_redraft_improvement_percent": {
+      "aime": 12.252913951388855,
+      "hashmap": 13.910821008541108,
+      "code": 5.62159927732111,
+      "chinese": 9.578135458606663
+    },
+    "baseline_schedule_fp8_improvement_percent": {
+      "aime": 10.446668303604522,
+      "hashmap": 9.446626183419404,
+      "code": 6.036582615839348,
+      "chinese": 9.670485553654107
+    }
+  },
+  "validation": {
+    "recommendation": "Under a provisional two-point fixed math-subset quality budget (94/100 -> 92/100), candidate-fp8-light remains the recommended opt-in: metadata reuse adds no meaningful speed and MTP4 has mixed workload results with no MGSM score. It does not meet a no-quality-drop requirement. Original recipe/default and portfolio remain unchanged. The target-FP8 projection screen in GB10-QWENNVIDIA-005 was also not selected for speed and cannot inherit this profile's quality results.",
+    "default_changed": false,
+    "portfolio_metrics_changed": false,
+    "checkpoint_bytes_requantized": false,
+    "target_precision_changed": false,
+    "separate_draft_head_quantized": true,
+    "full_vocabulary_retained": true,
+    "math_output_hash_parity": true,
+    "long_output_hash_parity": false,
+    "smoke": {
+      "cases": 52,
+      "baseline_strict_passed": 41,
+      "baseline_answer_correct": 42,
+      "target_only_strict_passed": 42,
+      "target_only_answer_correct": 43,
+      "candidate_strict_passed": 42,
+      "candidate_answer_correct": 43,
+      "paired_candidate_regressions": []
+    },
+    "mgsm": {
+      "source": "https://github.com/google-research/url-nlp/tree/452a21ad3dae5668c06ceeac21ff073e1e40f9be/mgsm",
+      "license": "CC-BY-4.0",
+      "sha256": {
+        "en": "50021d0f28cc957edcb44e7806425b1c7fbd648ddcb9e0a8ec689d10e57d40fa",
+        "zh": "b2fa63151022370a0de1f4211c8c284eae74b0f5a3b003b1d5982c0d4a73f661"
+      },
+      "indices_per_language": [
+        2,
+        7,
+        12,
+        17,
+        22,
+        27,
+        32,
+        37,
+        42,
+        47,
+        52,
+        57,
+        62,
+        67,
+        72,
+        77,
+        82,
+        87,
+        92,
+        97,
+        102,
+        107,
+        112,
+        117,
+        122,
+        127,
+        132,
+        137,
+        142,
+        147,
+        152,
+        157,
+        162,
+        167,
+        172,
+        177,
+        182,
+        187,
+        192,
+        197,
+        202,
+        207,
+        212,
+        217,
+        222,
+        227,
+        232,
+        237,
+        242,
+        247
+      ],
+      "protocol": "zero-shot; thinking off; temperature 0; max_tokens 1536; FINAL numeric match",
+      "total": 100,
+      "baseline_passed": 94,
+      "candidate_passed": 92,
+      "baseline_by_language": {
+        "en": 50,
+        "zh": 44
+      },
+      "candidate_by_language": {
+        "en": 49,
+        "zh": 43
+      },
+      "baseline_failed_ids": [
+        "mgsm-zh-12",
+        "mgsm-zh-42",
+        "mgsm-zh-62",
+        "mgsm-zh-87",
+        "mgsm-zh-157",
+        "mgsm-zh-162"
+      ],
+      "candidate_failed_ids": [
+        "mgsm-en-87",
+        "mgsm-zh-12",
+        "mgsm-zh-42",
+        "mgsm-zh-62",
+        "mgsm-zh-157",
+        "mgsm-zh-162",
+        "mgsm-zh-172",
+        "mgsm-zh-187"
+      ],
+      "new_regressions": [
+        "mgsm-en-87",
+        "mgsm-zh-172",
+        "mgsm-zh-187"
+      ],
+      "improvements": [
+        "mgsm-zh-87"
+      ],
+      "regression_details": {
+        "mgsm-en-87": "Baseline FINAL=9360 in509 tokens; candidate hits1536-token limit without FINAL.",
+        "mgsm-zh-172": "Baseline FINAL=51 in919 tokens; candidate disputes interpretation and truncates at1536 without FINAL.",
+        "mgsm-zh-187": "Baseline FINAL=106; candidate FINAL=106.12 (compound rather than dataset simple-interest interpretation). Gold/scoring unchanged."
+      }
+    },
+    "lifecycle": {
+      "candidate_passed": 15,
+      "total": 15,
+      "checks": "9 output budgets, stop-string, 2 multi-turn replacements, 3 streamed-disconnect recovery probes",
+      "cache_error_scan": "No AssertionError/Traceback/ERROR/illegal memory/out-of-memory in completed short-cap server log."
+    },
+    "extended_candidate": {
+      "max_seq_len_override": 32768,
+      "actual_recall_prompt_tokens": [
+        11735,
+        11735,
+        11735
+      ],
+      "passed": 15,
+      "total": 15,
+      "paired_regressions_vs_target_only": [],
+      "lifecycle_passed": 15,
+      "lifecycle_total": 15,
+      "telemetry": {
+        "samples": 196,
+        "duration_s": 203.22571249102475,
+        "swap_start_bytes": 738033664,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 737869824,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "swap_max": "max",
+            "swap_current_bytes": 72036352,
+            "swap_peak_bytes": 2587770880,
+            "oom_kill": 0
+          },
+          "end": {
+            "swap_max": "max",
+            "swap_current_bytes": 71872512,
+            "swap_peak_bytes": 2587770880,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": -163840
+          }
+        },
+        "power_w_avg": 40.92316326530612,
+        "power_w_peak": 65.2,
+        "temperature_c_peak": 70,
+        "utilization_pct_avg": 60.464285714285715,
+        "request_energy_j_est": 8316.639011978368,
+        "mem_available_gib_min": 27.697341918945312,
+        "nvme_temperature_c_peak": 55.85,
+        "swap_in_pages_delta": 52,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 24481326,
+        "major_faults_delta": 306,
+        "oom_kill_delta": 0
+      },
+      "shutdown_warning": "multiprocessing resource_tracker reported four semaphore objects for cleanup; no cache-integrity assertion or CUDA/OOM error observed."
+    },
+    "tests": {
+      "cpu_passed": 1602,
+      "cpu_skipped": 81,
+      "gpu_gdn_prefix_vs_replay_passed": 18,
+      "new_file_ruff": "passed",
+      "git_diff_check": "passed",
+      "gpu_qsa_metadata_bitwise_passed": 33,
+      "note": "Latest CPU suite includes opt-in Qwen4 MTP4 family limits, 36 chunked-prefill watermark cases, and five-row metadata capacity. GPU QSA tests cover five-row verification metadata. MTP4 startup, speed/smoke/lifecycle screen completed; its MGSM subset has not run."
+    },
+    "limits": [
+      "One fixed100-case EN/ZH MGSM subset, not the full500 cases or canonical few-shot protocol.",
+      "No general quality equivalence,64K recall,concurrency or full endurance certification.",
+      "Correctness is measured at the same fixed token budget; mentions of a gold number before truncation do not count as a final answer.",
+      "The fixed100-case EN/ZH MGSM subset was used during tuning; it is not an independent held-out final certification."
+    ],
+    "bf16_redraft": {
+      "smoke": {
+        "strict_passed": 42,
+        "answer_correct": 43,
+        "total": 52
+      },
+      "mgsm": {
+        "total": 100,
+        "passed": 93,
+        "by_language": {
+          "en": 49,
+          "zh": 44
+        },
+        "failed_ids": [
+          "mgsm-en-87",
+          "mgsm-zh-12",
+          "mgsm-zh-42",
+          "mgsm-zh-62",
+          "mgsm-zh-157",
+          "mgsm-zh-162",
+          "mgsm-zh-187"
+        ],
+        "new_regressions": [
+          "mgsm-en-87",
+          "mgsm-zh-187"
+        ],
+        "improvements": [
+          "mgsm-zh-87"
+        ],
+        "attribution": "Restoring BF16 draft-head precision does not remove these immediate-redraft regressions. Neither draft precision nor scheduling should be blamed alone without component ablations."
+      },
+      "lifecycle": {
+        "passed": 15,
+        "total": 15
+      },
+      "extended": {
+        "max_seq_len_override": 32768,
+        "actual_recall_prompt_tokens": [
+          11735,
+          11735,
+          11735
+        ],
+        "passed": 15,
+        "total": 15,
+        "lifecycle_passed": 15,
+        "lifecycle_total": 15,
+        "telemetry": {
+          "samples": 197,
+          "duration_s": 204.83170610002708,
+          "swap_start_bytes": 727379968,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 726515712,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 63655936,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 62803968,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -851968
+            }
+          },
+          "power_w_avg": 41.07670050761421,
+          "power_w_peak": 65.07,
+          "temperature_c_peak": 68,
+          "utilization_pct_avg": 60.7258883248731,
+          "request_energy_j_est": 8413.810645934467,
+          "mem_available_gib_min": 28.29104995727539,
+          "nvme_temperature_c_peak": 55.85,
+          "swap_in_pages_delta": 166,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 24495760,
+          "major_faults_delta": 311,
+          "oom_kill_delta": 0
+        }
+      }
+    },
+    "quality_budget": {
+      "provisional": true,
+      "date": "2026-09-06",
+      "reference_passed": 94,
+      "minimum_subset_passed": 92,
+      "total": 100,
+      "scope": "Provisional budget on the existing fixed EN/ZH MGSM subset only, not a bound on general-task accuracy loss.",
+      "original_profile_retained": true
+    },
+    "baseline_schedule_fp8": {
+      "smoke": {
+        "strict_passed": 41,
+        "answer_correct": 42,
+        "total": 52
+      },
+      "mgsm": {
+        "passed": 94,
+        "total": 100,
+        "by_language": {
+          "en": 49,
+          "zh": 45
+        },
+        "new_regressions": [
+          "mgsm-en-12"
+        ],
+        "improvements": [
+          "mgsm-zh-87"
+        ],
+        "note": "Same aggregate score does not imply identical answers or zero per-case regression."
+      },
+      "lifecycle": {
+        "passed": 15,
+        "total": 15
+      },
+      "extended": {
+        "passed": 15,
+        "total": 15,
+        "lifecycle_passed": 15,
+        "lifecycle_total": 15,
+        "max_seq_len_override": 32768,
+        "actual_recall_prompt_tokens": [
+          11735,
+          11735,
+          11735
+        ],
+        "telemetry": {
+          "samples": 195,
+          "duration_s": 202.23522917897208,
+          "swap_start_bytes": 724869120,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 724541440,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "swap_max": "max",
+              "swap_current_bytes": 61825024,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "end": {
+              "swap_max": "max",
+              "swap_current_bytes": 61497344,
+              "swap_peak_bytes": 2587770880,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -327680
+            }
+          },
+          "power_w_avg": 41.351128205128205,
+          "power_w_peak": 65.11,
+          "temperature_c_peak": 67,
+          "utilization_pct_avg": 62.38974358974359,
+          "request_energy_j_est": 8362.65488937316,
+          "mem_available_gib_min": 28.101253509521484,
+          "nvme_temperature_c_peak": 55.85,
+          "swap_in_pages_delta": 65,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 24539808,
+          "major_faults_delta": 276,
+          "oom_kill_delta": 0
+        },
+        "shutdown_warning": "Four multiprocessing semaphore objects reported for cleanup at shutdown."
+      },
+      "provenance": {
+        "source_manifest": "baseline-schedule-fp8-source.json",
+        "source_manifest_sha256": "ca524acb32574d806fbf903eadc50386b876f7df7bc5209824a239a2992d7435",
+        "source_diff_sha256": "939d8fe2ae05361ef0ea380d1706dfb277f4f243bed50609721457634de55fa6",
+        "source_files_sha256": {
+          "python/sparklab/models/qwen4_exp/model.py": "93355037407d08ed72f11465277cc77dba4424b06936423adef3635e23c7e0b5",
+          "python/sparklab/runtime/engine/engine.py": "e606c1e92773e184b6d3af9392b1c00297df886b77395b40993c80d9b12d6bf3",
+          "python/sparklab/runtime/scheduler/prefill.py": "d320bda8e21dbc17cf890da731a38d2b61cbc65e03f0a03b3ca9ea1d97f4bad2",
+          "python/sparklab/runtime/kvcache/linear_state_pool.py": "8775d9a5d22b15e2678f212f354731914d3b66a0e24108af3a97a140ae419c6b",
+          "python/sparklab/attention/qsa.py": "077f45a07d26fdb70c8fea452bb27d249b4fde725942d0dd210f8fb8e7c1da2b",
+          "benchmarks/quality/qwen4_regression.py": "306995df56e55b5bd6e6c1a9a70cce27fff2256e1d98df62dee083c4a5aeb262",
+          "benchmarks/bench_single_stream.py": "b9f62626e92b43e53b8f6bf955b73bcebbd1013818086490210f54f0dda4a50c",
+          "tests/models/test_qwen4_exp.py": "02f5ee4a2726c9aa29015f635257e02da0977d9e05ef572167493477fd823005",
+          "tests/models/test_qwen4_qsa_metadata.py": "64523ebcb9c541e88dbd30afb954f3eaf563fa060a75276f52c16d1fc38b0b84"
+        },
+        "extended_source_manifest": "baseline-schedule-fp8-extended-source.json",
+        "extended_source_manifest_sha256": "ca524acb32574d806fbf903eadc50386b876f7df7bc5209824a239a2992d7435"
+      }
+    },
+    "screens": {
+      "relaxed-fp8-fast-screen": {
+        "status": "complete",
+        "smoke": {
+          "strict_passed": 42,
+          "answer_correct": 43,
+          "total": 52
+        },
+        "lifecycle": {
+          "passed": 15,
+          "total": 15
+        },
+        "mgsm": "Not run for this speed screen; do not inherit candidate-fp8-light's 92/100 score.",
+        "change_percent_vs_candidate_fp8_light": {
+          "aime": 0.24945278519683534,
+          "hashmap": 0.48406142465511337,
+          "code": 0.15147529064478693,
+          "chinese": -0.02356594589474348
+        },
+        "decision": "No meaningful speed gain: all workload median changes are within 0.5%. Do not add FAST_QSA_METADATA to the recommended fast profile.",
+        "test_overlap_note": "A brief CPU-only regression suite ran during this exploratory screen; GPU/model jobs were serial. This is not a clean isolated microbenchmark of sub-percent differences.",
+        "provenance": {
+          "source_manifest": "relaxed-fp8-fast-screen-source.json",
+          "source_manifest_sha256": "09cb5d55983ee7e1ed8b53ce0cbd17e214436d9dca72bb135f3ff14d9dfe7b7e",
+          "source_diff_sha256": "939d8fe2ae05361ef0ea380d1706dfb277f4f243bed50609721457634de55fa6",
+          "source_files_sha256": {
+            "python/sparklab/models/qwen4_exp/model.py": "93355037407d08ed72f11465277cc77dba4424b06936423adef3635e23c7e0b5",
+            "python/sparklab/runtime/engine/engine.py": "e606c1e92773e184b6d3af9392b1c00297df886b77395b40993c80d9b12d6bf3",
+            "python/sparklab/runtime/scheduler/prefill.py": "d320bda8e21dbc17cf890da731a38d2b61cbc65e03f0a03b3ca9ea1d97f4bad2",
+            "python/sparklab/runtime/kvcache/linear_state_pool.py": "8775d9a5d22b15e2678f212f354731914d3b66a0e24108af3a97a140ae419c6b",
+            "python/sparklab/attention/qsa.py": "077f45a07d26fdb70c8fea452bb27d249b4fde725942d0dd210f8fb8e7c1da2b",
+            "benchmarks/quality/qwen4_regression.py": "306995df56e55b5bd6e6c1a9a70cce27fff2256e1d98df62dee083c4a5aeb262",
+            "benchmarks/bench_single_stream.py": "b9f62626e92b43e53b8f6bf955b73bcebbd1013818086490210f54f0dda4a50c",
+            "tests/models/test_qwen4_exp.py": "02f5ee4a2726c9aa29015f635257e02da0977d9e05ef572167493477fd823005",
+            "tests/models/test_qwen4_qsa_metadata.py": "64523ebcb9c541e88dbd30afb954f3eaf563fa060a75276f52c16d1fc38b0b84",
+            "tests/models/test_qwen4_reject_draft.py": "f24bf941d63963cfddfa7385926d015646625eaf58d71060bddfc505cbf58d80",
+            "python/sparklab/kernels/triton/qwen4_skinny.py": "938762a5aa40cb4810004bef589502eb1cc3f57428258d6ce51e98e4953c507c",
+            "tests/runtime/kvcache/test_linear_state_pool_alloc.py": "578be602612d3abf0d751ebaae90b3c1c7d481d37e1687a6dcbd2dd0dff2edf4",
+            "tests/runtime/scheduler/test_scheduler_chunked_prefill.py": "ed16ea5012300c36aa8fee8dd64e43c73e6b9d69262ed1551fe971b5e63e0c6a"
+          }
+        }
+      },
+      "relaxed-fp8-mtp4-screen": {
+        "status": "complete",
+        "smoke": {
+          "strict_passed": 42,
+          "answer_correct": 43,
+          "total": 52
+        },
+        "lifecycle": {
+          "passed": 15,
+          "total": 15
+        },
+        "mgsm": "Not run for this speed screen; no evidence that MTP4 meets the accepted 92/100 budget.",
+        "change_percent_vs_candidate_fp8_light": {
+          "aime": -1.195029954385074,
+          "hashmap": 0.9489239779733261,
+          "code": 6.431505920464753,
+          "chinese": -2.5797896293718425
+        },
+        "decision": "Mixed workload trade-off, not a general replacement: code improves, math and Chinese regress. Keep MTP3 as recommendation; MTP4 remains opt-in research pending its own full quality evaluation.",
+        "provenance": {
+          "source_manifest": "relaxed-fp8-mtp4-screen-source.json",
+          "source_manifest_sha256": "2484a8c0894681c5fa39c157f6b74b34351a7447bf74005a475ade38000646a9",
+          "source_diff_sha256": "cdb82d1a16f5d620d862291240dd2d74d4b23ab9fd04a6dd0e9a7a5e153b94c4",
+          "source_files_sha256": {
+            "python/sparklab/models/qwen4_exp/model.py": "93355037407d08ed72f11465277cc77dba4424b06936423adef3635e23c7e0b5",
+            "python/sparklab/runtime/engine/engine.py": "5c72fafb4b72b1874693dd10b8aa805a88e7ffe76f4e7d35b83e1a3e1dfdadce",
+            "python/sparklab/runtime/scheduler/prefill.py": "d320bda8e21dbc17cf890da731a38d2b61cbc65e03f0a03b3ca9ea1d97f4bad2",
+            "python/sparklab/runtime/kvcache/linear_state_pool.py": "8775d9a5d22b15e2678f212f354731914d3b66a0e24108af3a97a140ae419c6b",
+            "python/sparklab/attention/qsa.py": "60d9211ef374df2fbf641e89bb3df2d8113de33f4710ef120dc0fc3a680e67ea",
+            "benchmarks/quality/qwen4_regression.py": "306995df56e55b5bd6e6c1a9a70cce27fff2256e1d98df62dee083c4a5aeb262",
+            "benchmarks/bench_single_stream.py": "b9f62626e92b43e53b8f6bf955b73bcebbd1013818086490210f54f0dda4a50c",
+            "tests/models/test_qwen4_exp.py": "02f5ee4a2726c9aa29015f635257e02da0977d9e05ef572167493477fd823005",
+            "tests/models/test_qwen4_qsa_metadata.py": "2b5ebd5f252f907ee27c7ecc58b3d0bd985ef83b8f6b1813c229d28a7f639635",
+            "tests/models/test_qwen4_reject_draft.py": "dbc6d2f47901c8bd354074071371301defc6d45d07814472d8376ec302ea8ca1",
+            "python/sparklab/kernels/triton/qwen4_skinny.py": "938762a5aa40cb4810004bef589502eb1cc3f57428258d6ce51e98e4953c507c",
+            "tests/runtime/kvcache/test_linear_state_pool_alloc.py": "578be602612d3abf0d751ebaae90b3c1c7d481d37e1687a6dcbd2dd0dff2edf4",
+            "tests/runtime/scheduler/test_scheduler_chunked_prefill.py": "243e44ef85d946a2a4b734723b85cc5b69cfc7eacfb8c85e14b0055f13da89cf"
+          }
+        }
+      }
+    }
+  },
+  "source": {
+    "summary": "Native full-vocabulary speculative optimizations: immediate redraft, optional proposal-only FP8 head, smaller verification snapshots and exact metadata reuse. All measured trade-offs retained under a provisional two-point fixed-subset quality budget.",
+    "raw_artifact": "$HOME/results/qwen38-quality-opt/",
+    "raw_artifact_sha256": {
+      "baseline-fixed-repeat.json": "c4547f00a395a04b52d68f1bc18f185f365ab540aa5387a627b37d23c4b39a59",
+      "baseline-fixed-repeat-server.log": "a52e8a950764aa0c9ca2c71f26b7735fe7708e9517c19c9b0fd15629b2d63a5e",
+      "baseline-fixed-repeat-quality.json": "c4c7d32c5311e3d276cfdb6a3f00e5227bc1a8fe505086d8e25e785cb9a33fce",
+      "baseline-fixed-repeat-mgsm.json": "6e276ba36ee2903c06af70acfab7455d6940b11b611e6045d90bc5c01c9cbc5f",
+      "candidate-fp8-light.json": "00e8642723c93db7bef5e6c95c0d5bb94426e7d2aefec528a91d6e1f3278ca03",
+      "candidate-fp8-light-server.log": "ead50cba605f789f90c89a1de96e0d5e342742c920b38f44cf913a294b0541f9",
+      "candidate-fp8-light-quality.json": "c6e340e6fc2b1d5b4dda7cec1f4bced026d8f7f386115c5485eb4ccb8ef6c7cb",
+      "candidate-fp8-light-mgsm.json": "c47b1cd3c8a678d68f5a46dfec8ca6e95f74db325bb17fea080ecfe3e75e3bb8",
+      "candidate-fp8-light-lifecycle.json": "5000c453bbe4cb8d5701bb455cbd18311be02caf49602df87d56803e2ac2d751",
+      "target-quality-quality.json": "9c9d2f7af52a9e80466802c0b4ac446ad2d8944740b2df237c22a34abd41eee6",
+      "target-extended-extended-quality.json": "82f8956aff566862db45a7509acb2032ef80f55854350db967ca28c24538b4a6",
+      "candidate-fp8-light-extended.json": "2c065b31f709143caf7028ac2021c6d87b6d14f10f2f42fd46f2e67277dcc3a8",
+      "candidate-fp8-light-extended-server.log": "05432c295cb6425414460e58ea9f555864f5907405daa36c35c974d0450d45bd",
+      "candidate-fp8-light-extended-extended-quality.json": "f99af21f2fa46b2892665832938c387909d373e4dbd3c8fb7e70fda1e1e98e14",
+      "candidate-fp8-light-extended-lifecycle.json": "73dc51b75c1ece4c4eb0a33004fb12e132524089988c3e6c0761c15ba12a4b21",
+      "candidate-bf16-light.json": "6a30dcf67c770762185b91fe27edd93edb27306923a22ec9f584d3d718bf1dc6",
+      "candidate-bf16-light-server.log": "4f011a7c8275ad42d3d7eb5acd068f1af62544eeda1f436a4aa66cc79d44c3d2",
+      "candidate-bf16-light-quality.json": "c6e340e6fc2b1d5b4dda7cec1f4bced026d8f7f386115c5485eb4ccb8ef6c7cb",
+      "candidate-bf16-light-mgsm.json": "dfdda49e8ac9a4ad2a6549c8159a23d37c3f4c1903dd31989dc3e76af8ec2912",
+      "candidate-bf16-light-lifecycle.json": "0d9827b1dab580c017992fe0f51b069bee93824eef87f3bc34d37611e6ef127b",
+      "candidate-bf16-light-extended.json": "92e35f79d4abcd31491904577747755a207dd3c3cd8600222117606180dc67f3",
+      "candidate-bf16-light-extended-server.log": "a41a70bb1705ac39cf4045d9dbc04078a436f0e2ac5f6c88ce8e3bc0e198aca4",
+      "candidate-bf16-light-extended-extended-quality.json": "eed18c3c07006a94464f272ae6be541df4b4f5df009a49a7985ee107573616c0",
+      "candidate-bf16-light-extended-lifecycle.json": "b74d34d4e020cc70e1b292e43d686cb67c1e0c394015e321b7d5edbaae77e36f",
+      "baseline-schedule-fp8-extended-extended-quality.json": "ed231ad36314aac4c9531f90db85fbb04a6abe77cad6a2fb15971d522de1fe23",
+      "baseline-schedule-fp8-extended-lifecycle.json": "766d7ac43f8c2b2ec4468f0b0797e2b8a0f67668fba4133de4c876aeda0d9d6b",
+      "baseline-schedule-fp8-extended-source.json": "ca524acb32574d806fbf903eadc50386b876f7df7bc5209824a239a2992d7435",
+      "baseline-schedule-fp8-extended.json": "d31a2d2913a3980c4746f8c608a4ccb4d049a47588604cacf50cee6eee9992b7",
+      "baseline-schedule-fp8-lifecycle.json": "932ba6661d5b1a5d8ee21d9a2e8ca4dc806bd8488aa994d8a6a71b9e1ad83759",
+      "baseline-schedule-fp8-mgsm.json": "d0afc3dcfb866034fd73bff6fb22bcdfadcf9e721d88678a909df620d4f08cc7",
+      "baseline-schedule-fp8-quality.json": "4c26977854ccee1767a73c16375a3a5e64ed2e67c0704ced5ed1b6c58c5154d7",
+      "baseline-schedule-fp8-source.json": "ca524acb32574d806fbf903eadc50386b876f7df7bc5209824a239a2992d7435",
+      "baseline-schedule-fp8.json": "3d37b7b6e464403312483a4228253fddee47a424bbd2d435e22546fdb9d77973",
+      "baseline-schedule-fp8-extended-server.log": "bb0e4d6396c0856ba0ae83618fb1d0c2d7330c88589c7faad3443f745a179c06",
+      "baseline-schedule-fp8-server.log": "9016da5d10fe9fc264dd230b1781cf871a992618ba0e32e0b2f7feb37b6a1149",
+      "relaxed-fp8-fast-screen-lifecycle.json": "c4138b8a07acf9588a228cae911a9c6ce8aabb4ae4b5350673516c90bf9a1697",
+      "relaxed-fp8-fast-screen-quality.json": "c6e340e6fc2b1d5b4dda7cec1f4bced026d8f7f386115c5485eb4ccb8ef6c7cb",
+      "relaxed-fp8-fast-screen-source.json": "09cb5d55983ee7e1ed8b53ce0cbd17e214436d9dca72bb135f3ff14d9dfe7b7e",
+      "relaxed-fp8-fast-screen.json": "517a3838d4ca53b5dc093a4b35fe7c05b6e13946b5f9fb1ba836b9f3652c2125",
+      "relaxed-fp8-fast-screen-server.log": "3f33860bc71d0f666ce448a72e6090a9e23c36fad9aecb336fe9c6ffc31a254a",
+      "relaxed-fp8-mtp4-screen-lifecycle.json": "c98f9f6b12ba273145ffd303d5441a581473436f4602473d51e5ac895765e420",
+      "relaxed-fp8-mtp4-screen-quality.json": "e761cb3545d9377a1473a5da74eea64789e39b3d56c02b44c6ba2268492f98a8",
+      "relaxed-fp8-mtp4-screen-source.json": "2484a8c0894681c5fa39c157f6b74b34351a7447bf74005a475ade38000646a9",
+      "relaxed-fp8-mtp4-screen.json": "10552056ece48824ce916a61deb0d9b6320f6755daa98e32b831668e0b9f2f74",
+      "relaxed-fp8-mtp4-screen-server.log": "ccecdb7bbc4613c1c57f8cdde8499699b0e4da3fdc8c90db620b860f9ad34dcf"
+    },
+    "candidate_started_utc": "2026-09-06T16:46:12.059440+00:00",
+    "candidate_source_files_sha256": {
+      "python/sparklab/models/qwen4_exp/model.py": "a6b97e10ddd7ac21dde3232cad82973bea06feffb469677899a6ef5649784a72",
+      "python/sparklab/runtime/engine/engine.py": "8b36269039277d92c5b0164577d9dd1d09410357ecd7344a58d6b41e629a42fe",
+      "python/sparklab/runtime/scheduler/prefill.py": "d320bda8e21dbc17cf890da731a38d2b61cbc65e03f0a03b3ca9ea1d97f4bad2",
+      "benchmarks/quality/qwen4_regression.py": "306995df56e55b5bd6e6c1a9a70cce27fff2256e1d98df62dee083c4a5aeb262"
+    },
+    "candidate_source_diff_sha256": "db76a16043fc6991ea4d9f9b3e3217e330ba9031c911731778433e736cd9875d",
+    "provenance_limit": "Baseline predates per-file source snapshot logging. Candidate capture omitted linear_state_pool.py; original QSA four-query allocation was active. A disabled MTP4 config experiment was present during this run and removed afterward; it did not affect width3.",
+    "bf16_redraft_provenance": {
+      "started_utc": "2026-09-06T17:11:02.732970+00:00",
+      "source_files_sha256": {
+        "python/sparklab/models/qwen4_exp/model.py": "a6b97e10ddd7ac21dde3232cad82973bea06feffb469677899a6ef5649784a72",
+        "python/sparklab/runtime/engine/engine.py": "e606c1e92773e184b6d3af9392b1c00297df886b77395b40993c80d9b12d6bf3",
+        "python/sparklab/runtime/scheduler/prefill.py": "d320bda8e21dbc17cf890da731a38d2b61cbc65e03f0a03b3ca9ea1d97f4bad2",
+        "python/sparklab/runtime/kvcache/linear_state_pool.py": "8775d9a5d22b15e2678f212f354731914d3b66a0e24108af3a97a140ae419c6b",
+        "python/sparklab/attention/qsa.py": "9fac049425bdd187eaee6ef32df56fde7b52964815f6cb63e812b9a03a1a7331",
+        "benchmarks/quality/qwen4_regression.py": "306995df56e55b5bd6e6c1a9a70cce27fff2256e1d98df62dee083c4a5aeb262"
+      },
+      "source_diff_sha256": "8904ec1a9124c2a21bf1b6bb34c4cf93636d407c9259f41aeaffbba2d07a3b69"
+    }
+  }
+}

--- a/benchmarks/gb10/results/GB10-QWENNVIDIA-005.json
+++ b/benchmarks/gb10/results/GB10-QWENNVIDIA-005.json
@@ -1,0 +1,798 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWENNVIDIA-005",
+  "status": "measured",
+  "platform": {
+    "device": "NVIDIA GB10",
+    "memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "driver": "580.126.09"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "revision": "80acbe5aee9548a6dae9f244dfa6d851f61fab42",
+    "git_tracked_dirty": true,
+    "kernel_cache_version_check_disabled": true,
+    "note": "Isolated development worktree. Existing pinned/radix extensions reused with source/cache version check bypass; not clean-revision certification."
+  },
+  "model": {
+    "repository": "nvidia/Qwen3.8-Flash-Next-NVFP4",
+    "revision": "fab0aecb760cec45227f6656abcaafa11abca87a",
+    "checkpoint_format": "ftw-nvfp4 + native FP8 MTP/PLE",
+    "fingerprint": "94e1ee0daa442357",
+    "payload_bytes": 131931279080,
+    "runtime_target_projection_storage": "per-row FP8 W8A16; checkpoint bytes, target LM head and embeddings unchanged"
+  },
+  "workload": {
+    "date": "2026-09-06",
+    "concurrency": 1,
+    "trials_per_workload": 5,
+    "warmups_per_workload": 1,
+    "order": [
+      "aime",
+      "hashmap",
+      "code",
+      "chinese"
+    ],
+    "sampling": "temperature=0, ignore_eos=true for fixed-length speed only; thinking on only for aime",
+    "metric": "(completion_tokens - 1) / (last content chunk time - first content chunk time)",
+    "configuration": {
+      "speculative_method": "mtp",
+      "speculative_tokens": 3,
+      "draft_vocabulary": "full, 248320 tokens",
+      "target_resident_projections": "fp8",
+      "qsa_kv": "bf16",
+      "gdn_recurrent_state": "float32",
+      "expert_preload": 24576,
+      "nvfp4_backend": "triton",
+      "kv_token_capacity": 131072,
+      "max_seq_len_override": 8792,
+      "page_size": 16,
+      "cache_type": "radix resolves hybrid_radix",
+      "host_cache_gb": 0,
+      "prefill_overlap": false
+    },
+    "comparison_boundary": "Same NVIDIA checkpoint, MTP3, full draft vocabulary, proposal-only FP8 head, immediate redraft and light snapshots; target resident projection storage changes from BF16 to FP8. All requests C1. No runtime model/test contention during timed requests."
+  },
+  "metrics": {
+    "comparison_result": "GB10-QWENNVIDIA-004",
+    "comparison_profile": "candidate-fp8-light",
+    "comparison_workloads": {
+      "aime": {
+        "decode_tok_s_median": 42.13908026419058,
+        "ttft_seconds_median": 0.24402077100239694
+      },
+      "hashmap": {
+        "decode_tok_s_median": 34.2068268816413,
+        "ttft_seconds_median": 0.24692775402218103
+      },
+      "code": {
+        "decode_tok_s_median": 38.64305771006826,
+        "ttft_seconds_median": 0.2796721800114028
+      },
+      "chinese": {
+        "decode_tok_s_median": 36.18014089792002,
+        "ttft_seconds_median": 0.2352549889474176
+      }
+    },
+    "candidate": {
+      "environment": {
+        "SPARKLAB_QWEN4_FAST_QSA_METADATA": "0",
+        "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+        "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+        "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+        "SPARKLAB_QWEN4_MTP4": "0",
+        "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+        "SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK": "1"
+      },
+      "server_argv": [
+        "$HOME/projects/freetoken/.venv/bin/python",
+        "-m",
+        "sparklab.cli",
+        "serve",
+        "--model",
+        "$HOME/models/qwen38-nvidia/prepared/fab0aecb760c",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "1938",
+        "--moe-backend",
+        "offload",
+        "--nvfp4-backend",
+        "triton",
+        "--moe-storage",
+        "disk",
+        "--moe-host-cache-gb",
+        "0.0",
+        "--max-running-requests",
+        "1",
+        "--max-seq-len-override",
+        "8792",
+        "--attention-backend",
+        "qsa",
+        "--page-size",
+        "16",
+        "--cache-type",
+        "radix",
+        "--memory-ratio",
+        "0.9",
+        "--cuda-graph-max-bs",
+        "1",
+        "--moe-hybrid-max-fetch",
+        "-1",
+        "--moe-cache-policy",
+        "lru",
+        "--speculative-method",
+        "mtp",
+        "--speculative-tokens",
+        "3",
+        "--draft-sample-method",
+        "greedy",
+        "--dspark-confidence-threshold",
+        "0.0",
+        "--dspark-draft-cache-slots",
+        "0",
+        "--dspark-draft-cache-quotas",
+        "",
+        "--dsv4-kv-storage",
+        "bf16",
+        "--dsv4-index-storage",
+        "bf16",
+        "--qwen4-dense-storage",
+        "fp8",
+        "--num-tokens",
+        "131072",
+        "--disable-moe-prefill-overlap",
+        "--moe-preload-all",
+        "--moe-collect-stats",
+        "--moe-cache-size",
+        "24576"
+      ],
+      "workloads": {
+        "aime": {
+          "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+          "thinking": true,
+          "trials": [
+            {
+              "decode_tokens_per_second": 35.92282362514978,
+              "ttft_seconds": 0.2559185459977016,
+              "elapsed_seconds": 3.7921121370163746,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "output_sha256": "07779a4d1fe443e33fe628449169fe549341c71ceb90cc5e41063ccb3dacb66b"
+            },
+            {
+              "decode_tokens_per_second": 36.159051308960294,
+              "ttft_seconds": 0.23771257302723825,
+              "elapsed_seconds": 3.7508730760309845,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "output_sha256": "07779a4d1fe443e33fe628449169fe549341c71ceb90cc5e41063ccb3dacb66b"
+            },
+            {
+              "decode_tokens_per_second": 36.22409820205944,
+              "ttft_seconds": 0.23714513197774068,
+              "elapsed_seconds": 3.744103538978379,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "output_sha256": "07779a4d1fe443e33fe628449169fe549341c71ceb90cc5e41063ccb3dacb66b"
+            },
+            {
+              "decode_tokens_per_second": 36.20265885957405,
+              "ttft_seconds": 0.23821808496722952,
+              "elapsed_seconds": 3.747044104966335,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "output_sha256": "07779a4d1fe443e33fe628449169fe549341c71ceb90cc5e41063ccb3dacb66b"
+            },
+            {
+              "decode_tokens_per_second": 36.273849192432245,
+              "ttft_seconds": 0.23688835196662694,
+              "elapsed_seconds": 3.738698158005718,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "output_sha256": "07779a4d1fe443e33fe628449169fe549341c71ceb90cc5e41063ccb3dacb66b"
+            }
+          ],
+          "decode_tok_s_median": 36.20265885957405,
+          "ttft_seconds_median": 0.23771257302723825
+        },
+        "hashmap": {
+          "prompt": "Write a detailed step-by-step explanation of how a hash map works, including collision handling, resizing, and time complexity. Be thorough.",
+          "thinking": false,
+          "trials": [
+            {
+              "decode_tokens_per_second": 33.408700802298256,
+              "ttft_seconds": 0.24469423398841172,
+              "elapsed_seconds": 18.175175232987385,
+              "usage": {
+                "prompt_tokens": 39,
+                "completion_tokens": 600,
+                "total_tokens": 639
+              },
+              "output_sha256": "fee87043573c8e8d0fb0850fba3ecd293606dfbb8808a9aaead118194dac6cc5"
+            },
+            {
+              "decode_tokens_per_second": 36.100835750942316,
+              "ttft_seconds": 0.2478807430015877,
+              "elapsed_seconds": 16.841459218994714,
+              "usage": {
+                "prompt_tokens": 39,
+                "completion_tokens": 600,
+                "total_tokens": 639
+              },
+              "output_sha256": "73e8bc6c4db438171323f6abdb1316552ac84112135134cc0316bb809b71443d"
+            },
+            {
+              "decode_tokens_per_second": 34.02602610675266,
+              "ttft_seconds": 0.24570678803138435,
+              "elapsed_seconds": 17.85077614604961,
+              "usage": {
+                "prompt_tokens": 39,
+                "completion_tokens": 600,
+                "total_tokens": 639
+              },
+              "output_sha256": "e002c82a74ec8f447ec118849db73596b1ca927b4c4b7e27b3108ee95934a384"
+            },
+            {
+              "decode_tokens_per_second": 35.12492960317594,
+              "ttft_seconds": 0.244581623992417,
+              "elapsed_seconds": 17.298287131008692,
+              "usage": {
+                "prompt_tokens": 39,
+                "completion_tokens": 600,
+                "total_tokens": 639
+              },
+              "output_sha256": "4613a19340174ac73798eb57fcd40b467ca8a43d9cec4d3cc74686ce3c646ec5"
+            },
+            {
+              "decode_tokens_per_second": 33.216603994581604,
+              "ttft_seconds": 0.2489714359981008,
+              "elapsed_seconds": 18.283005627978127,
+              "usage": {
+                "prompt_tokens": 39,
+                "completion_tokens": 600,
+                "total_tokens": 639
+              },
+              "output_sha256": "f86fdb64314aa92c0c9beb6d541f19d6f7e8969e4df545ef73841be8e9781a92"
+            }
+          ],
+          "decode_tok_s_median": 34.02602610675266,
+          "ttft_seconds_median": 0.24570678803138435
+        },
+        "code": {
+          "prompt": "Implement a Python LRU cache using a doubly linked list and a dictionary. Include get and put methods, a capacity check, and tests covering updates, eviction, and capacity one. Explain the invariants.",
+          "thinking": false,
+          "trials": [
+            {
+              "decode_tokens_per_second": 36.00101557391889,
+              "ttft_seconds": 0.2766616510343738,
+              "elapsed_seconds": 14.471294704009779,
+              "usage": {
+                "prompt_tokens": 53,
+                "completion_tokens": 512,
+                "total_tokens": 565
+              },
+              "output_sha256": "aedeb9e26e361dd349e7d1703211cfa0f475ff581ddbed3ffe733da72a9c377a"
+            },
+            {
+              "decode_tokens_per_second": 38.595318655434845,
+              "ttft_seconds": 0.2793938199756667,
+              "elapsed_seconds": 13.520039767958224,
+              "usage": {
+                "prompt_tokens": 53,
+                "completion_tokens": 512,
+                "total_tokens": 565
+              },
+              "output_sha256": "1a68e291186419a315ee9d5b93ef29c56340ede9439fb586b8818d68a18456b1"
+            },
+            {
+              "decode_tokens_per_second": 38.8246565498166,
+              "ttft_seconds": 0.27997243899153545,
+              "elapsed_seconds": 13.442729717004113,
+              "usage": {
+                "prompt_tokens": 53,
+                "completion_tokens": 512,
+                "total_tokens": 565
+              },
+              "output_sha256": "080893b9326c24a1ddf1c40f7c65cbade2c1de9dd369014a0439aeacdc2ee9a9"
+            },
+            {
+              "decode_tokens_per_second": 38.77682343527308,
+              "ttft_seconds": 0.27505723299691454,
+              "elapsed_seconds": 13.453758368035778,
+              "usage": {
+                "prompt_tokens": 53,
+                "completion_tokens": 512,
+                "total_tokens": 565
+              },
+              "output_sha256": "bbc355f0b44e256a671af20112fd665990621486e8614e810e9757e7f98987ad"
+            },
+            {
+              "decode_tokens_per_second": 39.365657435779326,
+              "ttft_seconds": 0.276534239994362,
+              "elapsed_seconds": 13.257908520987257,
+              "usage": {
+                "prompt_tokens": 53,
+                "completion_tokens": 512,
+                "total_tokens": 565
+              },
+              "output_sha256": "080893b9326c24a1ddf1c40f7c65cbade2c1de9dd369014a0439aeacdc2ee9a9"
+            }
+          ],
+          "decode_tok_s_median": 38.77682343527308,
+          "ttft_seconds_median": 0.2766616510343738
+        },
+        "chinese": {
+          "prompt": "请用中文详细解释哈希表的工作原理，包括哈希冲突、扩容、负载因子以及时间复杂度，并给出具体例子。",
+          "thinking": false,
+          "trials": [
+            {
+              "decode_tokens_per_second": 32.68374708829222,
+              "ttft_seconds": 0.23766940698260441,
+              "elapsed_seconds": 18.565933261008468,
+              "usage": {
+                "prompt_tokens": 37,
+                "completion_tokens": 600,
+                "total_tokens": 637
+              },
+              "output_sha256": "5146c3b3a574b7554308113fd0db9ab9d780a606dace294a7a45a4d248f3df2c"
+            },
+            {
+              "decode_tokens_per_second": 31.668355611387092,
+              "ttft_seconds": 0.2310320459655486,
+              "elapsed_seconds": 19.14612703601597,
+              "usage": {
+                "prompt_tokens": 37,
+                "completion_tokens": 600,
+                "total_tokens": 637
+              },
+              "output_sha256": "19396efb9633fb6312fca7c7846f43db070193fc7686e5d9ce9188017d6b1fda"
+            },
+            {
+              "decode_tokens_per_second": 32.393717945448614,
+              "ttft_seconds": 0.23573320196010172,
+              "elapsed_seconds": 18.72729069000343,
+              "usage": {
+                "prompt_tokens": 37,
+                "completion_tokens": 600,
+                "total_tokens": 637
+              },
+              "output_sha256": "d58d4f95f6a6d4613747d391b6f35df10c555e5dafd91b6e54174b34ef7cfd1c"
+            },
+            {
+              "decode_tokens_per_second": 33.577561458725945,
+              "ttft_seconds": 0.23430220899172127,
+              "elapsed_seconds": 18.073914777021855,
+              "usage": {
+                "prompt_tokens": 37,
+                "completion_tokens": 600,
+                "total_tokens": 637
+              },
+              "output_sha256": "ed8ebca929dfb0c356af8dd69740de5d71473f9d361cef2d55d8e7d28355e5d5"
+            },
+            {
+              "decode_tokens_per_second": 35.366513928430464,
+              "ttft_seconds": 0.22974937001708895,
+              "elapsed_seconds": 17.166923440003302,
+              "usage": {
+                "prompt_tokens": 37,
+                "completion_tokens": 600,
+                "total_tokens": 637
+              },
+              "output_sha256": "499f7189549a8f9d8fa266a6b45a0e4bcda03883dd08e033c8aa2fccdddf9682"
+            }
+          ],
+          "decode_tok_s_median": 32.68374708829222,
+          "ttft_seconds_median": 0.23430220899172127
+        }
+      },
+      "telemetry": {
+        "samples": 466,
+        "duration_s": 485.5452551409835,
+        "swap_start_bytes": 716414976,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 715534336,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "swap_max": "max",
+            "swap_current_bytes": 53387264,
+            "swap_peak_bytes": 2587770880,
+            "oom_kill": 0
+          },
+          "end": {
+            "swap_max": "max",
+            "swap_current_bytes": 52506624,
+            "swap_peak_bytes": 2587770880,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": -880640
+          }
+        },
+        "power_w_avg": 42.9581974248927,
+        "power_w_peak": 68.64,
+        "temperature_c_peak": 69,
+        "utilization_pct_avg": 78.66094420600858,
+        "request_energy_j_est": 20858.14892906627,
+        "mem_available_gib_min": 32.32687759399414,
+        "nvme_temperature_c_peak": 55.85,
+        "swap_in_pages_delta": 260,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 25831303,
+        "major_faults_delta": 355,
+        "oom_kill_delta": 0
+      }
+    },
+    "change_percent_vs_accepted_fast_profile": {
+      "aime": -14.087686222381201,
+      "hashmap": -0.5285517289113861,
+      "code": 0.3461571964838761,
+      "chinese": -9.66384796425379
+    }
+  },
+  "validation": {
+    "status": "complete_speed_smoke_lifecycle_screen",
+    "recommendation": "Not selected for speed. Math and Chinese are materially slower; prose and code are nearly unchanged. Keep the BF16 target projections with the accepted candidate-fp8-light profile.",
+    "quality_budget": {
+      "provisional": true,
+      "date": "2026-09-06",
+      "reference_passed": 94,
+      "minimum_subset_passed": 92,
+      "total": 100,
+      "scope": "Provisional budget on the existing fixed EN/ZH MGSM subset only, not a bound on general-task accuracy loss.",
+      "original_profile_retained": true
+    },
+    "mgsm": "Not run: speed screen does not justify a full MGSM evaluation for recommendation. The accepted profile's 92/100 score must not be assigned to this target-FP8 candidate.",
+    "smoke": {
+      "strict_passed": 41,
+      "answer_correct": 42,
+      "total": 52,
+      "accepted_fast_profile_strict_passed": 42,
+      "accepted_fast_profile_answer_correct": 43,
+      "new_answer_regressions_vs_accepted_fast_profile": [
+        "remainder-4"
+      ],
+      "cases": [
+        {
+          "name": "multiply-0",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-1",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-2",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-3",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-4",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-5",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-6",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-7",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-8",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-9",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-10",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-11",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-12",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-13",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-14",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-15",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-16",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-17",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-18",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-19",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-20",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-21",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-22",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "multiply-23",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "remainder-0",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-1",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-2",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-3",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-4",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-5",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-6",
+          "passed": false,
+          "answer_correct": true
+        },
+        {
+          "name": "remainder-7",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-8",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-9",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "remainder-10",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "remainder-11",
+          "passed": false,
+          "answer_correct": false
+        },
+        {
+          "name": "recall-0",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-1",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-2",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-3",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-4",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-5",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-6",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "recall-7",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-0",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-1",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-2",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-3",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-4",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-5",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-6",
+          "passed": true,
+          "answer_correct": true
+        },
+        {
+          "name": "json-7",
+          "passed": true,
+          "answer_correct": true
+        }
+      ]
+    },
+    "lifecycle": {
+      "passed": 15,
+      "total": 15
+    },
+    "checkpoint_bytes_requantized": false,
+    "target_precision_changed": true,
+    "target_lm_head_storage": "bf16",
+    "target_embedding_storage": "bf16",
+    "default_changed": false,
+    "portfolio_metrics_changed": false,
+    "math_output_hash_parity": false,
+    "tests": {
+      "cpu_passed": 1602,
+      "cpu_skipped": 81,
+      "gpu_gdn_prefix_vs_replay_passed": 18,
+      "gpu_qsa_metadata_bitwise_passed": 33,
+      "new_file_ruff": "passed",
+      "git_diff_check": "passed"
+    },
+    "shutdown_warning": "multiprocessing resource_tracker reported four semaphore objects for cleanup; no cache-integrity assertion or CUDA/OOM error observed.",
+    "limits": [
+      "Five-trial medians on four fixed C1 workloads; not a general task-throughput benchmark.",
+      "No MGSM, extended, long-context or full endurance certification for this unselected candidate.",
+      "The fixed 100-case subset quality budget applies to evaluated profiles, not arbitrary FP8 configurations."
+    ]
+  },
+  "source": {
+    "summary": "Bounded screen of existing --qwen4-dense-storage fp8 under a provisional two-point fixed-subset quality budget; candidate not selected.",
+    "public_copy_note": "Machine-specific home directories in server_argv are replaced by $HOME. Raw artifact hashes refer to the original local evidence, not this portable public summary.",
+    "raw_artifact": "$HOME/results/qwen38-quality-opt/",
+    "source_manifest": "relaxed-fp8-dense-screen-source.json",
+    "source_manifest_sha256": "cbcc8a50e2d0f64617790099ec626f433abf18e48b8cb8ec3e631174959b5d8f",
+    "source_diff_sha256": "35eea6d9c6b348e47a3e391dffe0de59118205a28981d01f814791230f30dd9f",
+    "source_files_sha256": {
+      "python/sparklab/models/qwen4_exp/model.py": "93355037407d08ed72f11465277cc77dba4424b06936423adef3635e23c7e0b5",
+      "python/sparklab/runtime/engine/engine.py": "5c72fafb4b72b1874693dd10b8aa805a88e7ffe76f4e7d35b83e1a3e1dfdadce",
+      "python/sparklab/runtime/scheduler/prefill.py": "d320bda8e21dbc17cf890da731a38d2b61cbc65e03f0a03b3ca9ea1d97f4bad2",
+      "python/sparklab/runtime/kvcache/linear_state_pool.py": "8775d9a5d22b15e2678f212f354731914d3b66a0e24108af3a97a140ae419c6b",
+      "python/sparklab/attention/qsa.py": "60d9211ef374df2fbf641e89bb3df2d8113de33f4710ef120dc0fc3a680e67ea",
+      "benchmarks/quality/qwen4_regression.py": "306995df56e55b5bd6e6c1a9a70cce27fff2256e1d98df62dee083c4a5aeb262",
+      "benchmarks/bench_single_stream.py": "b9f62626e92b43e53b8f6bf955b73bcebbd1013818086490210f54f0dda4a50c",
+      "tests/models/test_qwen4_exp.py": "02f5ee4a2726c9aa29015f635257e02da0977d9e05ef572167493477fd823005",
+      "tests/models/test_qwen4_qsa_metadata.py": "2b5ebd5f252f907ee27c7ecc58b3d0bd985ef83b8f6b1813c229d28a7f639635",
+      "tests/models/test_qwen4_reject_draft.py": "dbc6d2f47901c8bd354074071371301defc6d45d07814472d8376ec302ea8ca1",
+      "python/sparklab/kernels/triton/qwen4_skinny.py": "938762a5aa40cb4810004bef589502eb1cc3f57428258d6ce51e98e4953c507c",
+      "python/sparklab/models/qwen4_exp/weight.py": "6726f6fba919a5784c878935b23f077e33c1f85c6b827ca7e993b595eda7dabf",
+      "python/sparklab/models/qwen4_exp/attention.py": "02c8c5b449abc9fc24cf6e5a59158cc7655616b86077f659369565d62afb3f12",
+      "python/sparklab/models/qwen4_exp/hyper.py": "dbb7087f6701a7164725bbefeb6d747e68d70365cfe90bf6ae032a7dc5c05629",
+      "python/sparklab/models/qwen3_5_moe/gdn.py": "86bea3c44e06587996526a81c7c60b6a32c3179cd1b1a9e05ca81c14c633983c",
+      "tests/runtime/kvcache/test_linear_state_pool_alloc.py": "578be602612d3abf0d751ebaae90b3c1c7d481d37e1687a6dcbd2dd0dff2edf4",
+      "tests/runtime/scheduler/test_scheduler_chunked_prefill.py": "243e44ef85d946a2a4b734723b85cc5b69cfc7eacfb8c85e14b0055f13da89cf"
+    },
+    "raw_artifact_sha256": {
+      "relaxed-fp8-dense-screen-lifecycle.json": "b58bc7eaae4f96959ab88dc10186925520d20f9a7d09a0ab172ba80c56d9d690",
+      "relaxed-fp8-dense-screen-quality.json": "063537ef9b973ac1d3901844e79c420c688dd556ed2375619ced9924891ef751",
+      "relaxed-fp8-dense-screen-source.json": "cbcc8a50e2d0f64617790099ec626f433abf18e48b8cb8ec3e631174959b5d8f",
+      "relaxed-fp8-dense-screen.json": "2dd29fad7f11319b3fa7d0e589000fcf818bd3aaea324949b5a13c065d7f8bc1",
+      "relaxed-fp8-dense-screen-server.log": "f96f73c8d8ca5ac34a0ee9f5605671d77facf970229fa5214726d24373cd51cb"
+    }
+  }
+}

--- a/benchmarks/quality/README.md
+++ b/benchmarks/quality/README.md
@@ -105,6 +105,43 @@ exactly three steps and a passing evaluator. Full W4 runs require exactly thirte
 `--mode smoke --allow-partial-scenario` is available only to validate client wiring and is
 always labeled as smoke in the output.
 
+## Focused Qwen4 optimization regressions
+
+`qwen4_regression.py` checks an already-running server. Run the **same suite and
+protocol on baseline and candidate**, serially, then compare individual cases as
+well as aggregate scores. These checks do not establish general quality parity
+or Frontier certification. Keep speed measurements separate from CPU test runs.
+
+```bash
+python benchmarks/quality/qwen4_regression.py \
+  --base-url http://127.0.0.1:8000 --model qwen3.8-flash-next \
+  --suite smoke --output results/baseline-smoke.json
+```
+
+- `smoke`: 52 fixed arithmetic, recall and JSON cases. Reports answer correctness
+  separately from strict formatting; thinking off, greedy, 256-token limit.
+- `extended`: five constrained executable Python tasks, four thinking-on reasoning
+  cases, three roughly 12K-token recall positions and three tool calls. The
+  server needs at least 16K context. Generated code runs in a resource-limited
+  subprocess with restricted syntax/builtins; tool calls are graded, not executed.
+- `mgsm`: 100 fixed cases (50 English, 50 Chinese), selected before evaluation as
+  zero-based indices `2, 7, ..., 247`. This is **not full MGSM**. Zero-shot,
+  thinking off, greedy, 1,536-token limit, final numeric-answer matching.
+- `lifecycle`: 15 checks for output limits around speculative/page boundaries,
+  stop-string handling, multi-turn label replacement, and streamed requests
+  disconnected after one to three content chunks followed by recovery probes.
+  Inspect cache-integrity logs too; a correct probe alone is not a leak test.
+
+For MGSM, place the official `mgsm_en.tsv` and `mgsm_zh.tsv` files from
+[Google Research's pinned dataset](https://github.com/google-research/url-nlp/tree/452a21ad3dae5668c06ceeac21ff073e1e40f9be/mgsm)
+in a directory and pass `--data-dir /path/to/mgsm`. The runner validates their
+SHA-256 digests before use. The dataset is licensed CC-BY-4.0; provenance,
+selection and protocol are recorded in the report.
+
+Choose a fresh output path for each run. Reports are saved after every case and
+label incomplete runs `running`; a complete case count does not by itself prove
+server health or memory safety. Retain server logs and memory telemetry too.
+
 ## Supported models and validation
 
 `models.json` contains the three paper models and their reported weight formats. An arbitrary

--- a/benchmarks/quality/qwen4_regression.py
+++ b/benchmarks/quality/qwen4_regression.py
@@ -1,0 +1,563 @@
+"""Focused Qwen4 regression checks, not broad quality certification.
+
+Runs against an existing local OpenAI-compatible server. MGSM uses a fixed,
+SHA-pinned 100-case subset; provide the official EN/ZH TSVs with --data-dir.
+"""
+
+import ast
+import csv
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+
+def cases():
+    result = []
+    for i in range(24):
+        a, b = 23 + 7 * i, 11 + 3 * i
+        expected = a * b
+        wording = f"Compute {a} * {b}." if i % 2 == 0 else f"计算 {a} 乘以 {b}。"
+        result.append(
+            (
+                f"multiply-{i}",
+                wording + " Reply only with FINAL=<integer>.",
+                str(expected),
+                "final",
+            )
+        )
+    for i in range(12):
+        a, b, c = 107 + 19 * i, 7 + i, 3 + 2 * i
+        result.append(
+            (
+                f"remainder-{i}",
+                f"What is the remainder when ({a} * {b} + {c}) is divided by 17? Reply only with FINAL=<integer>.",
+                str((a * b + c) % 17),
+                "final",
+            )
+        )
+    for i in range(8):
+        key = f"violet-{7319 + 137 * i}"
+        filler = "The record contains ordinary inventory notes. " * 120
+        result.append(
+            (
+                f"recall-{i}",
+                f"{filler}\nThe verification key is {key}.\n{filler}\nReturn only the verification key.",
+                key,
+                "exact",
+            )
+        )
+    for i in range(8):
+        result.append(
+            (
+                f"json-{i}",
+                f'Return only a JSON object with exactly these fields: "sum" equal to {13 + i} + {7 * i}, and "label" equal to "sample-{i}". No markdown.',
+                {"sum": 13 + 8 * i, "label": f"sample-{i}"},
+                "json",
+            )
+        )
+    return result
+
+
+def run_smoke(origin, model, path):
+    rows = []
+    suite = cases()
+    for name, prompt, expected, kind in suite:
+        body = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "max_tokens": 256,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        req = urllib.request.Request(
+            origin + "/v1/chat/completions",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=180) as resp:
+            data = json.load(resp)
+        answer = data["choices"][0]["message"].get("content") or ""
+        text = answer.strip()
+        if kind == "final":
+            match = re.fullmatch(r"FINAL\s*=\s*(-?\d+)", text)
+            ok = bool(match and match.group(1) == expected)
+            finals = re.findall(r"FINAL\s*=\s*(-?\d+)", text)
+            correct = bool(finals and finals[-1] == expected)
+        elif kind == "json":
+            try:
+                ok = json.loads(text) == expected
+            except ValueError:
+                ok = False
+        else:
+            ok = text == expected
+        if kind != "final":
+            correct = ok
+        rows.append(
+            {
+                "name": name,
+                "prompt": prompt,
+                "expected": expected,
+                "answer": answer,
+                "passed": ok,
+                "answer_correct": correct,
+                "usage": data.get("usage"),
+            }
+        )
+        path.write_text(
+            json.dumps(
+                {
+                    "status": "complete" if len(rows) == len(suite) else "running",
+                    "expected_total": len(suite),
+                    "passed": sum(r["passed"] for r in rows),
+                    "total": len(rows),
+                    "cases": rows,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        print("quality", name, ok, flush=True)
+    return rows
+
+
+CODE_CASES = [
+    (
+        "gcd",
+        "Implement gcd(a, b) for non-negative integers using Euclid's algorithm.",
+        [([54, 24], 6), ([0, 7], 7), ([17, 13], 1), ([0, 0], 0)],
+    ),
+    (
+        "clamp",
+        "Implement clamp(x, lo, hi), returning lo below range, hi above range, otherwise x.",
+        [([-3, 0, 10], 0), ([11, 0, 10], 10), ([5, 0, 10], 5), ([2, 2, 2], 2)],
+    ),
+    (
+        "unique",
+        "Implement unique(xs), preserving the first occurrence of each integer in the input list.",
+        [([[2, 1, 2, 3, 1]], [2, 1, 3]), ([[]], []), ([[0, 0]], [0])],
+    ),
+    (
+        "search",
+        "Implement search(xs, target): binary search over a sorted distinct integer list, returning its index or -1.",
+        [([[1, 4, 9], 4], 1), ([[1, 4, 9], 2], -1), ([[], 1], -1), ([[8], 8], 0)],
+    ),
+    (
+        "factorial",
+        "Implement factorial(n) for non-negative integers, with factorial(0)=1.",
+        [([0], 1), ([1], 1), ([5], 120), ([8], 40320)],
+    ),
+]
+
+RUNNER = """
+import json, resource, sys
+resource.setrlimit(resource.RLIMIT_AS, (256*1024*1024,256*1024*1024))
+resource.setrlimit(resource.RLIMIT_CPU, (2,2))
+p=json.load(sys.stdin)
+b={k:__builtins__.__dict__[k] for k in ['abs','range','len','min','max','int','str','list','dict','set','tuple','enumerate','zip','sorted','sum','reversed','ValueError']}
+scope={'__builtins__':b}
+exec(p['code'],scope)
+print(json.dumps([scope[p['name']](*args) for args,expected in p['tests']]))
+"""
+
+
+def request(origin, model, prompt, *, thinking=False, tokens=1024, extra=None):
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "max_tokens": tokens,
+        "chat_template_kwargs": {"enable_thinking": thinking},
+    }
+    body.update(extra or {})
+    req = urllib.request.Request(
+        origin + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        return json.load(resp)
+
+
+def run_extended(origin, model, path):
+    rows = []
+
+    def save(row):
+        rows.append(row)
+        path.write_text(
+            json.dumps(
+                {
+                    "status": "complete" if len(rows) == 15 else "running",
+                    "expected_total": 15,
+                    "passed": sum(x["passed"] for x in rows),
+                    "total": len(rows),
+                    "cases": rows,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        print("extended", row["name"], row["passed"], flush=True)
+
+    for name, prompt, tests in CODE_CASES:
+        data = request(
+            origin,
+            model,
+            prompt
+            + " Output only Python code. Do not import modules. Name the function exactly as specified.",
+        )
+        answer = data["choices"][0]["message"].get("content") or ""
+        blocks = re.findall(r"```(?:python)?\s*\n(.*?)```", answer, re.S)
+        code = blocks[0] if blocks else answer
+        try:
+            tree = ast.parse(code)
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.Import, ast.ImportFrom)):
+                    raise ValueError("imports not allowed")
+                if isinstance(node, ast.Name) and node.id.startswith("__"):
+                    raise ValueError("private name")
+                if isinstance(node, ast.Attribute) and node.attr not in {
+                    "append",
+                    "get",
+                    "items",
+                    "keys",
+                    "values",
+                    "add",
+                }:
+                    raise ValueError("attribute not allowed")
+            proc = subprocess.run(
+                [sys.executable, "-I", "-c", RUNNER],
+                input=json.dumps({"code": code, "name": name, "tests": tests}),
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env={},
+            )
+            values = json.loads(proc.stdout)
+            ok = values == [expected for args, expected in tests]
+            error = proc.stderr
+        except Exception as exc:
+            ok = False
+            error = str(exc)
+        save(
+            {
+                "name": "code-" + name,
+                "prompt": prompt,
+                "response": data,
+                "passed": ok,
+                "error": error,
+            }
+        )
+
+    for i in range(4):
+        a, b, c = 113 + 37 * i, 9 + 2 * i, 5 + 3 * i
+        expected = (a * b + c) % 19
+        prompt = f"Calculate the remainder of ({a} * {b} + {c}) divided by 19. Think through the calculation and end your answer with FINAL=<integer>."
+        data = request(origin, model, prompt, thinking=True, tokens=2048)
+        answer = data["choices"][0]["message"].get("content") or ""
+        values = re.findall(r"FINAL\s*=\s*(-?\d+)", answer)
+        save(
+            {
+                "name": f"reasoning-{i}",
+                "prompt": prompt,
+                "expected": expected,
+                "response": data,
+                "passed": bool(values and int(values[-1]) == expected),
+            }
+        )
+
+    for i, depth in enumerate([0.1, 0.5, 0.9]):
+        filler = "A record describes ordinary items and their locations. " * 1300
+        offset = int(len(filler) * depth)
+        key = f"cobalt-{8107 + 173 * i}"
+        prompt = (
+            filler[:offset]
+            + f"\nThe secret verification key is {key}.\n"
+            + filler[offset:]
+            + "\nReturn only the secret verification key."
+        )
+        data = request(origin, model, prompt, tokens=128)
+        answer = data["choices"][0]["message"].get("content") or ""
+        save(
+            {
+                "name": f"sparse-recall-{i}",
+                "expected": key,
+                "response": data,
+                "passed": answer.strip() == key,
+            }
+        )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "multiply",
+                "description": "Multiply two integers.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                    "required": ["a", "b"],
+                },
+            },
+        }
+    ]
+    for i in range(3):
+        a, b = 17 + 4 * i, 23 + 8 * i
+        data = request(
+            origin,
+            model,
+            f"Use the multiply tool to multiply {a} and {b}.",
+            extra={"tools": tools, "tool_choice": "auto"},
+        )
+        calls = data["choices"][0]["message"].get("tool_calls") or []
+        try:
+            ok = (
+                len(calls) == 1
+                and calls[0]["function"]["name"] == "multiply"
+                and json.loads(calls[0]["function"]["arguments"]) == {"a": a, "b": b}
+            )
+        except Exception:
+            ok = False
+        save({"name": f"tool-{i}", "response": data, "passed": ok})
+    return rows
+
+
+REVISION = "452a21ad3dae5668c06ceeac21ff073e1e40f9be"
+DIGESTS = {
+    "en": "50021d0f28cc957edcb44e7806425b1c7fbd648ddcb9e0a8ec689d10e57d40fa",
+    "zh": "b2fa63151022370a0de1f4211c8c284eae74b0f5a3b003b1d5982c0d4a73f661",
+}
+INDICES = list(range(2, 250, 5))
+
+
+def run_mgsm(origin, model, path, data_dir):
+    root = Path(data_dir)
+    rows = []
+    for lang in ["en", "zh"]:
+        data_path = root / ("mgsm_" + lang + ".tsv")
+        assert hashlib.sha256(data_path.read_bytes()).hexdigest() == DIGESTS[lang]
+        with data_path.open() as handle:
+            dataset = list(csv.reader(handle, delimiter="\t"))
+        assert len(dataset) == 250
+        for idx in INDICES:
+            question, expected = dataset[idx]
+            instruction = (
+                "\nBriefly show your reasoning and end with FINAL=<number>."
+                if lang == "en"
+                else "\n请简要说明推理过程，最后用 FINAL=<数字> 给出答案。"
+            )
+            body = {
+                "model": model,
+                "messages": [{"role": "user", "content": question + instruction}],
+                "temperature": 0,
+                "max_tokens": 1536,
+                "chat_template_kwargs": {"enable_thinking": False},
+            }
+            req = urllib.request.Request(
+                origin + "/v1/chat/completions",
+                data=json.dumps(body).encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=300) as response:
+                result = json.load(response)
+            answer = result["choices"][0]["message"].get("content") or ""
+            values = re.findall(r"FINAL\s*=\s*([+-]?\d[\d,]*(?:\.\d+)?)", answer)
+            try:
+                correct = bool(
+                    values and Decimal(values[-1].replace(",", "")) == Decimal(expected)
+                )
+            except InvalidOperation:
+                correct = False
+            rows.append(
+                {
+                    "name": f"mgsm-{lang}-{idx}",
+                    "language": lang,
+                    "index": idx,
+                    "prompt": body["messages"][0]["content"],
+                    "expected": expected,
+                    "passed": correct,
+                    "response": result,
+                }
+            )
+            report = {
+                "status": "complete" if len(rows) == 2 * len(INDICES) else "running",
+                "expected_total": 2 * len(INDICES),
+                "source": f"https://github.com/google-research/url-nlp/tree/{REVISION}/mgsm",
+                "license": "CC-BY-4.0",
+                "sha256": DIGESTS,
+                "indices": INDICES,
+                "protocol": "zero-shot; thinking off; temperature 0; max_tokens 1536; FINAL numeric match",
+                "total": len(rows),
+                "passed": sum(row["passed"] for row in rows),
+                "cases": rows,
+            }
+            path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n")
+            print("mgsm", lang, idx, correct, result.get("usage"), flush=True)
+    return rows
+
+
+def run_lifecycle(origin, model, path):
+    """Budget/stop boundaries, prefix reuse and disconnect cleanup (single stream)."""
+    rows = []
+
+    def save(row):
+        rows.append(row)
+        path.write_text(
+            json.dumps(
+                {
+                    "status": "complete" if len(rows) == 15 else "running",
+                    "expected_total": 15,
+                    "total": len(rows),
+                    "passed": sum(row["passed"] for row in rows),
+                    "cases": rows,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        print("lifecycle", row["name"], row["passed"], flush=True)
+
+    for budget in [1, 2, 3, 4, 5, 7, 8, 15, 16]:
+        data = request(
+            origin,
+            model,
+            "List the integers from 1 through 100, separated by commas.",
+            tokens=budget,
+        )
+        save(
+            {
+                "name": f"budget-{budget}",
+                "response": data,
+                "passed": data["usage"]["completion_tokens"] == budget
+                and data["choices"][0]["finish_reason"] == "length",
+            }
+        )
+
+    data = request(
+        origin,
+        model,
+        "Copy exactly this text: START-ALPHA STOP-HERE END-OMEGA",
+        tokens=128,
+        extra={"stop": ["STOP-HERE"]},
+    )
+    answer = data["choices"][0]["message"].get("content") or ""
+    save(
+        {
+            "name": "stop-string",
+            "response": data,
+            "passed": "START-ALPHA" in answer
+            and "STOP-HERE" not in answer
+            and "END-OMEGA" not in answer
+            and data["choices"][0]["finish_reason"] == "stop",
+        }
+    )
+
+    history = []
+    for i, key in enumerate(["cyan-8127", "coral-9531"]):
+        history.append(
+            {
+                "role": "user",
+                "content": f"The current label of the amber box is {key}. Replace any previous label. Reply only ACK.",
+            }
+        )
+        set_result = request(origin, model, "", tokens=128, extra={"messages": history})
+        history.append(set_result["choices"][0]["message"])
+        history.append(
+            {
+                "role": "user",
+                "content": "Return only the current label of the amber box.",
+            }
+        )
+        result = request(origin, model, "", tokens=128, extra={"messages": history})
+        history.append(result["choices"][0]["message"])
+        save(
+            {
+                "name": f"multiturn-{i}",
+                "set_response": set_result,
+                "response": result,
+                "expected": key,
+                "passed": (result["choices"][0]["message"].get("content") or "").strip()
+                == key,
+            }
+        )
+
+    for i in range(3):
+        body = {
+            "model": model,
+            "messages": [
+                {"role": "user", "content": "Explain hash tables in great detail."}
+            ],
+            "temperature": 0,
+            "max_tokens": 512,
+            "stream": True,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        req = urllib.request.Request(
+            origin + "/v1/chat/completions",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        chunks = 0
+        with urllib.request.urlopen(req, timeout=60) as stream:
+            for line in stream:
+                if not line.startswith(b"data: ") or line.strip() == b"data: [DONE]":
+                    continue
+                event = json.loads(line[6:])
+                if event.get("choices") and event["choices"][0].get("delta", {}).get(
+                    "content"
+                ):
+                    chunks += 1
+                    if chunks == i + 1:
+                        break
+        time.sleep(0.25)
+        marker = f"READY-{7129 + i}"
+        probe = request(origin, model, f"Reply exactly with {marker}", tokens=64)
+        save(
+            {
+                "name": f"cancel-{i}",
+                "observed_chunks": chunks,
+                "response": probe,
+                "passed": chunks == i + 1
+                and (probe["choices"][0]["message"].get("content") or "").strip()
+                == marker,
+            }
+        )
+    return rows
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument(
+        "--suite", choices=["smoke", "extended", "mgsm", "lifecycle"], required=True
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--data-dir", type=Path)
+    args = parser.parse_args()
+    if args.output.exists():
+        parser.error("output already exists; choose a fresh evidence path")
+    if args.suite == "mgsm" and args.data_dir is None:
+        parser.error("--data-dir is required for the pinned MGSM TSVs")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    origin = args.base_url.rstrip("/")
+    if args.suite == "mgsm":
+        run_mgsm(origin, args.model, args.output, args.data_dir)
+    else:
+        runner = {
+            "smoke": run_smoke,
+            "extended": run_extended,
+            "lifecycle": run_lifecycle,
+        }[args.suite]
+        runner(origin, args.model, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -71,6 +71,101 @@ replay. All three runs produced the same output hash; that hash differs from
 target-only and pre-optimization MTP. See
 [accepted-prefix evidence](../../benchmarks/gb10/results/GB10-QWENNVIDIA-002.json).
 
+## Experimental full-vocabulary draft optimization
+
+The development profile below combines immediate drafting after a rejection,
+a separate FP8 draft-only output head, and smaller verification snapshots.
+It requires the corresponding source changes; it is not enabled by recipe 0.9.0.
+
+```bash
+SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE=0 \
+SPARKLAB_QWEN4_REJECT_DRAFT=1 \
+SPARKLAB_QWEN4_DRAFT_HEAD=fp8 \
+SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT=1 \
+SPARKLAB_QWEN4_FAST_QSA_METADATA=0 \
+  sparklab run qwen3.8-flash-next --root /path/to/models -- --speculative-tokens 3
+```
+
+All three switches are off by default (`DRAFT_HEAD=bf16`). The FP8 head is a
+separate full-vocabulary proposal copy, adding approximately 0.59 GiB. It never
+replaces the BF16 target head or tied embeddings. Target weights on disk, target
+precision, BF16 QSA KV and FP32 GDN state stay unchanged. Target verification
+still checks every draft; draft-head quantization may change acceptance and
+floating-point execution paths. This is not a promise of identical generated
+text or general quality equivalence.
+
+Fresh single-stream measurements use five trials after one warmup per workload:
+
+| Workload | Current MTP3 | Optimized MTP3 | Change |
+|---|---:|---:|---:|
+| Math, 128 tokens, thinking on | 32.57 tok/s | 42.14 tok/s | +29.4% |
+| English hash-map prose, 600 tokens | 27.58 tok/s | 34.21 tok/s | +24.0% |
+| Python LRU code, 512 tokens | 33.67 tok/s | 38.64 tok/s | +14.8% |
+| Chinese hash-map prose, 600 tokens | 29.28 tok/s | 36.18 tok/s | +23.6% |
+
+These are greedy, fixed-length streaming probes, not quality scores. The math
+output hash matches the baseline; the longer generated texts differ. The current
+development evaluation has no new failures on the 52-case arithmetic/recall/JSON
+set. However, the fixed 100-case English/Chinese MGSM subset fell from **94/100
+to 92/100**: three new failures and one improved case. Two new failures exhausted
+the identical 1,536-token allowance; one chose a different interpretation than
+the dataset's answer. Gold answers, prompts, budgets and scoring were not changed.
+The 15 extended coding/reasoning/recall/tool checks and both 15-case lifecycle
+runs passed, with no OOM, swap-out, or memory-guard event. Actual long recall
+was about 11,735 prompt tokens, not 32K/64K certification. This is the fastest
+fully evaluated profile so far and is a reasonable opt-in when the observed
+two-point loss on this subset is acceptable. It does **not** meet a
+no-quality-drop requirement; two points here are not a bound on losses on other
+tasks. The original recipe and portfolio metric remain unchanged.
+This fixed subset was used during tuning, not as an independent final evaluation.
+
+Restoring the BF16 draft head while retaining immediate redraft scored
+**93/100**, with two new failures and one improvement, at smaller speed gains
+of 5.6–13.9%. Keeping the baseline draft schedule with FP8 proposals, light
+snapshots and `SPARKLAB_QWEN4_FAST_QSA_METADATA=1` scored **94/100** and reached
+35.98/30.19/35.70/32.11 tok/s in the same workload order. That unchanged total
+includes one new failure and one recovery, not identical answers. Its extended
+and lifecycle checks also passed. These ablations do not isolate draft
+quantization as the sole cause of changed outputs. See
+[the measured evidence](../../benchmarks/gb10/results/GB10-QWENNVIDIA-004.json).
+
+Further five-trial screens did not produce a better general replacement:
+metadata reuse changed each median by less than 0.5%; MTP4 improved code by
+6.4% but slowed math and Chinese, and has not run the MGSM subset. Existing
+`--qwen4-dense-storage fp8` also slowed math by 14.1% and Chinese by 9.7%,
+with prose/code nearly flat and one new smoke-test answer regression versus
+the accepted fast profile. That target-precision experiment was not selected;
+see its [separate results](../../benchmarks/gb10/results/GB10-QWENNVIDIA-005.json).
+
+To reproduce the speed probes against each freshly started server, use the
+same order and settings (one request at a time, no concurrent tests):
+
+```bash
+python benchmarks/bench_single_stream.py --base-url http://127.0.0.1:8000 \
+  --model qwen3.8-flash-next --workloads aime --tokens 128 --thinking \
+  --trials 5 --label candidate --output results/candidate-math.json
+python benchmarks/bench_single_stream.py --base-url http://127.0.0.1:8000 \
+  --model qwen3.8-flash-next --workloads hashmap --tokens 600 \
+  --trials 5 --label candidate --output results/candidate-prose.json
+python benchmarks/bench_single_stream.py --base-url http://127.0.0.1:8000 \
+  --model qwen3.8-flash-next --workloads code --tokens 512 \
+  --trials 5 --label candidate --output results/candidate-code.json
+python benchmarks/bench_single_stream.py --base-url http://127.0.0.1:8000 \
+  --model qwen3.8-flash-next --workloads chinese --tokens 600 \
+  --trials 5 --label candidate --output results/candidate-chinese.json
+```
+
+Use the model ID returned by `/v1/models`. Repeat on a fresh baseline server
+with `REJECT_DRAFT=0`, `DRAFT_HEAD=bf16`, `LIGHT_VERIFY_SNAPSHOT=0`, and
+`FAST_QSA_METADATA=0` (all names
+have the `SPARKLAB_QWEN4_` prefix). The measured speed runs additionally used
+`--max-seq-len-override 8792`, `--max-running-requests 1`,
+`--cuda-graph-max-bs 1`, `--disable-moe-prefill-overlap`, full expert preload,
+131,072 KV tokens and Triton NVFP4. No larger-context performance is implied.
+
+See the [focused quality runner](../../benchmarks/quality/README.md#focused-qwen4-optimization-regressions)
+for the fixed paired evaluation protocols.
+
 ## Experimental reduced draft vocabulary
 
 An independent experiment inspired by

--- a/python/sparklab/attention/qsa.py
+++ b/python/sparklab/attention/qsa.py
@@ -94,6 +94,8 @@ class QSAAttnBackend(BaseAttnBackend):
         self._fused_selection = os.getenv(
             "SPARKLAB_DISABLE_QSA_FUSED_SELECTION", "0"
         ).lower() not in {"1", "true", "yes"}
+        self._fast_metadata = os.getenv("SPARKLAB_QWEN4_FAST_QSA_METADATA", "0") == "1"
+        self._single_query_id: torch.Tensor | None = None
         self.capture: QSACaptureData | None = None
         self.capture_bs: List[int] = []
         self.max_graph_bs = 0
@@ -119,15 +121,35 @@ class QSAAttnBackend(BaseAttnBackend):
         # rather than one segment per request. ``paged_attention`` uses this tensor
         # to index ``indptr``, so it must map query N to segment N even when several
         # queries belong to the same request.
-        q_to_req = torch.arange(
-            offsets[-1], dtype=torch.int32, device=self.device
-        )
         dense = all(
             (req.cached_len + req.extend_len) // self.args.index_compress_ratio
             <= self.args.index_block_topk
             for req in reqs
         )
         dense_indptr = dense_indices = dense_q_positions = None
+        if dense and len(reqs) == 1 and lengths[0] == 1 and getattr(self, "_fast_metadata", False):
+            # One-query dense attention reads a contiguous page-table prefix.
+            # Avoid concatenating a copy and launching cumsum/arange kernels.
+            # These views are consumed on the engine stream before the request's
+            # page-table row can be repointed or freed.
+            req = reqs[0]
+            rows = get_global_ctx().page_table[
+                req.table_idx, : req.device_len
+            ].to(torch.int32)[: req.cached_len + 1]
+            if self._single_query_id is None:
+                self._single_query_id = torch.zeros(1, dtype=torch.int32, device=self.device)
+            packed = torch.tensor(
+                [0, rows.numel(), rows.numel() - 1], dtype=torch.int64, device=self.device
+            )
+            batch.attn_metadata = QSAMetadata(
+                qo_indptr=(0, 1), last_indices=self._single_query_id,
+                q_to_req=self._single_query_id, dense_indptr=packed[:2],
+                dense_indices=rows, dense_q_positions=packed[2:],
+            )
+            return
+        q_to_req = torch.arange(
+            offsets[-1], dtype=torch.int32, device=self.device
+        )
         if dense:
             # Before the sparse threshold QSA selection is layer-independent: every
             # visible physical row is selected. Build this packed metadata once per
@@ -157,6 +179,35 @@ class QSAAttnBackend(BaseAttnBackend):
             dense_indptr=dense_indptr,
             dense_indices=dense_indices,
             dense_q_positions=dense_q_positions,
+        )
+
+    def prepare_prefix_metadata(self, source: Batch, prefix: Batch) -> None:
+        """Reuse dense accepted-prefix addressing without changing draft arithmetic."""
+        md = source.attn_metadata
+        count = prefix.reqs[0].extend_len
+        if (
+            not getattr(self, "_fast_metadata", False)
+            or len(source.reqs) != 1 or len(prefix.reqs) != 1
+            or not isinstance(md, QSAMetadata) or md.dense_indices is None
+        ):
+            self.prepare_metadata(prefix)
+            return
+        req, original = prefix.reqs[0], source.reqs[0]
+        if (
+            req.table_idx != original.table_idx or req.cached_len != original.cached_len
+            or not 1 <= count <= md.q_to_req.numel()
+        ):
+            raise ValueError("QSA metadata reuse requires an unchanged accepted-prefix origin")
+        total = count * req.cached_len + count * (count + 1) // 2
+        prefix.attn_metadata = QSAMetadata(
+            qo_indptr=(0, count), last_indices=md.q_to_req[count - 1:count],
+            q_to_req=md.q_to_req[:count],
+            # Eager metadata uses int64 even when its source is an int32 capture.
+            dense_indptr=md.dense_indptr[:count + 1].to(torch.int64),
+            dense_indices=md.dense_indices[:total],
+            dense_q_positions=md.dense_q_positions[:count],
+            # Keep the same eager pooling implementation as fresh prefix metadata.
+            capture_decode=False,
         )
 
     @staticmethod
@@ -416,10 +467,11 @@ class QSAAttnBackend(BaseAttnBackend):
             dense_limit,
             self.device,
             max_bs=max(bs_list),
-            # Qwen MTP verification packs one target row and up to three
-            # draft rows into one request. Ordinary decode still consumes only
-            # the leading max_bs query slots from these same buffers.
-            max_queries_per_req=4,
+            # Verification packs one target row plus the configured draft
+            # width. Ordinary decode consumes only the leading max_bs slots.
+            max_queries_per_req=max(
+                4, 1 + int(getattr(self.config, "speculative_tokens", 0) or 0)
+            ),
         )
         self.capture_bs = sorted(bs_list)
         self.max_graph_bs = max(bs_list)

--- a/python/sparklab/models/qwen4_exp/model.py
+++ b/python/sparklab/models/qwen4_exp/model.py
@@ -122,6 +122,7 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
         self._mtp_path: str | None = None
         self._mtp_target_hidden: torch.Tensor | None = None
         self._draft_vocab = None
+        self._draft_fp8_head = None
         self._draft_required_ids: list[int] = []
         super().__init__()
 
@@ -145,6 +146,9 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
 
     def prepare_for_runtime(self) -> None:
         if self._mtp is not None:
+            draft_head = os.getenv("SPARKLAB_QWEN4_DRAFT_HEAD", "bf16")
+            if draft_head not in {"bf16", "fp8"}:
+                raise ValueError("SPARKLAB_QWEN4_DRAFT_HEAD must be bf16 or fp8")
             if self._mtp_path is None:
                 raise RuntimeError("Qwen4 MTP sidecar path was not prepared")
             self._mtp.load_sidecar(self._mtp_path, self.model.embed_tokens.weight.device)
@@ -157,12 +161,32 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
                     raise ValueError("reduced Qwen4 draft vocabulary requires TP=1")
                 ids = draft_token_ids(head.weight.shape[0], budget, self._draft_required_ids)
                 self._draft_vocab = DraftVocabulary(head.weight, self.lm_head.bias, ids)
+            if draft_head == "fp8":
+                from .weight import _quant_fp8_per_row
+
+                head = self.lm_head.tied_embedding or self.lm_head
+                if head.tp_size != 1 or budget or head.weight.dtype != torch.bfloat16:
+                    raise ValueError("FP8 Qwen4 draft head requires TP=1, BF16 source, and full vocabulary")
+                # Separate proposal-only copy: never replace the target head or
+                # tied embeddings. Chunking bounds temporary FP32 quantization memory.
+                weight = torch.empty_like(head.weight, dtype=torch.float8_e4m3fn)
+                scale = torch.empty(head.weight.shape[0], dtype=torch.float32, device=head.weight.device)
+                for start in range(0, head.weight.shape[0], 4096):
+                    part, part_scale = _quant_fp8_per_row(head.weight[start:start + 4096])
+                    weight[start:start + 4096] = part
+                    scale[start:start + 4096] = part_scale
+                self._draft_fp8_head = (weight, scale)
 
     def _select_draft_token(self, hidden: torch.Tensor) -> torch.Tensor:
         from sparklab.layers.linear import _linear_forward
 
         if self._draft_vocab is not None:
             return self._draft_vocab.select(hidden)
+        if self._draft_fp8_head is not None:
+            from sparklab.kernels.triton.fp8_pertensor_linear import fp8_pertensor_linear
+
+            weight, scale = self._draft_fp8_head
+            return fp8_pertensor_linear(hidden, weight, scale, self.lm_head.bias).argmax(-1)
         head = self.lm_head.tied_embedding or self.lm_head
         return _linear_forward(hidden, head.weight, self.lm_head.bias).argmax(-1)
 
@@ -190,6 +214,35 @@ class Qwen4ExpForCausalLM(BaseLLMModel):
         )
         self._mtp_target_hidden = multi
         return self.lm_head.forward(hidden)
+
+    def propose_mtp_prefix(self, batch, correction: torch.Tensor, accepted_inputs: int):
+        """Draft after rejection using only verified target features and tokens."""
+        from copy import copy
+
+        if not 1 <= accepted_inputs <= batch.input_ids.numel():
+            raise ValueError("accepted MTP prefix is outside the verification block")
+        if self._mtp_target_hidden is None:
+            return None
+        req = copy(batch.reqs[0])
+        req.device_len = req.cached_len + accepted_inputs
+        prefix = copy(batch)
+        prefix.reqs = [req]
+        prefix.padded_reqs = prefix.reqs
+        prefix.input_ids = batch.input_ids[:accepted_inputs]
+        prefix.positions = batch.positions[:accepted_inputs]
+        prefix.out_loc = batch.out_loc[:accepted_inputs]
+        backend = get_global_ctx().attn_backend
+        prepare_prefix = getattr(backend, "prepare_prefix_metadata", None)
+        if prepare_prefix is None:
+            backend.prepare_metadata(prefix)
+        else:
+            prepare_prefix(batch, prefix)
+        original_hidden = self._mtp_target_hidden
+        try:
+            self._mtp_target_hidden = original_hidden[:accepted_inputs]
+            return self.propose_mtp(prefix, correction)
+        finally:
+            self._mtp_target_hidden = original_hidden
 
     def propose_mtp(self, batch, next_token: torch.Tensor) -> torch.Tensor | None:
         """Greedily propose up to the configured MTP width for one request.

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -457,7 +457,8 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         raise ValueError(
             "--speculative-method mtp requires a supported checkpoint-native MTP head"
         )
-    max_tokens = 4 if glm5_mtp else 3
+    qwen4_mtp4 = qwen4_mtp and os.getenv("SPARKLAB_QWEN4_MTP4", "0") == "1"
+    max_tokens = 4 if glm5_mtp or qwen4_mtp4 else 3
     if speculative_tokens > max_tokens:
         family = "GLM-5.3 Flash" if glm5_mtp else "Qwen"
         raise ValueError(f"{family} MTP supports at most {max_tokens} speculative tokens")
@@ -1419,7 +1420,15 @@ class Engine:
                         # exclusively for speculative rollback.
                         live = req.table_idx
                         scratch = pool.num_slots - 1
-                    pool.copy_from(live, scratch)
+                    if (
+                        getattr(pool, "verify_steps", 0)
+                        and self.config.speculative_method == "mtp"
+                        and getattr(getattr(self.config, "model_config", None), "qwen4_exp_args", None) is not None
+                        and os.getenv("SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT", "0") == "1"
+                    ):
+                        pool.snapshot_verify_inputs(live, scratch)
+                    else:
+                        pool.copy_from(live, scratch)
                     state_snapshots.append((live, scratch))
                 if getattr(pool, "verify_steps", 0):
                     batch.cache_verify_states = True
@@ -1481,6 +1490,14 @@ class Engine:
                     self.mtp_stats["replay_tokens"] += accepted + 1
                 req.speculative_drafts = None
                 req.speculative_draft_probs = None
+                prefix_proposer = getattr(self.model, "propose_mtp_prefix", None)
+                if (
+                    self.config.speculative_method == "mtp"
+                    and batch.cache_verify_states
+                    and prefix_proposer is not None
+                    and os.getenv("SPARKLAB_QWEN4_REJECT_DRAFT", "0") == "1"
+                ):
+                    req.speculative_drafts = prefix_proposer(batch, chosen[-1:], accepted + 1)
                 if (
                     self.config.speculative_method == "dflash2"
                     and batch.cache_verify_states

--- a/python/sparklab/runtime/kvcache/linear_state_pool.py
+++ b/python/sparklab/runtime/kvcache/linear_state_pool.py
@@ -237,6 +237,19 @@ class LinearStatePool:
         for state in self._aux_states.values():
             state[dst].copy_(state[src])
 
+    def snapshot_verify_inputs(self, src: int, dst: int) -> None:
+        """Save convolution history for a transactional prefix commit only.
+
+        Transactional GDN verification does not overwrite the live recurrent
+        state. Its commit reads verify_recurrent_states, never the snapshot's
+        recurrent lane. This is NOT a whole-state snapshot for replay or COW.
+        """
+        if not self._verify_steps:
+            raise RuntimeError("light verify snapshots require prefix transactions")
+        self.conv_states[:, dst].copy_(self.conv_states[:, src])
+        for state in self._aux_states.values():
+            state[dst].copy_(state[src])
+
     def ensure_aux_state(
         self, name: str, shape: tuple[int, ...], dtype: torch.dtype, *, fill: float = 0.0
     ) -> torch.Tensor:

--- a/python/sparklab/runtime/scheduler/prefill.py
+++ b/python/sparklab/runtime/scheduler/prefill.py
@@ -121,6 +121,7 @@ class PrefillAdder:
         next_track_idx: int = 0,
         restore_src: int | None = None,
         swa_evicted_seqlen: int = 0,
+        allocated_len: int | None = None,
     ) -> Req | None:
         remain_len = pending_req.input_len - cached_len
         chunk_size = min(self.token_budget, remain_len)
@@ -186,6 +187,11 @@ class PrefillAdder:
         req.mamba_next_track_idx = next_track_idx
         req.mamba_restore_src = restore_src
         req.swa_evicted_seqlen = swa_evicted_seqlen  # carry the extend-free watermark across chunks
+        if allocated_len is not None:
+            # MTP can reserve draft rows beyond the previous chunk's target
+            # boundary. These pages remain owned by this request; forgetting
+            # them reallocates the same logical page and leaks the old one.
+            req.allocated_len = max(req.allocated_len, allocated_len)
         return req
 
     def try_add_one(self, pending_req: PendingReq) -> Req | None:
@@ -203,6 +209,7 @@ class PrefillAdder:
                 next_track_idx=chunked_req.mamba_next_track_idx,
                 restore_src=None,  # continuation chunk already has live state
                 swa_evicted_seqlen=chunked_req.swa_evicted_seqlen,  # extend-free watermark so far
+                allocated_len=chunked_req.allocated_len,
             )
 
         if resource := self._try_allocate_one(pending_req):

--- a/tests/models/test_qwen4_draft_vocab.py
+++ b/tests/models/test_qwen4_draft_vocab.py
@@ -48,6 +48,7 @@ def test_model_draft_selector_defaults_to_full_head():
     weight = torch.arange(10, dtype=torch.float32).view(10, 1)
     model.lm_head = SimpleNamespace(weight=weight, bias=None, tied_embedding=None)
     model._draft_vocab = None
+    model._draft_fp8_head = None
     hidden = torch.ones(1, 1)
     assert model._select_draft_token(hidden).item() == 9
     model._draft_vocab = DraftVocabulary(weight, None, [0, 1, 2])

--- a/tests/models/test_qwen4_exp.py
+++ b/tests/models/test_qwen4_exp.py
@@ -1083,9 +1083,10 @@ def test_ple_consumes_prelaunched_lookup_without_sync_fallback():
     torch.testing.assert_close(ple._capture_embed[:1], rows)
 
 
-def test_ple_stages_smaller_batch_into_stable_graph_input_prefix():
+@pytest.mark.parametrize("num_rows", [3, 5])
+def test_ple_stages_smaller_batch_into_stable_graph_input_prefix(num_rows):
     ple = Qwen4PLE.__new__(Qwen4PLE)
-    rows = torch.arange(24, dtype=torch.bfloat16).view(3, 8)
+    rows = torch.arange(num_rows * 8, dtype=torch.bfloat16).view(num_rows, 8)
     ple.embedding = SimpleNamespace(forward=lambda _batch: rows)
     ple.key_proj = SimpleNamespace(weight=torch.empty(4, 8, dtype=torch.bfloat16))
     ple._capture_embed = None
@@ -1154,15 +1155,15 @@ def test_ple_verification_updates_dynamic_state_slot(monkeypatch):
     torch.testing.assert_close(states[2], original[2])
 
 
-@pytest.mark.parametrize("accepted_inputs", [1, 2, 3, 4])
+@pytest.mark.parametrize("num_inputs,accepted_inputs", [(n, a) for n in (4, 5) for a in range(1, n + 1)])
 @pytest.mark.parametrize("state_len", [2, 9])
-def test_ple_verify_prefix_commits_only_accepted_history(monkeypatch, accepted_inputs, state_len):
+def test_ple_verify_prefix_commits_only_accepted_history(monkeypatch, num_inputs, accepted_inputs, state_len):
     from sparklab.runtime.kvcache.linear_state_pool import LinearStatePool
 
     config = parse_config(_config())
     pool = LinearStatePool(config.linear_attention_group(), 3, torch.float32,
                            torch.device("cpu"), tp_size=1)
-    pool.enable_verify_transactions(4)
+    pool.enable_verify_transactions(num_inputs)
     states = pool.ensure_aux_state("qwen4_ple_0_conv", (2, state_len), torch.float32)
     states[1].copy_(torch.arange(2 * state_len).view(2, state_len))
     pool.copy_from(1, 2)
@@ -1172,7 +1173,7 @@ def test_ple_verify_prefix_commits_only_accepted_history(monkeypatch, accepted_i
     ple = Qwen4PLE.__new__(Qwen4PLE)
     ple.layer_id, ple.width, ple.state_len, ple.dilation = 0, 2, state_len, 1
     ple.conv1d = SimpleNamespace(weight=torch.ones(2, 1, state_len + 1))
-    x = torch.arange(8, dtype=torch.float32).view(4, 2) + 20
+    x = torch.arange(num_inputs * 2, dtype=torch.float32).view(num_inputs, 2) + 20
     batch = SimpleNamespace(is_verify=True, cache_verify_states=True,
         padded_reqs=[SimpleNamespace()],
         fla_metadata=SimpleNamespace(cache_indices=torch.tensor([1], dtype=torch.int32)))
@@ -1186,8 +1187,9 @@ def test_ple_verify_prefix_commits_only_accepted_history(monkeypatch, accepted_i
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-@pytest.mark.parametrize("accepted_inputs", [1, 2, 3, 4])
-def test_qwen4_gdn_verify_prefix_matches_replay(monkeypatch, accepted_inputs):
+@pytest.mark.parametrize("num_inputs,accepted_inputs", [(n, a) for n in (4, 5) for a in range(1, n + 1)])
+@pytest.mark.parametrize("light_snapshot", [False, True])
+def test_qwen4_gdn_verify_prefix_matches_replay(monkeypatch, num_inputs, accepted_inputs, light_snapshot):
     from sparklab.models.qwen3_5_moe import gdn as module
     from sparklab.runtime.kvcache.linear_state_pool import LinearStatePool
     from sparklab.runtime.distributed import info
@@ -1209,13 +1211,13 @@ def test_qwen4_gdn_verify_prefix_matches_replay(monkeypatch, accepted_inputs):
     block.load_state_dict({name: torch.randn_like(value, device="cuda") * 0.05
                           for name, value in block.state_dict().items()})
     pool = LinearStatePool(group, 3, torch.bfloat16, torch.device("cuda"), tp_size=1)
-    pool.enable_verify_transactions(4)
+    pool.enable_verify_transactions(num_inputs)
     pool.conv_states.normal_(std=0.1)
     pool.recurrent_states.normal_(std=0.1)
     pool.copy_from(1, 2)
     context = SimpleNamespace(linear_state_pool=pool)
     monkeypatch.setattr(module, "get_global_ctx", lambda: context)
-    hidden = torch.randn(5, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+    hidden = torch.randn(num_inputs + 1, config.hidden_size, device="cuda", dtype=torch.bfloat16)
 
     def run(x, capture=False):
         context.batch = SimpleNamespace(is_verify=capture, is_speculative_replay=not capture,
@@ -1229,14 +1231,19 @@ def test_qwen4_gdn_verify_prefix_matches_replay(monkeypatch, accepted_inputs):
     expected_output = run(hidden[:accepted_inputs])
     expected_conv = pool.conv_states[:, 1].clone()
     expected_rec = pool.recurrent_states[:, 1].clone()
-    expected_next = run(hidden[4:])
+    expected_next = run(hidden[num_inputs:])
     pool.copy_from(2, 1)
-    actual = run(hidden[:4], True)
+    if light_snapshot:
+        pool.snapshot_verify_inputs(1, 2)
+        pool.recurrent_states[:, 2].fill_(float("nan"))
+    original_recurrent = pool.recurrent_states[:, 1].clone()
+    actual = run(hidden[:num_inputs], True)
+    assert torch.equal(pool.recurrent_states[:, 1], original_recurrent)
     pool.commit_verify_prefix(2, 1, accepted_inputs)
     torch.testing.assert_close(pool.conv_states[:, 1], expected_conv)
     torch.testing.assert_close(pool.recurrent_states[:, 1], expected_rec, atol=1e-5, rtol=1e-4)
     torch.testing.assert_close(actual[:accepted_inputs], expected_output)
-    torch.testing.assert_close(run(hidden[4:]), expected_next)
+    torch.testing.assert_close(run(hidden[num_inputs:]), expected_next)
 
 
 def test_ple_prefill_checkpoint_includes_convolution_history(monkeypatch):

--- a/tests/models/test_qwen4_qsa_metadata.py
+++ b/tests/models/test_qwen4_qsa_metadata.py
@@ -1,0 +1,206 @@
+"""Optimized addressing must exactly match the original QSA metadata builder."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sparklab.attention.qsa import QSAAttnBackend, QSACaptureData
+
+
+def _backend(monkeypatch, fast):
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.device = torch.device("cpu")
+    backend.args = SimpleNamespace(index_compress_ratio=4, index_block_topk=8)
+    backend._fast_metadata = fast
+    backend._single_query_id = None
+    page_table = torch.arange(192, dtype=torch.int32).view(3, 64).flip(1)
+    monkeypatch.setattr(
+        "sparklab.attention.qsa.get_global_ctx",
+        lambda: SimpleNamespace(page_table=page_table),
+    )
+    return backend
+
+
+def _batch(cached, count, table=1):
+    req = SimpleNamespace(
+        cached_len=cached, extend_len=count, device_len=cached + count, table_idx=table
+    )
+    return SimpleNamespace(reqs=[req])
+
+
+def _equal(actual, expected):
+    assert actual.qo_indptr == expected.qo_indptr
+    assert actual.capture_decode == expected.capture_decode
+    for name in [
+        "last_indices",
+        "q_to_req",
+        "dense_indptr",
+        "dense_indices",
+        "dense_q_positions",
+    ]:
+        a, b = getattr(actual, name), getattr(expected, name)
+        if b is None:
+            assert a is None
+        else:
+            assert a.dtype == b.dtype
+            assert a.shape == b.shape
+            assert torch.equal(a, b)
+
+
+@pytest.mark.parametrize("cached", [0, 1, 3, 8, 31, 34, 35])
+def test_single_query_metadata_matches_original_builder(monkeypatch, cached):
+    backend = _backend(monkeypatch, False)
+    reference = _batch(cached, 1)
+    backend.prepare_metadata(reference)
+    backend._fast_metadata = True
+    candidate = _batch(cached, 1)
+    backend.prepare_metadata(candidate)
+    _equal(candidate.attn_metadata, reference.attn_metadata)
+
+    # Preparing another request must not overwrite a previous request's scalars.
+    before = candidate.attn_metadata.dense_q_positions
+    if before is not None:
+        saved = before.clone()
+        backend.prepare_metadata(_batch(7, 1, table=2))
+        assert torch.equal(before, saved)
+
+
+@pytest.mark.parametrize("cached", [0, 1, 3, 8, 30])
+@pytest.mark.parametrize("accepted", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("captured", [False, True])
+def test_prefix_metadata_matches_fresh_eager_builder(
+    monkeypatch, cached, accepted, captured
+):
+    backend = _backend(monkeypatch, False)
+    source, reference = _batch(cached, 5), _batch(cached, accepted)
+    backend.prepare_metadata(source)
+    backend.prepare_metadata(reference)
+    if captured:
+        backend.capture = QSACaptureData.create(
+            64, torch.device("cpu"), max_queries_per_req=5
+        )
+        backend._point_to_capture(source)
+    source_metadata = source.attn_metadata
+    source_indices = source_metadata.dense_indices.clone()
+    backend._fast_metadata = True
+    candidate = _batch(cached, accepted)
+
+    backend.prepare_prefix_metadata(source, candidate)
+
+    _equal(candidate.attn_metadata, reference.attn_metadata)
+    assert source.attn_metadata is source_metadata
+    assert torch.equal(source_metadata.dense_indices, source_indices)
+    assert (
+        candidate.attn_metadata.dense_indices.data_ptr()
+        == source_metadata.dense_indices.data_ptr()
+    )
+
+
+@pytest.mark.parametrize("cached", [32, 36])
+@pytest.mark.parametrize("accepted", [1, 2, 3, 4])
+def test_sparse_source_rebuilds_metadata_including_dense_prefix(
+    monkeypatch, cached, accepted
+):
+    backend = _backend(monkeypatch, False)
+    source, reference = _batch(cached, 4), _batch(cached, accepted)
+    backend.prepare_metadata(source)
+    assert source.attn_metadata.dense_indices is None
+    backend.prepare_metadata(reference)
+    backend._fast_metadata = True
+    candidate = _batch(cached, accepted)
+    backend.prepare_prefix_metadata(source, candidate)
+    _equal(candidate.attn_metadata, reference.attn_metadata)
+
+
+def test_prefix_reuse_rejects_changed_request_origin(monkeypatch):
+    backend = _backend(monkeypatch, True)
+    source = _batch(7, 4)
+    backend.prepare_metadata(source)
+    with pytest.raises(ValueError, match="unchanged accepted-prefix origin"):
+        backend.prepare_prefix_metadata(source, _batch(8, 2))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="QSA arithmetic needs CUDA")
+@pytest.mark.parametrize("cached", [0, 17, 127])
+@pytest.mark.parametrize(
+    "mode,count",
+    [("single", 1)]
+    + [
+        (mode, count)
+        for mode in ["eager-prefix", "capture-prefix"]
+        for count in range(1, 6)
+    ],
+)
+def test_cuda_attention_is_bitwise_equal_with_reused_metadata(
+    monkeypatch, cached, mode, count
+):
+    from sparklab.kernels.triton.attention import paged_attention
+
+    torch.manual_seed(412)
+    device = torch.device("cuda")
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.device = device
+    backend.args = SimpleNamespace(index_compress_ratio=4, index_block_topk=512)
+    backend._fast_metadata = False
+    backend._single_query_id = None
+    page_table = torch.randperm(512, dtype=torch.int32, device=device).view(2, 256)
+    monkeypatch.setattr(
+        "sparklab.attention.qsa.get_global_ctx",
+        lambda: SimpleNamespace(page_table=page_table),
+    )
+    source, reference = _batch(cached, 5), _batch(cached, count)
+    backend.prepare_metadata(source)
+    backend.prepare_metadata(reference)
+    if mode == "capture-prefix":
+        backend.capture = QSACaptureData.create(256, device, max_queries_per_req=5)
+        backend._point_to_capture(source)
+    backend._fast_metadata = True
+    candidate = _batch(cached, count)
+    if mode == "single":
+        backend.prepare_metadata(candidate)
+    else:
+        backend.prepare_prefix_metadata(source, candidate)
+    _equal(candidate.attn_metadata, reference.attn_metadata)
+    q = torch.randn(count, 8, 256, dtype=torch.bfloat16, device=device)
+    k = torch.randn(512, 2, 256, dtype=torch.bfloat16, device=device)
+    v = torch.randn_like(k)
+
+    def forward(md):
+        return paged_attention(
+            q=q,
+            k_cache=k,
+            v_cache=v,
+            indptr=md.dense_indptr,
+            indices=md.dense_indices,
+            q_to_req=md.q_to_req,
+            q_positions=md.dense_q_positions,
+            sm_scale=256**-0.5,
+        )
+
+    assert torch.equal(
+        forward(candidate.attn_metadata), forward(reference.attn_metadata)
+    )
+
+
+@pytest.mark.parametrize("width", [0, 1, 3, 4])
+@pytest.mark.parametrize("max_bs", [1, 3])
+def test_capture_capacity_includes_target_and_every_draft_row(
+    monkeypatch, width, max_bs
+):
+    backend = _backend(monkeypatch, False)
+    backend.config = SimpleNamespace(speculative_tokens=width)
+    backend.capture = None
+    backend.init_capture_graph(64, [1, max_bs])
+    capacity = max_bs * max(4, width + 1)
+    assert backend.capture.dense_indptr.numel() == capacity + 1
+    assert backend.capture.dense_q_positions.numel() == capacity
+    assert backend.capture.q_to_req.numel() == capacity
+    assert backend.capture.last_indices.numel() == capacity
+    assert backend.capture.dense_indices.numel() == capacity * 35
+
+    batch = _batch(2, width + 1)
+    backend.prepare_metadata(batch)
+    backend._point_to_capture(batch)
+    assert batch.attn_metadata.capture_decode
+    assert batch.attn_metadata.dense_q_positions.tolist() == list(range(2, width + 3))

--- a/tests/models/test_qwen4_reject_draft.py
+++ b/tests/models/test_qwen4_reject_draft.py
@@ -1,0 +1,277 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sparklab.models.qwen4_exp.model import Qwen4ExpForCausalLM
+
+
+@pytest.mark.parametrize("width", [3, 4, 5])
+@pytest.mark.parametrize("experimental", [False, True])
+@pytest.mark.parametrize("qwen4", [False, True])
+def test_optimizations_keep_supported_draft_width_limit(
+    monkeypatch, width, experimental, qwen4
+):
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+    from tests.models.test_qwen4_exp import _config, parse_config
+
+    monkeypatch.setenv("SPARKLAB_QWEN4_MTP4", "1" if experimental else "0")
+    model_config = parse_config(_config())
+    if not qwen4:
+        object.__setattr__(model_config, "qwen4_exp_args", None)
+        object.__setattr__(model_config, "mtp_num_hidden_layers", 1)
+    allowed = width <= (4 if qwen4 and experimental else 3)
+    config = SimpleNamespace(
+        model_config=model_config,
+        speculative_tokens=width,
+        max_running_req=1,
+        cache_type="radix",
+        cuda_graph_bs=[],
+        cuda_graph_max_bs=0,
+    )
+
+    def adjust():
+        _adjust_speculative_config(
+            config, lambda name, value: setattr(config, name, value)
+        )
+
+    if allowed:
+        adjust()
+        assert config.model_config.speculative_tokens == width
+    else:
+        with pytest.raises(ValueError, match="MTP supports at most"):
+            adjust()
+
+
+@pytest.mark.parametrize("accepted", [1, 2, 3, 4])
+@pytest.mark.parametrize("raises", [False, True])
+def test_prefix_proposal_hides_rejected_tokens_and_restores_features(
+    monkeypatch, accepted, raises
+):
+    req = SimpleNamespace(cached_len=7, device_len=11, max_device_len=64)
+    batch = SimpleNamespace(
+        reqs=[req],
+        input_ids=torch.tensor([10, 20, 30, 40]),
+        positions=torch.arange(7, 11),
+        out_loc=torch.arange(17, 21),
+    )
+    model = Qwen4ExpForCausalLM.__new__(Qwen4ExpForCausalLM)
+    hidden = torch.arange(24).reshape(4, 6)
+    model._mtp_target_hidden = hidden
+    prepared = []
+    backend = SimpleNamespace(prepare_metadata=lambda b: prepared.append(b))
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.model.get_global_ctx",
+        lambda: SimpleNamespace(attn_backend=backend),
+    )
+    correction = torch.tensor([99])
+
+    def propose(prefix, token):
+        assert prefix is prepared[0]
+        assert prefix.reqs[0] is not req
+        assert prefix.reqs[0].cached_len == 7
+        assert prefix.reqs[0].device_len == 7 + accepted
+        assert prefix.reqs[0].max_device_len == 64
+        assert prefix.input_ids.tolist() == batch.input_ids[:accepted].tolist()
+        assert prefix.positions.tolist() == list(range(7, 7 + accepted))
+        assert prefix.out_loc.tolist() == list(range(17, 17 + accepted))
+        assert torch.equal(model._mtp_target_hidden, hidden[:accepted])
+        assert token is correction
+        if raises:
+            raise RuntimeError("test failure")
+        return token
+
+    model.propose_mtp = propose
+    if raises:
+        with pytest.raises(RuntimeError, match="test failure"):
+            model.propose_mtp_prefix(batch, correction, accepted)
+    else:
+        assert model.propose_mtp_prefix(batch, correction, accepted) is correction
+    assert model._mtp_target_hidden is hidden
+    assert req.device_len == 11
+    assert batch.input_ids.numel() == 4
+
+
+@pytest.mark.parametrize("accepted", [0, 5])
+def test_invalid_accepted_prefix_fails_closed(accepted):
+    model = Qwen4ExpForCausalLM.__new__(Qwen4ExpForCausalLM)
+    with pytest.raises(ValueError):
+        model.propose_mtp_prefix(
+            SimpleNamespace(input_ids=torch.zeros(4)), torch.tensor([1]), accepted
+        )
+
+
+@pytest.mark.parametrize("tied", [False, True])
+def test_fp8_draft_head_does_not_replace_target_weights(monkeypatch, tied):
+    monkeypatch.setenv("SPARKLAB_QWEN4_DRAFT_HEAD", "fp8")
+    monkeypatch.setenv("SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE", "0")
+    original = torch.arange(48, dtype=torch.bfloat16).reshape(8, 6) / 48
+    head = SimpleNamespace(weight=original.clone(), tp_size=1)
+    if tied:
+        lm_head = SimpleNamespace(tied_embedding=head, bias=None)
+    else:
+        lm_head = head
+        lm_head.tied_embedding = None
+        lm_head.bias = None
+    model = Qwen4ExpForCausalLM.__new__(Qwen4ExpForCausalLM)
+    model.lm_head = lm_head
+    model.model = SimpleNamespace(embed_tokens=head)
+    model._mtp = SimpleNamespace(load_sidecar=lambda *_: None)
+    model._mtp_path = "unused-test-sidecar"
+    model._draft_vocab = None
+    model._draft_fp8_head = None
+    model.prepare_for_runtime()
+    weight, scale = model._draft_fp8_head
+    assert weight.dtype == torch.float8_e4m3fn
+    assert weight.shape == original.shape
+    assert scale.shape == (original.shape[0],)
+    assert weight.data_ptr() != head.weight.data_ptr()
+    assert torch.equal(head.weight, original)
+    assert head.weight.dtype == torch.bfloat16
+
+    def reference(hidden, actual_weight, actual_scale, bias):
+        assert actual_weight is weight and actual_scale is scale and bias is None
+        return hidden.float() @ (weight.float() * scale[:, None]).T
+
+    monkeypatch.setattr(
+        "sparklab.kernels.triton.fp8_pertensor_linear.fp8_pertensor_linear", reference
+    )
+    assert model._select_draft_token(torch.ones(1, 6)).tolist() == [7]
+    assert torch.equal(head.weight, original)
+
+
+def test_mtp_proposal_does_not_override_sampled_requests(monkeypatch):
+    model = Qwen4ExpForCausalLM.__new__(Qwen4ExpForCausalLM)
+    model._mtp = object()
+    model._mtp_target_hidden = torch.ones(1, 6)
+    batch = SimpleNamespace(
+        size=1,
+        reqs=[
+            SimpleNamespace(
+                sampling_params=SimpleNamespace(is_greedy=False),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "sparklab.models.qwen4_exp.model.get_global_ctx", lambda: object()
+    )
+    assert model.propose_mtp(batch, torch.tensor([1])) is None
+
+
+@pytest.mark.parametrize(
+    "width,accepted", [(w, a) for w in (3, 4) for a in range(w + 1)]
+)
+@pytest.mark.parametrize("mode", ["enabled", "disabled", "missing_hook", "replay"])
+@pytest.mark.parametrize("light_snapshot", [False, True])
+def test_engine_redraft_preserves_verified_outputs_and_state(
+    monkeypatch, width, accepted, mode, light_snapshot
+):
+    """Exercise the real verifier/engine branch, stubbing only device execution."""
+    from sparklab.runtime.engine.engine import Engine
+
+    monkeypatch.setenv(
+        "SPARKLAB_QWEN4_REJECT_DRAFT", "0" if mode == "disabled" else "1"
+    )
+    monkeypatch.setenv(
+        "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT", "1" if light_snapshot else "0"
+    )
+    engine = Engine.__new__(Engine)
+    engine.stream = object()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: engine.stream)
+    monkeypatch.setattr(
+        torch.cuda, "Event", lambda: SimpleNamespace(record=lambda _: None)
+    )
+    engine.config = SimpleNamespace(
+        speculative_tokens=width,
+        speculative_method="mtp",
+        model_config=SimpleNamespace(qwen4_exp_args=object()),
+    )
+    engine.ctx = SimpleNamespace(forward_batch=lambda _: nullcontext())
+    engine.cpu_moe_executor = None
+    engine.mtp_graph_runner = None
+    engine.graph_runner = SimpleNamespace(can_use_cuda_graph=lambda _: False)
+    engine.mtp_stats = dict(
+        target_forwards=0,
+        drafted=0,
+        accepted=0,
+        outputs=0,
+        replay_calls=0,
+        replay_tokens=0,
+    )
+    events = []
+    engine.linear_state_pool = SimpleNamespace(
+        num_slots=4,
+        verify_steps=0 if mode == "replay" else width + 1,
+        copy_from=lambda *args: events.append(("copy", *args)),
+        snapshot_verify_inputs=lambda *args: events.append(("light", *args)),
+        commit_verify_prefix=lambda *args: events.append(("commit", *args)),
+    )
+    req = SimpleNamespace(
+        table_idx=1,
+        cached_len=7,
+        device_len=7 + width + 1,
+        linear_slot_idx=None,
+        mamba_ping_pong=None,
+        speculative_draft_probs=None,
+        sampling_params=SimpleNamespace(is_greedy=True),
+        can_decode=True,
+    )
+    batch = SimpleNamespace(
+        is_prefill=False,
+        is_verify=True,
+        size=1,
+        reqs=[req],
+        verify_cached_lens=(7,),
+        input_ids=torch.arange(1, width + 2) * 10,
+        cache_verify_states=False,
+    )
+    truth = [20, 30, 40, 50][:width] + [99]
+    truth[accepted] = 99
+    logits = torch.zeros(width + 1, 100)
+    logits[torch.arange(width + 1), torch.tensor(truth)] = 1
+    proposals = torch.arange(51, 51 + width, dtype=torch.int32)
+
+    def prefix_propose(active_batch, correction, length):
+        assert active_batch is batch
+        assert correction.tolist() == [99]
+        assert length == accepted + 1
+        # Recurrent state must be committed before generating new drafts.
+        assert ("commit", 3, 1, length) in events
+        events.append(("redraft", length))
+        return proposals
+
+    engine.model = SimpleNamespace(
+        begin_external_inputs=lambda _: None, forward=lambda: logits
+    )
+    if mode != "missing_hook":
+        engine.model.propose_mtp_prefix = prefix_propose
+    engine._propose_speculative = lambda *_: proposals
+    engine._replay_verified_prefix = lambda *args: events.append(("replay", args[1]))
+
+    output = engine.forward_batch(batch, None)
+    assert events[0] == (
+        "light" if light_snapshot and mode != "replay" else "copy",
+        1,
+        3,
+    )
+    expected = [20, 30, 40, 50][:accepted] + [99]
+    assert output.next_tokens_cpu.tolist() == expected
+    assert output.next_tokens_gpu.tolist() == expected
+    assert output.token_counts == (accepted + 1,)
+    assert output.managed_writes
+    assert req.cached_len == 7 + accepted + 1
+    assert req.device_len == req.cached_len + 1
+    assert batch.speculative_write[:2] == (1, req.cached_len)
+    assert int(batch.speculative_write[2]) == 99
+    assert engine.mtp_stats["accepted"] == accepted
+    assert engine.mtp_stats["outputs"] == accepted + 1
+    should_redraft = accepted < width and mode == "enabled"
+    assert any(event[0] == "redraft" for event in events) == should_redraft
+    if should_redraft or accepted == width:
+        assert req.speculative_drafts is proposals
+    else:
+        assert req.speculative_drafts is None
+    assert engine.mtp_stats["replay_calls"] == int(
+        mode == "replay" and accepted < width
+    )

--- a/tests/runtime/kvcache/test_linear_state_pool_alloc.py
+++ b/tests/runtime/kvcache/test_linear_state_pool_alloc.py
@@ -64,6 +64,46 @@ def test_copy_from_snapshot():
     assert torch.equal(pool.recurrent_states[:, dst], pool.recurrent_states[:, src])
 
 
+@pytest.mark.parametrize("length", [1, 2, 3, 4, 5])
+def test_light_snapshot_commit_never_reads_snapshot_recurrent_state(length):
+    pool = _pool(num_slots=4)
+    pool.enable_verify_transactions(5)
+    src, dst = 1, 2
+    torch.manual_seed(25)
+    pool.conv_states.normal_()
+    pool.recurrent_states.normal_()
+    aux = pool.ensure_aux_state("ple", (2, 7), torch.bfloat16)
+    aux.normal_()
+    aux_inputs = pool.ensure_aux_verify_inputs("ple")
+    aux_inputs.normal_()
+    pool.verify_recurrent_states.normal_()
+    pool.verify_conv_inputs.normal_()
+    conv_before = pool.conv_states[:, src].clone()
+    aux_before = aux[src].clone()
+    rec_before = pool.recurrent_states[:, src].clone()
+    pool.recurrent_states[:, dst].fill_(float("nan"))
+
+    pool.snapshot_verify_inputs(src, dst)
+    assert torch.equal(pool.conv_states[:, dst], conv_before)
+    assert torch.equal(aux[dst], aux_before)
+    assert torch.isnan(pool.recurrent_states[:, dst]).all()
+    assert torch.equal(pool.recurrent_states[:, src], rec_before)
+    pool.conv_states[:, src].fill_(99)
+    aux[src].fill_(99)
+    pool.commit_verify_prefix(dst, src, length)
+
+    expected_conv = torch.cat((conv_before, pool.verify_conv_inputs[:, :length].transpose(1, 2)), -1)
+    expected_aux = torch.cat((aux_before, aux_inputs[:length].T), -1)
+    assert torch.equal(pool.conv_states[:, src], expected_conv[..., -conv_before.shape[-1]:])
+    assert torch.equal(aux[src], expected_aux[..., -aux_before.shape[-1]:])
+    assert torch.equal(pool.recurrent_states[:, src], pool.verify_recurrent_states[:, 0, length - 1])
+
+
+def test_light_snapshot_requires_transactions():
+    with pytest.raises(RuntimeError, match="prefix transactions"):
+        _pool().snapshot_verify_inputs(1, 2)
+
+
 @pytest.mark.parametrize("length", [1, 2, 3, 4])
 def test_commit_verify_prefix(length):
     pool = _pool(num_slots=6)

--- a/tests/runtime/scheduler/test_scheduler_chunked_prefill.py
+++ b/tests/runtime/scheduler/test_scheduler_chunked_prefill.py
@@ -14,6 +14,7 @@ prompt is inserted once when the final (non-chunked) chunk is processed.
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 CHUNK = 8
@@ -150,3 +151,51 @@ def test_batched_prefill_carries_each_new_prompt_admission():
     batch = pm.schedule_next_batch(16)
     assert batch is not None
     assert batch.prompt_admissions == [(1, 3, 0), (2, 5, 0)]
+
+
+@pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("lookahead", [1, 3, 4])
+@pytest.mark.parametrize("cache_type", ["radix", "hybrid_radix"])
+@pytest.mark.parametrize("abort_after", [None, 1, 2])
+def test_chunked_prefill_retains_speculative_allocation_watermark(
+    page_size, lookahead, cache_type, abort_after,
+):
+    from sparklab.core import SamplingParams
+    from sparklab.runtime.scheduler.cache import CacheManager
+    from sparklab.runtime.scheduler.decode import DecodeManager
+    from sparklab.runtime.scheduler.prefill import PrefillManager
+    from sparklab.runtime.scheduler.table import TableManager
+    from sparklab.runtime.scheduler.utils import PendingReq
+    from tests.runtime.scheduler.test_hybrid_cache_manager import _pool
+
+    _setup_context()
+    pt = torch.zeros((4, 128), dtype=torch.int32)
+    pool = _pool() if cache_type == "hybrid_radix" else None
+    cm = CacheManager(128, page_size, pt, cache_type, linear_state_pool=pool)
+    tm = TableManager(max_running_reqs=4, page_table=pt)
+    pm = PrefillManager(cm, tm, DecodeManager(page_size=page_size))
+    pm.pending_list = [PendingReq(
+        UID, torch.arange(48, dtype=torch.int32), SamplingParams(max_tokens=8),
+    )]
+    prior_allocated = 0
+    chunks = 0
+    while pm.runnable:
+        batch = pm.schedule_next_batch(16)
+        req = batch.reqs[0]
+        assert req.allocated_len == prior_allocated
+        # Same lookahead reservation as Scheduler._prepare_batch. The next
+        # ChunkedReq must inherit it even though target cached_len is shorter.
+        actual = req.device_len
+        req.device_len += lookahead
+        cm.allocate_paged([req])
+        prior_allocated = req.allocated_len
+        req.device_len = actual
+        req.complete_one()
+        chunks += 1
+        if chunks == abort_after:
+            assert pm.abort_req(UID) is req
+            break
+
+    cm.cache_req(req, finished=True)
+    tm.free(req.table_idx)
+    cm.check_integrity()

--- a/tests/test_qwen4_regression.py
+++ b/tests/test_qwen4_regression.py
@@ -1,0 +1,146 @@
+"""Keep the optimization quality protocol deterministic and its grading honest."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _module():
+    path = Path(__file__).parents[1] / "benchmarks/quality/qwen4_regression.py"
+    spec = importlib.util.spec_from_file_location("qwen4_regression_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fixed_smoke_cases_and_mgsm_subset():
+    module = _module()
+    cases = module.cases()
+    assert len(cases) == len({row[0] for row in cases}) == 52
+    assert module.INDICES == list(range(2, 250, 5))
+    assert len(module.INDICES) == 50
+    assert len(module.CODE_CASES) == 5
+
+
+def test_smoke_distinguishes_correct_answer_from_strict_format(monkeypatch, tmp_path):
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "cases",
+        lambda: [
+            ("exact", "unused", "42", "final"),
+            ("format", "unused", "42", "final"),
+            ("wrong", "unused", "42", "final"),
+            ("object", "unused", {"sum": 42}, "json"),
+        ],
+    )
+    answers = iter(
+        ["FINAL=42", "The answer is FINAL=42", "FINAL=42 then FINAL=41", '{"sum":42}']
+    )
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+        def read(self):
+            return json.dumps(
+                {"choices": [{"message": {"content": next(answers)}}]}
+            ).encode()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *_, **__: Response())
+    path = tmp_path / "report.json"
+    module.run_smoke("http://localhost", "fixture", path)
+    report = json.loads(path.read_text())
+    assert report["status"] == "complete"
+    assert report["expected_total"] == report["total"] == 4
+    assert report["passed"] == 2
+    assert [row["answer_correct"] for row in report["cases"]] == [
+        True,
+        True,
+        False,
+        True,
+    ]
+
+
+def test_lifecycle_protocol_checks_boundaries_and_closes_streams(monkeypatch, tmp_path):
+    module = _module()
+    current_label = ""
+
+    def request(_origin, _model, prompt, *, tokens=1024, extra=None, **_):
+        nonlocal current_label
+        finish = "stop"
+        if prompt.startswith("List"):
+            answer, finish = "1", "length"
+        elif prompt.startswith("Copy"):
+            answer = "START-ALPHA "
+        elif prompt.startswith("Reply exactly"):
+            answer = prompt.removeprefix("Reply exactly with ")
+        else:
+            last = extra["messages"][-1]["content"]
+            if "Replace any previous label" in last:
+                current_label = last.split(" is ")[1].split(".")[0]
+                answer = "ACK"
+            else:
+                answer = current_label
+        return {
+            "usage": {"completion_tokens": tokens},
+            "choices": [
+                {
+                    "finish_reason": finish,
+                    "message": {"role": "assistant", "content": answer},
+                }
+            ],
+        }
+
+    closed = []
+
+    class Stream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            closed.append(True)
+
+        def __iter__(self):
+            for _ in range(3):
+                yield b'data: {"choices":[{"delta":{"content":"part"}}]}\n'
+
+    monkeypatch.setattr(module, "request", request)
+    monkeypatch.setattr(module.urllib.request, "urlopen", lambda *_, **__: Stream())
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    path = tmp_path / "lifecycle.json"
+    module.run_lifecycle("http://localhost", "fixture", path)
+    result = json.loads(path.read_text())
+    assert result["status"] == "complete"
+    assert result["passed"] == result["expected_total"] == result["total"] == 15
+    assert len(closed) == 3
+    assert [row["observed_chunks"] for row in result["cases"][-3:]] == [1, 2, 3]
+
+
+def test_interrupted_lifecycle_report_is_not_complete(monkeypatch, tmp_path):
+    module = _module()
+    calls = 0
+
+    def request(*_, tokens, **__):
+        nonlocal calls
+        calls += 1
+        if calls == 4:
+            raise RuntimeError("server failed")
+        return {
+            "usage": {"completion_tokens": tokens},
+            "choices": [{"finish_reason": "length"}],
+        }
+
+    monkeypatch.setattr(module, "request", request)
+    path = tmp_path / "partial.json"
+    with pytest.raises(RuntimeError, match="server failed"):
+        module.run_lifecycle("http://localhost", "fixture", path)
+    result = json.loads(path.read_text())
+    assert result["status"] == "running"
+    assert result["total"] == 3
+    assert result["expected_total"] == 15


### PR DESCRIPTION
## Outcome

Add an opt-in full-vocabulary Qwen3.8-Flash-Next MTP3 profile for native single-DGX-Spark serving. Recipe defaults, model weights, target precision, and portfolio metrics remain unchanged.

- Redraft immediately from the verified prefix after a rejection.
- Build a separate full-vocabulary FP8 proposal head while preserving the BF16 target head and embeddings.
- Avoid copying recurrent state that transactional verification does not overwrite.
- Preserve speculative allocation watermarks across chunked prefill, fixing a page leak.
- Retain separately gated metadata-reuse and Qwen4-only MTP4 research options with bounds/correctness tests; neither replaces the recommended MTP3 profile.
- Add portable fixed smoke, MGSM-subset, extended, and lifecycle regression runners plus versioned benchmark evidence.

### Measured single-stream trade-off

Five-trial medians, one warmup per workload, same NVIDIA checkpoint:

| Workload | Fresh baseline | Opt-in fast MTP3 | Change |
|---|---:|---:|---:|
| Math, 128 tokens | 32.57 tok/s | 42.14 tok/s | +29.4% |
| English prose, 600 tokens | 27.58 tok/s | 34.21 tok/s | +24.0% |
| Code, 512 tokens | 33.67 tok/s | 38.64 tok/s | +14.8% |
| Chinese prose, 600 tokens | 29.28 tok/s | 36.18 tok/s | +23.6% |

The fixed 100-case EN/ZH MGSM tuning subset changes from **94/100 to 92/100**: three new failures and one recovery. This is a disclosed opt-in trade-off, not a no-quality-drop claim or a bound on other tasks. Prompts, gold answers, budgets, and scoring were not changed. The subset was used during tuning, not held out for final certification.

Evidence: [`GB10-QWENNVIDIA-004`](https://github.com/sixteen-miles-labs/sparklab/blob/9e22ab406a0481655481c0f3450f421ef4168053/benchmarks/gb10/results/GB10-QWENNVIDIA-004.json). The existing target-FP8 projection mode was separately screened and not selected for speed: [`GB10-QWENNVIDIA-005`](https://github.com/sixteen-miles-labs/sparklab/blob/9e22ab406a0481655481c0f3450f421ef4168053/benchmarks/gb10/results/GB10-QWENNVIDIA-005.json). Neither the metadata nor MTP4/target-FP8 speed screens inherit the accepted profile's MGSM score.

## Validation

- Post-rebase CPU regression selection: 1,602 passed, 81 skipped.
- GPU GDN prefix-commit versus replay: 18 passed.
- GPU QSA attention output equality with reused/five-row metadata: 33 passed.
- New-file Ruff check and format check, JSON syntax, public-tree hygiene, and `git diff --check` passed.
- The selected profile's 52-case smoke suite has no new answer regressions; extended coding/reasoning/recall/tool checks passed 15/15, and lifecycle checks passed 15/15 at both tested sequence caps.
- No OOM, swap-out, or memory-guard events in the recorded completed runs. Shutdown reported four multiprocessing semaphore objects for cleanup; not described as warning-free.

Exact local commands:

```bash
CUDA_VISIBLE_DEVICES='' SPARKLAB_DISABLE_JIT=1 \
SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 PYTHONPATH=python \
python -m pytest -q tests/checkpoint tests/daemon tests/models tests/serving \
  tests/sparklab tests/tokenizer tests/runtime tests/test_*.py \
  -m 'not slow and not needs_weights'

SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 PYTHONPATH=python \
python -m pytest -q tests/models/test_qwen4_exp.py \
  -k gdn_verify_prefix_matches_replay

SPARKLAB_DISABLE_KERNEL_CACHE_VERSION_CHECK=1 PYTHONPATH=python \
python -m pytest -q tests/models/test_qwen4_qsa_metadata.py \
  -k cuda_attention_is_bitwise_equal
```

Benchmarks were measured in a development worktree using existing pinned extensions with the source/cache version check bypassed. They are not clean-revision, concurrency, 64K-context, or full endurance certification. Actual extended recall prompts were approximately 11,735 tokens. Recorded source hashes and raw-artifact hashes preserve the measurement provenance; portable public summaries replace machine-specific home paths with `$HOME`.

## Checklist

- [x] Focused changes; no unrelated generated files, model weights, or credentials.
- [x] Behavior changes include tests and documentation.
- [x] Performance and quality claims link versioned evidence and disclose limitations.
- [x] No breaking package/artifact-format/compatibility change; runtime experiments are opt-in.
- [x] Commit includes a DCO `Signed-off-by` line.
- [x] Submitted under the repository's contribution and licensing terms.
