### PR TITLE
docs: simplify Qwen3.8 portfolio labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
     <tr>
       <td><a href="https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW">Qwen3.8-Flash-Next</a></td>
       <td>125B LM + 55B auxiliary / 6B active</td>
-      <td>NVFP4 · FTW + opt-in fast MTP3 (FP8 draft head)</td>
-      <td>Experimental<br><small>MGSM subset: 94/100 → 92/100</small></td>
+      <td>NVFP4 · FTW + opt-in fast MTP3</td>
+      <td>Experimental</td>
       <td align="right"><a href="benchmarks/gb10/results/GB10-QWENNVIDIA-004.json" title="Single stream, 128 output tokens, five-trial median">42.14</a></td>
       <td align="right">0.244</td>
-      <td><a href="docs/models/qwen3.8-flash-next.md#experimental-full-vocabulary-draft-optimization">Fast profile</a></td>
+      <td><a href="docs/models/qwen3.8-flash-next.md#experimental-full-vocabulary-draft-optimization">Instructions</a></td>
     </tr>
     <tr>
       <td><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731">DeepSeek V4 Flash</a></td>

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
       <td>125B LM + 55B auxiliary / 6B active</td>
       <td>NVFP4 · FTW + opt-in fast MTP3</td>
       <td>Experimental</td>
-      <td align="right"><a href="benchmarks/gb10/results/GB10-QWENNVIDIA-004.json" title="Single stream, 128 output tokens, five-trial median">42.14</a></td>
+      <td align="right">42.14</td>
       <td align="right">0.244</td>
       <td><a href="docs/models/qwen3.8-flash-next.md#experimental-full-vocabulary-draft-optimization">Instructions</a></td>
     </tr>


### PR DESCRIPTION
## Outcome

Apply the requested README-only wording correction after #66:

- Restore the link label to **Instructions**, retaining its fast-profile destination.
- Remove the **(FP8 draft head)** parenthetical and inline MGSM-subset note from the portfolio row.
- Display **42.14** as plain text without a hyperlink.
- Keep **42.14 tok/s**, **0.244 s warm TTFT**, the opt-in MTP3 label, and Experimental status unchanged.

The model guide and benchmark evidence still contain the full configuration and measured quality trade-off. No runtime, recipe, or other model row changes.

## Validation

- Inspected the README-only diff; performance values and the Instructions destination are unchanged.
- `git diff --check` passed.
- Commit includes DCO sign-off.
