### PR TITLE
docs: update Qwen3.8 fast profile in README portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
     <tr>
       <td><a href="https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW">Qwen3.8-Flash-Next</a></td>
       <td>125B LM + 55B auxiliary / 6B active</td>
-      <td>NVFP4 · FTW + optional MTP3</td>
-      <td>Experimental</td>
-      <td align="right">31.97</td>
-      <td align="right">0.260</td>
-      <td><a href="docs/models/qwen3.8-flash-next.md">Instructions</a></td>
+      <td>NVFP4 · FTW + opt-in fast MTP3 (FP8 draft head)</td>
+      <td>Experimental<br><small>MGSM subset: 94/100 → 92/100</small></td>
+      <td align="right"><a href="benchmarks/gb10/results/GB10-QWENNVIDIA-004.json" title="Single stream, 128 output tokens, five-trial median">42.14</a></td>
+      <td align="right">0.244</td>
+      <td><a href="docs/models/qwen3.8-flash-next.md#experimental-full-vocabulary-draft-optimization">Fast profile</a></td>
     </tr>
     <tr>
       <td><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731">DeepSeek V4 Flash</a></td>

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -116,7 +116,8 @@ was about 11,735 prompt tokens, not 32K/64K certification. This is the fastest
 fully evaluated profile so far and is a reasonable opt-in when the observed
 two-point loss on this subset is acceptable. It does **not** meet a
 no-quality-drop requirement; two points here are not a bound on losses on other
-tasks. The original recipe and portfolio metric remain unchanged.
+tasks. Recipe defaults remain unchanged; the README portfolio reports this
+opt-in profile.
 This fixed subset was used during tuning, not as an independent final evaluation.
 
 Restoring the BF16 draft head while retaining immediate redraft scored


### PR DESCRIPTION
## Outcome

Update only the README portfolio selection and its matching model-guide description following #65.

- Qwen3.8-Flash-Next now shows **42.14 tok/s** and **0.244 s warm TTFT**, both from the same `candidate-fp8-light` single-stream, 128-token, five-trial math probe.
- Label the row as **opt-in fast MTP3 (FP8 draft head)**, retain Experimental status, and disclose the fixed MGSM tuning-subset change from **94/100 to 92/100**.
- Link directly to the evidence and the correct fast-profile instructions.
- Recipe defaults, catalog metrics, other portfolio rows, and model weights are unchanged. The model guide now explicitly distinguishes the README's opt-in selection from default recipe behavior.

Evidence: [GB10-QWENNVIDIA-004](https://github.com/sixteen-miles-labs/sparklab/blob/974b474718bbedca14d18aa7ab8152b48623d8af/benchmarks/gb10/results/GB10-QWENNVIDIA-004.json).

## Validation

- Programmatically compared both displayed values against the exact recorded medians with the README's rounding.
- Verified the local evidence path and model-guide heading/anchor.
- Checked that the diff contains only README.md and the corresponding model-guide paragraph; other model rows and recipe files are unchanged.
- `git diff --check` and public-tree path hygiene passed.
- Documentation-only change; no new performance measurements or quality claims.

## Checklist

- [x] Focused change with no unrelated generated files or credentials.
- [x] Existing versioned evidence supports the displayed metrics and quality trade-off.
- [x] No runtime, public API, package, or artifact-format change.
- [x] Commit includes a DCO Signed-off-by line.
