### PR TITLE
perf(glm53): expand expert cache and refresh portfolio metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,20 +170,6 @@ Status meanings:
 - **Certified:** the exact recipe, revision, artifact, and release environment passed all
   required correctness, parser, agent, context, latency, memory, NVMe, and endurance gates.
 
-Throughput is decode tokens per second; warm TTFT is time to first token in seconds.
-Values report selected single-stream probes; see the
-[model evidence and caveats](docs/models.md#evidence-and-caveats) for configurations and
-validation limits. Qwen3.6-35B-A3B, Qwen3.8-27B, Qwen3.8-Flash-Next, DeepSeek V4 Flash, and GLM-5.3
-Flash report opt-in speculative profiles; target-only serving remains their default.
-Concurrent-serving measurements remain in the linked model evidence.
-
-Qwen3.6's row reports its optional MTP2 profile; full MTP certification remains pending.
-Its certified target-only profile measured
-67.79 tok/s and 0.329 s warm TTFT; see its
-[target-only evidence](benchmarks/gb10/results/GB10-QWEN36-FAST-002.json).
-GLM-5.3 and Kimi K3 measurements establish
-bounded execution; answer correctness remains unproven.
-
 Run `sparklab models --json` for exact recipe versions, checkpoint revisions, artifact
 fingerprints, implementation state, evidence IDs, and known constraints.
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
       <td>753B total / 40B active</td>
       <td>NVFP4 + resident FP8 · FTW</td>
       <td>Experimental</td>
-      <td align="right">0.81</td>
-      <td align="right">2.530</td>
+      <td align="right">1.11</td>
+      <td align="right">1.958</td>
       <td><a href="docs/models/glm-5.3.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/bench_aime_suite.py
+++ b/benchmarks/bench_aime_suite.py
@@ -92,6 +92,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--cpu-threads", type=int, default=8)
     p.add_argument("--mem-ratio", type=float, default=0.9)
     p.add_argument(
+        "--min-memory-gib", type=float, default=0.0,
+        help="terminate the server if system MemAvailable drops below this floor",
+    )
+    p.add_argument(
         "--num-tokens",
         type=int,
         default=0,
@@ -393,6 +397,7 @@ def summarize(
             "prefill_sparse_max_tokens": args.prefill_sparse_max_tokens,
             "shared_expert_overlap": args.shared_expert_overlap,
             "memory_ratio": args.mem_ratio,
+            "min_memory_gib": args.min_memory_gib,
             "cuda_graph": not args.no_graph,
             "minimum_duration_minutes": args.minimum_duration_minutes,
         },
@@ -476,6 +481,10 @@ def main() -> int:
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, start_new_session=True
         )
+        lifecycle = GpuTelemetry(
+            min_available_gib=args.min_memory_gib, abort_process_group=proc.pid,
+        )
+        lifecycle.start()
         pump = threading.Thread(target=pump_output, args=(proc.stdout, log_file), daemon=True)
         pump.start()
         try:
@@ -511,8 +520,11 @@ def main() -> int:
                 )
             serving_seconds = time.monotonic() - serving_started
         finally:
-            stop_server(proc)
-            pump.join(timeout=10)
+            try:
+                stop_server(proc)
+                pump.join(timeout=10)
+            finally:
+                lifecycle_telemetry = lifecycle.stop()
     stability = stability_summary(
         log_path=log_path,
         serving_seconds=serving_seconds,
@@ -527,6 +539,7 @@ def main() -> int:
         ),
     )
     summary = summarize(args, results, sampling, stability)
+    summary["lifecycle_telemetry"] = lifecycle_telemetry
     summary["server_log"] = log_path
     append_jsonl(args.json_out, summary)
     print(json.dumps(summary, indent=2), flush=True)

--- a/benchmarks/bench_decode_moe.py
+++ b/benchmarks/bench_decode_moe.py
@@ -645,17 +645,19 @@ def serve_cmd(args: argparse.Namespace, backend: str, port: int) -> list[str]:
         "--cuda-graph-max-bs", "0" if args.no_graph else "1",
         "--moe-hybrid-max-fetch", str(args.hybrid_fetch),
         "--moe-cache-policy", args.cache_policy,
-        "--speculative-method", args.speculative_method,
-        "--speculative-tokens", str(args.speculative_tokens),
-        "--draft-sample-method", args.draft_sample_method,
-        "--dspark-confidence-threshold", str(args.dspark_confidence_threshold),
-        "--dspark-draft-cache-slots", str(args.dspark_draft_cache_slots),
-        "--dspark-draft-cache-quotas", args.dspark_draft_cache_quotas,
-        "--dsv4-kv-storage", args.dsv4_kv_storage,
-        "--dsv4-index-storage", args.dsv4_index_storage,
-        "--qwen4-dense-storage", args.qwen4_dense_storage,
+        # The AIME/context/capability suites share this launcher but do not
+        # expose the decode probe's speculative and model-specific CLI knobs.
+        "--speculative-method", getattr(args, "speculative_method", "auto"),
+        "--speculative-tokens", str(getattr(args, "speculative_tokens", 0)),
+        "--draft-sample-method", getattr(args, "draft_sample_method", "greedy"),
+        "--dspark-confidence-threshold", str(getattr(args, "dspark_confidence_threshold", 0.0)),
+        "--dspark-draft-cache-slots", str(getattr(args, "dspark_draft_cache_slots", 0)),
+        "--dspark-draft-cache-quotas", getattr(args, "dspark_draft_cache_quotas", ""),
+        "--dsv4-kv-storage", getattr(args, "dsv4_kv_storage", "bf16"),
+        "--dsv4-index-storage", getattr(args, "dsv4_index_storage", "bf16"),
+        "--qwen4-dense-storage", getattr(args, "qwen4_dense_storage", "bf16"),
     ]
-    if args.speculative_draft_model:
+    if getattr(args, "speculative_draft_model", None):
         cmd += ["--speculative-draft-model", args.speculative_draft_model]
     if args.num_tokens > 0:
         cmd += ["--num-tokens", str(args.num_tokens)]

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-aime2850.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-aime2850.json
@@ -1,0 +1,548 @@
+{
+  "notes": [
+    "Local home paths redacted to $HOME; measurements unchanged."
+  ],
+  "rows": [
+    {
+      "kind": "request",
+      "problem": 0,
+      "expected": "70",
+      "answer": "70",
+      "correct": true,
+      "prompt_tokens": 54,
+      "completion_tokens": 841,
+      "decode_steps": 840,
+      "decode_seconds": 769.9959698920138,
+      "decode_tok_s": 1.0909148006551304,
+      "ttft_ms": 25781.043876952026,
+      "inter_token_ms_p50": 917.807943013031,
+      "inter_token_ms_p95": 1106.5994320088066,
+      "output_sha1": "4bb42da2c07f",
+      "finish_reason": "stop",
+      "ended_by_eos": true,
+      "parser_ok": true,
+      "reasoning_channel_seen": true,
+      "content_channel_seen": true,
+      "vram_gib": 76.9296875,
+      "gpu_telemetry": {
+        "samples": 769,
+        "duration_s": 796.769856769999,
+        "swap_start_bytes": 687820800,
+        "memory_guard_gib": 0,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86806528,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": -45056
+          }
+        },
+        "power_w_avg": 17.288049414824446,
+        "power_w_peak": 19.15,
+        "temperature_c_peak": 48,
+        "utilization_pct_avg": 35.198959687906374,
+        "request_energy_j_est": 13774.59665608234,
+        "mem_available_gib_min": 29.85367202758789,
+        "nvme_temperature_c_peak": 52.85,
+        "swap_in_pages_delta": 30,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 6559854,
+        "major_faults_delta": 14,
+        "oom_kill_delta": 0
+      },
+      "reasoning_output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nFirst, convert to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = 9b + 7$\n\nWe need $(b+7) \\mid (9b + 7)$.\n\nNote that $9b + 7 = 9(b + 7) - 63 + 7 = 9(b+7) - 56$.\n\nSo $(b+7) \\mid (9b+7)$ iff $(b+7) \\mid 56$.\n\nSo $b + 7$ must be a divisor of 56, with $b > 9$, so $b + 7 > 16$.\n\nDivisors of 56: 1, 2, 4, 7, 8, 14, 28, 56.\n\nWe need $b + 7 > 16$, so $b + 7 \\in \\{28, 56\\}$, giving $b = 21$ or $b = 49$.\n\nCheck: $b = 21$: $17_{21} = 28$, $97_{21} = 9 \\cdot 21 + 7 = 196$. $196 / 28 = 7$. Yes.\n\n$b = 49$: $17_{49} = 56$, $97_{49} = 9 \\cdot 49 + 7 = 448$. $448 / 56 = 8$. Yes.\n\nSum: $21 + 49 = 70$.",
+      "output_text": "## Setting Up the Problem\n\nFirst, I'll convert each number from base $b$ to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = 9b + 7$\n\nI need to find all bases $b > 9$ where $(b+7) \\mid (9b+7)$.\n\n## Simplifying the Divisibility Condition\n\nI'll try to relate $9b + 7$ to $b + 7$. Multiplying $b+7$ by 9:\n$$9(b+7) = 9b + 63$$\n\nSo:\n$$9b + 7 = 9(b+7) - 63 + 7 = 9(b+7) - 56$$\n\nSince $9(b+7)$ is automatically divisible by $(b+7)$, the condition becomes:\n$$(b+7) \\mid 56$$\n\n## Finding Valid Bases\n\nThe positive divisors of 56 are:\n$$1, 2, 4, 7, 8, 14, 28, 56$$\n\nSince $b > 9$, I need $b + 7 > 16$. Checking the divisors:\n- $b + 7 = 28 \\implies b = 21$ ✓\n- $b + 7 = 56 \\implies b = 49$ ✓\n\nAll other divisors give $b + 7 \\leq 14$, meaning $b \\leq 7$, which fails $b > 9$.\n\n## Verification\n\n**Base $b = 21$:** $17_{21} = 28$ and $97_{21} = 9(21) + 7 = 196$. Since $196 = 7 \\cdot 28$, it works. ✓\n\n**Base $b = 49$:** $17_{49} = 56$ and $97_{49} = 9(49) + 7 = 448$. Since $448 = 8 \\cdot 56$, it works. ✓\n\n## Final Answer\n\nThe sum of all valid bases is:\n$$21 + 49 = \\boxed{70}$$",
+      "moe": {
+        "active": 504600,
+        "missing": 230542,
+        "fetched": 0,
+        "calls": 63075,
+        "sparse_prefill_layers": 300,
+        "sparse_prefill_routes": 176400,
+        "sparse_prefill_unique_rows": 11449,
+        "sparse_prefill_fallback_layers": 0,
+        "shared_expert_overlap_calls": 63375,
+        "disk": {
+          "cache_hits": 0,
+          "cache_misses": 240794,
+          "cache_evictions": 0,
+          "cache_bypasses": 10252,
+          "read_ops": 963176,
+          "logical_bytes": 5112938889216,
+          "physical_bytes": 5112938889216,
+          "read_seconds": 481.6573417884647,
+          "cache_capacity_entries": 0,
+          "cache_capacity_bytes": 0,
+          "cache_allocated_bytes": 0,
+          "cache_occupancy_entries": 0,
+          "cache_occupancy_bytes": 0,
+          "staging_allocated_bytes": 5435817984,
+          "host_allocated_bytes": 5435817984,
+          "read_workers": 20,
+          "cache_policy": "layer_lru",
+          "staging_buffers": 1
+        }
+      }
+    },
+    {
+      "kind": "request",
+      "problem": 1,
+      "expected": "588",
+      "answer": null,
+      "correct": false,
+      "prompt_tokens": 180,
+      "completion_tokens": 1024,
+      "decode_steps": 1023,
+      "decode_seconds": 941.7629881449975,
+      "decode_tok_s": 1.0862605696737095,
+      "ttft_ms": 36702.91888399515,
+      "inter_token_ms_p50": 914.6150990272872,
+      "inter_token_ms_p95": 1120.6481520202942,
+      "output_sha1": "ec60faef3dd1",
+      "finish_reason": "length",
+      "ended_by_eos": false,
+      "parser_ok": true,
+      "reasoning_channel_seen": true,
+      "content_channel_seen": false,
+      "vram_gib": 77.53515625,
+      "gpu_telemetry": {
+        "samples": 945,
+        "duration_s": 978.466779128008,
+        "swap_start_bytes": 687771648,
+        "memory_guard_gib": 0,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": 0
+          }
+        },
+        "power_w_avg": 17.33198941798942,
+        "power_w_peak": 19.29,
+        "temperature_c_peak": 49,
+        "utilization_pct_avg": 34.63492063492063,
+        "request_energy_j_est": 16958.775861700826,
+        "mem_available_gib_min": 29.48431396484375,
+        "nvme_temperature_c_peak": 54.85,
+        "swap_in_pages_delta": 2,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 8060380,
+        "major_faults_delta": 11,
+        "oom_kill_delta": 0
+      },
+      "reasoning_output_text": "We have triangle $ABC$ with points $D, E$ on $AB$ and $F, G$ on $AC$.\n\n$AD = 4$, $DE = 16$, $EB = 8$, so $AB = 4 + 16 + 8 = 28$.\n$AF = 13$, $FG = 52$, $GC = 26$, so $AC = 13 + 52 + 26 = 91$.\n\n$M$ is the reflection of $D$ through $F$: $F$ is the midpoint of $DM$, so $M$ is on ray $AF$ beyond $F$ with $FM = FD = AF - AD$... wait, $D$ is on $AB$, $F$ is on $AC$. $M = 2F - D$ (as vectors).\n\n$N$ is the reflection of $G$ through $E$: $E$ is midpoint of $GN$, so $N = 2E - G$.\n\nArea of quadrilateral $DEGF$ is 288. Find area of heptagon $AFNBCEM$.\n\nLet me set up coordinates. Let $A$ be at origin. Let $B$ be along one direction, $C$ along another. \n\nLet $\\vec{B} = \\mathbf{b}$, $\\vec{C} = \\mathbf{c}$. Then $D = \\frac{AD}{AB}\\mathbf{b} = \\frac{4}{28}\\mathbf{b} = \\frac{1}{7}\\mathbf{b}$. $E = \\frac{AD + DE}{AB}\\mathbf{b} = \\frac{20}{28}\\mathbf{b} = \\frac{5}{7}\\mathbf{b}$. $F = \\frac{AF}{AC}\\mathbf{c} = \\frac{13}{91}\\mathbf{c} = \\frac{1}{7}\\mathbf{c}$. $G = \\frac{AF+FG}{AC}\\mathbf{c} = \\frac{65}{91}\\mathbf{c} = \\frac{5}{7}\\mathbf{c}$.\n\nNice, so $D = \\frac{1}{7}\\mathbf{b}$, $E = \\frac{5}{7}\\mathbf{b}$, $F = \\frac{1}{7}\\mathbf{c}$, $G = \\frac{5}{7}\\mathbf{c}$.\n\n$M = 2F - D = \\frac{2}{7}\\mathbf{c} - \\frac{1}{7}\\mathbf{b}$.\n$N = 2E - G = \\frac{10}{7}\\mathbf{b} - \\frac{5}{7}\\mathbf{c}$.\n\nArea of quadrilateral $DEGF$: vertices $D, E, G, F$. This is a trapezoid-like region between segments $DE$ (on $AB$) and $FG$ (on $AC$). Its area: Let's compute using the fact that $DEGF$ is bounded by $DE$ on line $AB$, $FG$ on line $AC$, and segments $DG$ and $EF$.\n\nActually, quadrilateral $DEGF$ with vertices in order $D \\to E \\to G \\to F$. Area = area of triangle $ADG$... hmm, let me think. \n\nArea of triangle $ADE$ is 0 since $A, D, E$ are collinear. Let's compute area of $DEGF$ as area of triangle $AEG$ minus area of triangle $ADF$? Let's see: Triangle $AEG$ contains points $D$ (on $AE$) and $F$ (on $AG$). Quadrilateral $DEGF$ = triangle $AEG$ minus triangle $ADF$. Yes: triangle $AEG$ has vertices $A$, $E$ on $AB$, $G$ on $AC$. Removing triangle $ADF$ (with $D$ on $AE$, $F$ on $AG$) leaves quadrilateral $DEGF$.\n\nArea of triangle $AEG$: $\\frac{AE}{AB} \\cdot \\frac{AG}{AC} \\cdot [ABC] = \\frac{5}{7} \\cdot \\frac{5}{7} [ABC] = \\frac{25}{49}[ABC]$.\n\nArea of triangle $ADF$: $\\frac{AD}{AB}\\cdot\\frac{AF}{AC}[ABC] = \\frac{1}{7}\\cdot\\frac{1}{7}[ABC] = \\frac{1}{49}[ABC]$.\n\nSo area $DEGF$ = $\\frac{24}{49}[ABC] = 288$, giving $[ABC] =",
+      "output_text": "",
+      "moe": {
+        "active": 613800,
+        "missing": 283131,
+        "fetched": 0,
+        "calls": 76725,
+        "sparse_prefill_layers": 75,
+        "sparse_prefill_routes": 102000,
+        "sparse_prefill_unique_rows": 13557,
+        "sparse_prefill_fallback_layers": 0,
+        "shared_expert_overlap_calls": 76800,
+        "disk": {
+          "cache_hits": 0,
+          "cache_misses": 296657,
+          "cache_evictions": 0,
+          "cache_bypasses": 13526,
+          "read_ops": 1186628,
+          "logical_bytes": 6299115061248,
+          "physical_bytes": 6299115061248,
+          "read_seconds": 591.5360656913253,
+          "cache_capacity_entries": 0,
+          "cache_capacity_bytes": 0,
+          "cache_allocated_bytes": 0,
+          "cache_occupancy_entries": 0,
+          "cache_occupancy_bytes": 0,
+          "staging_allocated_bytes": 5435817984,
+          "host_allocated_bytes": 5435817984,
+          "read_workers": 20,
+          "cache_policy": "layer_lru",
+          "staging_buffers": 1
+        }
+      }
+    },
+    {
+      "kind": "summary",
+      "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+      "recipe": {
+        "slug": "glm-5.3",
+        "recipe_version": "0.1.0",
+        "model": "Inferact/GLM-5.3-NVFP4",
+        "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+        "intended_tier": "research",
+        "status_at_run": "experimental",
+        "deployment": {
+          "backend": "native",
+          "backend_api": "1.0",
+          "source_format": "safetensors",
+          "runtime_format": "ftw-nvfp4",
+          "quantization": "nvfp4",
+          "execution_policy": "nvme-moe",
+          "backend_options": {}
+        }
+      },
+      "checkpoint": {
+        "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+        "format": "ftw",
+        "bytes": 428713099264,
+        "fingerprint": "a0e799b03bceb4bf",
+        "quant_format": "nvfp4_b12x",
+        "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+        "external_artifacts": []
+      },
+      "platform": {
+        "checks": [
+          {
+            "detail": "SparkLab's supported runtime is Linux-only.",
+            "expected": "Linux / DGX OS",
+            "name": "operating_system",
+            "observed": "Linux",
+            "status": "pass"
+          },
+          {
+            "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+            "expected": "aarch64",
+            "name": "cpu_architecture",
+            "observed": "aarch64",
+            "status": "pass"
+          },
+          {
+            "detail": "CUDA must be visible to the Python runtime.",
+            "expected": "CUDA 13.x available",
+            "name": "cuda",
+            "observed": "13.0",
+            "status": "pass"
+          },
+          {
+            "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+            "expected": "13.x",
+            "name": "cuda_version",
+            "observed": "13.0",
+            "status": "pass"
+          },
+          {
+            "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+            "expected": "SM121 (12.1)",
+            "name": "compute_capability",
+            "observed": [
+              12,
+              1
+            ],
+            "status": "pass"
+          },
+          {
+            "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+            "expected": "NVIDIA GB10",
+            "name": "gpu_identity",
+            "observed": "NVIDIA GB10",
+            "status": "pass"
+          },
+          {
+            "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+            "expected": ">= 123480309760 bytes",
+            "name": "unified_memory",
+            "observed": 130663591936,
+            "status": "pass"
+          },
+          {
+            "detail": "Model recipes consume only memory above the operational reserve.",
+            "expected": ">= 12884901888 bytes safety reserve",
+            "name": "available_memory",
+            "observed": 126064148480,
+            "status": "pass"
+          },
+          {
+            "detail": "Swap is never counted as model capacity.",
+            "expected": "0 bytes used",
+            "name": "swap_usage",
+            "observed": 687771648,
+            "status": "fail"
+          },
+          {
+            "detail": "Device-mapper filesystems may require manual NVMe verification.",
+            "expected": "local NVMe-backed filesystem",
+            "name": "nvme_storage",
+            "observed": "/dev/nvme0n1p2",
+            "status": "pass"
+          },
+          {
+            "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+            "expected": ">= 549755813888 bytes free",
+            "name": "storage_capacity",
+            "observed": 1840902995968,
+            "status": "pass"
+          },
+          {
+            "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+            "expected": "same release and build stamp",
+            "name": "kernel_cache_version",
+            "observed": {
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130"
+            },
+            "status": "fail"
+          }
+        ],
+        "failures": [
+          "swap_usage",
+          "kernel_cache_version"
+        ],
+        "memory": {
+          "available_bytes": 126064148480,
+          "cuda_free_bytes": 99683311616,
+          "physical_bytes": 130663591936,
+          "safe_available_bytes": 113179246592,
+          "safety_reserve_bytes": 12884901888,
+          "swap_total_bytes": 17179865088,
+          "swap_used_bytes": 687771648
+        },
+        "platform_failures": [],
+        "product": "SparkLab",
+        "profile": "gb10",
+        "ready": false,
+        "recommendations": [
+          "Resolve failed platform checks before loading a model.",
+          "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+          "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+        ],
+        "runtime": {
+          "compute_capability": [
+            12,
+            1
+          ],
+          "cuda": "13.0",
+          "dependencies": {
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "sparklab": "0.1.2",
+            "sparklab-kernel-cache": "0.1.0+cu130",
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0"
+          },
+          "gpu": "NVIDIA GB10",
+          "integrated_gpu": true
+        },
+        "schema_version": "1.0",
+        "snapshot": {
+          "block_device": "/dev/nvme0n1p2",
+          "compute_capability": [
+            12,
+            1
+          ],
+          "cuda_available": true,
+          "cuda_free_bytes": 99683311616,
+          "cuda_version": "13.0",
+          "dependencies": {
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "sparklab": "0.1.2",
+            "sparklab-kernel-cache": "0.1.0+cu130",
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0"
+          },
+          "filesystem": "ext4",
+          "gpu_name": "NVIDIA GB10",
+          "gpu_total_bytes": 130663591936,
+          "integrated_gpu": true,
+          "machine": "aarch64",
+          "memory_available_bytes": 126064148480,
+          "memory_total_bytes": 130663591936,
+          "nvme": true,
+          "os_name": "Linux",
+          "storage_free_bytes": 1840902995968,
+          "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "storage_total_bytes": 4031871553536,
+          "swap_free_bytes": 16492093440,
+          "swap_total_bytes": 17179865088
+        },
+        "status": "supported_not_ready",
+        "storage": {
+          "block_device": "/dev/nvme0n1p2",
+          "filesystem": "ext4",
+          "free_bytes": 1840902995968,
+          "nvme": true,
+          "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "total_bytes": 4031871553536
+        },
+        "supported": true,
+        "warnings": [],
+        "exit_code": 1
+      },
+      "backend": "offload",
+      "problems": 2,
+      "correct": 1,
+      "reasoning_channel_requests": 2,
+      "accuracy": 0.5,
+      "sampling": {
+        "temperature": 0,
+        "top_p": 1,
+        "top_k": -1
+      },
+      "max_output_tokens": 1024,
+      "ended_by_eos": 1,
+      "hit_token_cap": 1,
+      "mean_decode_tok_s": 1.0885876851644198,
+      "token_weighted_decode_tok_s": 1.0883541699915664,
+      "mean_ttft_ms": 31241.98138047359,
+      "ttft_ms_p50": 36702.91888399515,
+      "ttft_ms_p95": 36702.91888399515,
+      "mean_inter_token_ms_p50": 916.2115210201591,
+      "mean_inter_token_ms_p95": 1113.6237920145504,
+      "first_request": {
+        "decode_tok_s": 1.0909148006551304,
+        "ttft_ms": 25781.043876952026
+      },
+      "steady_requests": {
+        "mean_decode_tok_s": 1.0862605696737095,
+        "mean_ttft_ms": 36702.91888399515
+      },
+      "disk": {
+        "cache_hits": 0,
+        "cache_misses": 537451,
+        "cache_evictions": 0,
+        "cache_bypasses": 23778,
+        "read_ops": 2149804,
+        "logical_bytes": 11412053950464,
+        "physical_bytes": 11412053950464,
+        "read_seconds": 1073.19340747979,
+        "physical_gib": 10628.303466796875,
+        "effective_gib_s": 9.903437155615423,
+        "host_cache_hit_rate": 0
+      },
+      "gpu_telemetry": {
+        "power_w_avg": 17.31001941640693,
+        "power_w_peak": 19.29,
+        "temperature_c_peak": 49,
+        "request_energy_j_total_est": 30733.372517783166
+      },
+      "config": {
+        "storage": "disk",
+        "attention_backend": "auto",
+        "qsa_fused_selection": true,
+        "page_size": 1,
+        "cache_type": "radix",
+        "max_seq_len": 9216,
+        "num_tokens": 2048,
+        "host_cache_gb": 0,
+        "nvfp4_backend": "flashinfer",
+        "hybrid_fetch": 3,
+        "cpu_threads": 8,
+        "disk_read_workers": 20,
+        "cache_policy": "layer_lru",
+        "prefill_overlap": false,
+        "preload_all": false,
+        "prefill_hit_d2d": false,
+        "prefill_sparse_max_tokens": 256,
+        "shared_expert_overlap": true,
+        "memory_ratio": 0.9,
+        "min_memory_gib": 12,
+        "cuda_graph": false,
+        "minimum_duration_minutes": 0
+      },
+      "provenance": {
+        "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+        "git_tracked_dirty": true,
+        "python": "3.11.15",
+        "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+        "packages": {
+          "torch": "2.11.0+cu130",
+          "triton": "3.6.0",
+          "flashinfer-python": "0.6.15.post1",
+          "sglang-kernel": "0.4.5",
+          "transformers": "5.16.1"
+        },
+        "gpu_driver": "NVIDIA GB10, 580.126.09"
+      },
+      "stability": {
+        "duration_minutes": 29.609845091983637,
+        "swap_start_bytes": 687820800,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "oom_count": 0,
+        "service_restarts": 0,
+        "completed_requests": 2,
+        "scored_requests": 2,
+        "soak_requests": 0,
+        "parser_failures": 0,
+        "uninterrupted": true,
+        "eligible_for_endurance_gate": true
+      },
+      "lifecycle_telemetry": {
+        "samples": 1762,
+        "duration_s": 1825.9767544930219,
+        "swap_start_bytes": 687820800,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86806528,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": -45056
+          }
+        },
+        "power_w_avg": 17.263808172531217,
+        "power_w_peak": 24.41,
+        "temperature_c_peak": 49,
+        "utilization_pct_avg": 34.803632236095346,
+        "request_energy_j_est": 31523.312417068657,
+        "mem_available_gib_min": 29.495803833007812,
+        "nvme_temperature_c_peak": 54.85,
+        "swap_in_pages_delta": 32,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 25283727,
+        "major_faults_delta": 25,
+        "oom_kill_delta": 0
+      },
+      "server_log": "/tmp/bench-aime-suite-aizbyzum.log"
+    }
+  ]
+}

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-aime675.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-aime675.json
@@ -1,0 +1,452 @@
+{
+  "notes": [
+    "Local home paths redacted to $HOME; measurements unchanged."
+  ],
+  "rows": [
+    {
+      "kind": "request",
+      "problem": 0,
+      "expected": "70",
+      "answer": "70",
+      "correct": true,
+      "prompt_tokens": 54,
+      "completion_tokens": 844,
+      "decode_steps": 843,
+      "decode_seconds": 1033.7941835719976,
+      "decode_tok_s": 0.8154427770982812,
+      "ttft_ms": 25691.920366021805,
+      "inter_token_ms_p50": 1233.2982780062594,
+      "inter_token_ms_p95": 1404.1506050270982,
+      "output_sha1": "0afcf524b5d1",
+      "finish_reason": "stop",
+      "ended_by_eos": true,
+      "parser_ok": true,
+      "reasoning_channel_seen": true,
+      "content_channel_seen": true,
+      "vram_gib": 33.8046875,
+      "gpu_telemetry": {
+        "samples": 1028,
+        "duration_s": 1060.6507831050549,
+        "swap_start_bytes": 687771648,
+        "memory_guard_gib": 0,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": 0
+          }
+        },
+        "power_w_avg": 15.120165369649806,
+        "power_w_peak": 16.01,
+        "temperature_c_peak": 48,
+        "utilization_pct_avg": 21.733463035019454,
+        "request_energy_j_est": 16037.215239996998,
+        "mem_available_gib_min": 73.0770149230957,
+        "nvme_temperature_c_peak": 53.85,
+        "swap_in_pages_delta": 3,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 9054527,
+        "major_faults_delta": 3,
+        "oom_kill_delta": 0
+      },
+      "reasoning_output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nFirst, convert to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = 9b + 7$\n\nWe need $(b+7) \\mid (9b + 7)$.\n\nNote that $9b + 7 = 9(b + 7) - 63 + 7 = 9(b+7) - 56$.\n\nSo $(b+7) \\mid (9b+7)$ if and only if $(b+7) \\mid 56$.\n\nSince $b > 9$, we have $b + 7 > 16$, so $b + 7 \\geq 17$.\n\nDivisors of 56: 1, 2, 4, 7, 8, 14, 28, 56.\n\nDivisors of 56 that are $\\geq 17$: 28 and 56.\n\nSo $b + 7 = 28 \\Rightarrow b = 21$, or $b + 7 = 56 \\Rightarrow b = 49$.\n\nCheck: For $b = 21$: $17_{21} = 28$, $97_{21} = 9 \\cdot 21 + 7 = 196$. $196 / 28 = 7$. Yes, divides.\n\nFor $b = 49$: $17_{49} = 56$, $97_{49} = 9 \\cdot 49 + 7 = 448$. $448 / 56 = 8$. Yes, divides.\n\nAlso need to check that digits are valid: $97_b$ requires $b > 9$, which is satisfied. Both bases are valid.\n\nSum: $21 + 49 = 70$.",
+      "output_text": "## Setting Up the Problem\n\nFirst, I'll convert both numbers from base $b$ to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = 9b + 7$\n\nI need $(b+7) \\mid (9b+7)$.\n\n## Applying the Divisibility Condition\n\nI can rewrite $9b + 7$ in terms of $(b+7)$:\n$$9b + 7 = 9(b + 7) - 63 + 7 = 9(b+7) - 56$$\n\nSince $9(b+7)$ is automatically divisible by $(b+7)$, the condition becomes:\n$$(b+7) \\mid 56$$\n\n## Finding Valid Bases\n\nSince $b > 9$, we need $b + 7 > 16$, so $b + 7 \\geq 17$.\n\nThe positive divisors of 56 are: $1, 2, 4, 7, 8, 14, 28, 56$.\n\nOnly **28** and **56** satisfy $b + 7 \\geq 17$:\n- $b + 7 = 28 \\implies b = 21$\n- $b + 7 = 56 \\implies b = 49$\n\n## Verification\n\n**Base $b = 21$:** $17_{21} = 28$ and $97_{21} = 9(21) + 7 = 196$. Check: $196 \\div 28 = 7$ ✓\n\n**Base $b = 49$:** $17_{49} = 56$ and $97_{49} = 9(49) + 7 = 448$. Check: $448 \\div 56 = 8$ ✓\n\nBoth bases exceed 9, so the digits 9 and 7 are valid.\n\n## Final Answer\n\n$$21 + 49 = \\boxed{70}$$",
+      "moe": {
+        "active": 506400,
+        "missing": 383875,
+        "fetched": 0,
+        "calls": 63300,
+        "sparse_prefill_layers": 300,
+        "sparse_prefill_routes": 176400,
+        "sparse_prefill_unique_rows": 11487,
+        "sparse_prefill_fallback_layers": 0,
+        "shared_expert_overlap_calls": 63600,
+        "disk": {
+          "cache_hits": 0,
+          "cache_misses": 394151,
+          "cache_evictions": 0,
+          "cache_bypasses": 10276,
+          "read_ops": 1576604,
+          "logical_bytes": 8369269899264,
+          "physical_bytes": 8369269899264,
+          "read_seconds": 778.3393191318028,
+          "cache_capacity_entries": 0,
+          "cache_capacity_bytes": 0,
+          "cache_allocated_bytes": 0,
+          "cache_occupancy_entries": 0,
+          "cache_occupancy_bytes": 0,
+          "staging_allocated_bytes": 5435817984,
+          "host_allocated_bytes": 5435817984,
+          "read_workers": 20,
+          "cache_policy": "layer_lru",
+          "staging_buffers": 1
+        }
+      }
+    },
+    {
+      "kind": "summary",
+      "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+      "recipe": {
+        "slug": "glm-5.3",
+        "recipe_version": "0.1.0",
+        "model": "Inferact/GLM-5.3-NVFP4",
+        "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+        "intended_tier": "research",
+        "status_at_run": "experimental",
+        "deployment": {
+          "backend": "native",
+          "backend_api": "1.0",
+          "source_format": "safetensors",
+          "runtime_format": "ftw-nvfp4",
+          "quantization": "nvfp4",
+          "execution_policy": "nvme-moe",
+          "backend_options": {}
+        }
+      },
+      "checkpoint": {
+        "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+        "format": "ftw",
+        "bytes": 428713099264,
+        "fingerprint": "a0e799b03bceb4bf",
+        "quant_format": "nvfp4_b12x",
+        "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+        "external_artifacts": []
+      },
+      "platform": {
+        "checks": [
+          {
+            "detail": "SparkLab's supported runtime is Linux-only.",
+            "expected": "Linux / DGX OS",
+            "name": "operating_system",
+            "observed": "Linux",
+            "status": "pass"
+          },
+          {
+            "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+            "expected": "aarch64",
+            "name": "cpu_architecture",
+            "observed": "aarch64",
+            "status": "pass"
+          },
+          {
+            "detail": "CUDA must be visible to the Python runtime.",
+            "expected": "CUDA 13.x available",
+            "name": "cuda",
+            "observed": "13.0",
+            "status": "pass"
+          },
+          {
+            "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+            "expected": "13.x",
+            "name": "cuda_version",
+            "observed": "13.0",
+            "status": "pass"
+          },
+          {
+            "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+            "expected": "SM121 (12.1)",
+            "name": "compute_capability",
+            "observed": [
+              12,
+              1
+            ],
+            "status": "pass"
+          },
+          {
+            "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+            "expected": "NVIDIA GB10",
+            "name": "gpu_identity",
+            "observed": "NVIDIA GB10",
+            "status": "pass"
+          },
+          {
+            "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+            "expected": ">= 123480309760 bytes",
+            "name": "unified_memory",
+            "observed": 130663591936,
+            "status": "pass"
+          },
+          {
+            "detail": "Model recipes consume only memory above the operational reserve.",
+            "expected": ">= 12884901888 bytes safety reserve",
+            "name": "available_memory",
+            "observed": 126081163264,
+            "status": "pass"
+          },
+          {
+            "detail": "Swap is never counted as model capacity.",
+            "expected": "0 bytes used",
+            "name": "swap_usage",
+            "observed": 687771648,
+            "status": "fail"
+          },
+          {
+            "detail": "Device-mapper filesystems may require manual NVMe verification.",
+            "expected": "local NVMe-backed filesystem",
+            "name": "nvme_storage",
+            "observed": "/dev/nvme0n1p2",
+            "status": "pass"
+          },
+          {
+            "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+            "expected": ">= 549755813888 bytes free",
+            "name": "storage_capacity",
+            "observed": 1840902737920,
+            "status": "pass"
+          },
+          {
+            "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+            "expected": "same release and build stamp",
+            "name": "kernel_cache_version",
+            "observed": {
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130"
+            },
+            "status": "fail"
+          }
+        ],
+        "failures": [
+          "swap_usage",
+          "kernel_cache_version"
+        ],
+        "memory": {
+          "available_bytes": 126081163264,
+          "cuda_free_bytes": 99679518720,
+          "physical_bytes": 130663591936,
+          "safe_available_bytes": 113196261376,
+          "safety_reserve_bytes": 12884901888,
+          "swap_total_bytes": 17179865088,
+          "swap_used_bytes": 687771648
+        },
+        "platform_failures": [],
+        "product": "SparkLab",
+        "profile": "gb10",
+        "ready": false,
+        "recommendations": [
+          "Resolve failed platform checks before loading a model.",
+          "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+          "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+        ],
+        "runtime": {
+          "compute_capability": [
+            12,
+            1
+          ],
+          "cuda": "13.0",
+          "dependencies": {
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "sparklab": "0.1.2",
+            "sparklab-kernel-cache": "0.1.0+cu130",
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0"
+          },
+          "gpu": "NVIDIA GB10",
+          "integrated_gpu": true
+        },
+        "schema_version": "1.0",
+        "snapshot": {
+          "block_device": "/dev/nvme0n1p2",
+          "compute_capability": [
+            12,
+            1
+          ],
+          "cuda_available": true,
+          "cuda_free_bytes": 99679518720,
+          "cuda_version": "13.0",
+          "dependencies": {
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "sparklab": "0.1.2",
+            "sparklab-kernel-cache": "0.1.0+cu130",
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0"
+          },
+          "filesystem": "ext4",
+          "gpu_name": "NVIDIA GB10",
+          "gpu_total_bytes": 130663591936,
+          "integrated_gpu": true,
+          "machine": "aarch64",
+          "memory_available_bytes": 126081163264,
+          "memory_total_bytes": 130663591936,
+          "nvme": true,
+          "os_name": "Linux",
+          "storage_free_bytes": 1840902737920,
+          "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "storage_total_bytes": 4031871553536,
+          "swap_free_bytes": 16492093440,
+          "swap_total_bytes": 17179865088
+        },
+        "status": "supported_not_ready",
+        "storage": {
+          "block_device": "/dev/nvme0n1p2",
+          "filesystem": "ext4",
+          "free_bytes": 1840902737920,
+          "nvme": true,
+          "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "total_bytes": 4031871553536
+        },
+        "supported": true,
+        "warnings": [],
+        "exit_code": 1
+      },
+      "backend": "offload",
+      "problems": 1,
+      "correct": 1,
+      "reasoning_channel_requests": 1,
+      "accuracy": 1,
+      "sampling": {
+        "temperature": 0,
+        "top_p": 1,
+        "top_k": -1
+      },
+      "max_output_tokens": 1024,
+      "ended_by_eos": 1,
+      "hit_token_cap": 0,
+      "mean_decode_tok_s": 0.8154427770982812,
+      "token_weighted_decode_tok_s": 0.8154427770982812,
+      "mean_ttft_ms": 25691.920366021805,
+      "ttft_ms_p50": 25691.920366021805,
+      "ttft_ms_p95": 25691.920366021805,
+      "mean_inter_token_ms_p50": 1233.2982780062594,
+      "mean_inter_token_ms_p95": 1404.1506050270982,
+      "first_request": {
+        "decode_tok_s": 0.8154427770982812,
+        "ttft_ms": 25691.920366021805
+      },
+      "steady_requests": {
+        "mean_decode_tok_s": 0,
+        "mean_ttft_ms": 0
+      },
+      "disk": {
+        "cache_hits": 0,
+        "cache_misses": 394151,
+        "cache_evictions": 0,
+        "cache_bypasses": 10276,
+        "read_ops": 1576604,
+        "logical_bytes": 8369269899264,
+        "physical_bytes": 8369269899264,
+        "read_seconds": 778.3393191318028,
+        "physical_gib": 7794.489990234375,
+        "effective_gib_s": 10.014257019584626,
+        "host_cache_hit_rate": 0
+      },
+      "gpu_telemetry": {
+        "power_w_avg": 15.120165369649806,
+        "power_w_peak": 16.01,
+        "temperature_c_peak": 48,
+        "request_energy_j_total_est": 16037.215239996998
+      },
+      "config": {
+        "storage": "disk",
+        "attention_backend": "auto",
+        "qsa_fused_selection": true,
+        "page_size": 1,
+        "cache_type": "radix",
+        "max_seq_len": 9216,
+        "num_tokens": 2048,
+        "host_cache_gb": 0,
+        "nvfp4_backend": "flashinfer",
+        "hybrid_fetch": 3,
+        "cpu_threads": 8,
+        "disk_read_workers": 20,
+        "cache_policy": "layer_lru",
+        "prefill_overlap": false,
+        "preload_all": false,
+        "prefill_hit_d2d": false,
+        "prefill_sparse_max_tokens": 256,
+        "shared_expert_overlap": true,
+        "memory_ratio": 0.9,
+        "min_memory_gib": 12,
+        "cuda_graph": false,
+        "minimum_duration_minutes": 0
+      },
+      "provenance": {
+        "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+        "git_tracked_dirty": true,
+        "python": "3.11.15",
+        "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+        "packages": {
+          "torch": "2.11.0+cu130",
+          "triton": "3.6.0",
+          "flashinfer-python": "0.6.15.post1",
+          "sglang-kernel": "0.4.5",
+          "transformers": "5.16.1"
+        },
+        "gpu_driver": "NVIDIA GB10, 580.126.09"
+      },
+      "stability": {
+        "duration_minutes": 17.699588389183432,
+        "swap_start_bytes": 687771648,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "oom_count": 0,
+        "service_restarts": 0,
+        "completed_requests": 1,
+        "scored_requests": 1,
+        "soak_requests": 0,
+        "parser_failures": 0,
+        "uninterrupted": true,
+        "eligible_for_endurance_gate": true
+      },
+      "lifecycle_telemetry": {
+        "samples": 1056,
+        "duration_s": 1089.2914046309888,
+        "swap_start_bytes": 687771648,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 687771648,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86761472,
+            "swap_peak_bytes": 1533071360,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": 0
+          }
+        },
+        "power_w_avg": 15.068484848484848,
+        "power_w_peak": 30.93,
+        "temperature_c_peak": 47,
+        "utilization_pct_avg": 21.27746212121212,
+        "request_energy_j_est": 16413.971026266834,
+        "mem_available_gib_min": 73.07737731933594,
+        "nvme_temperature_c_peak": 53.85,
+        "swap_in_pages_delta": 3,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 19469597,
+        "major_faults_delta": 3,
+        "oom_kill_delta": 0
+      },
+      "server_log": "/tmp/bench-aime-suite-1jrx2pmp.log"
+    }
+  ]
+}

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-baseline64.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-baseline64.json
@@ -1,0 +1,1272 @@
+{
+  "schema_version": "1.0",
+  "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+  "backend": "offload",
+  "recipe": {
+    "slug": "glm-5.3",
+    "recipe_version": "0.1.0",
+    "model": "Inferact/GLM-5.3-NVFP4",
+    "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+    "intended_tier": "research",
+    "status_at_run": "experimental",
+    "deployment": {
+      "backend": "native",
+      "backend_api": "1.0",
+      "source_format": "safetensors",
+      "runtime_format": "ftw-nvfp4",
+      "quantization": "nvfp4",
+      "execution_policy": "nvme-moe",
+      "backend_options": {}
+    }
+  },
+  "checkpoint": {
+    "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+    "format": "ftw",
+    "bytes": 428713099264,
+    "fingerprint": "a0e799b03bceb4bf",
+    "quant_format": "nvfp4_b12x",
+    "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+    "external_artifacts": []
+  },
+  "platform": {
+    "checks": [
+      {
+        "detail": "SparkLab's supported runtime is Linux-only.",
+        "expected": "Linux / DGX OS",
+        "name": "operating_system",
+        "observed": "Linux",
+        "status": "pass"
+      },
+      {
+        "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+        "expected": "aarch64",
+        "name": "cpu_architecture",
+        "observed": "aarch64",
+        "status": "pass"
+      },
+      {
+        "detail": "CUDA must be visible to the Python runtime.",
+        "expected": "CUDA 13.x available",
+        "name": "cuda",
+        "observed": "13.0",
+        "status": "pass"
+      },
+      {
+        "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+        "expected": "13.x",
+        "name": "cuda_version",
+        "observed": "13.0",
+        "status": "pass"
+      },
+      {
+        "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+        "expected": "SM121 (12.1)",
+        "name": "compute_capability",
+        "observed": [
+          12,
+          1
+        ],
+        "status": "pass"
+      },
+      {
+        "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+        "expected": "NVIDIA GB10",
+        "name": "gpu_identity",
+        "observed": "NVIDIA GB10",
+        "status": "pass"
+      },
+      {
+        "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+        "expected": ">= 123480309760 bytes",
+        "name": "unified_memory",
+        "observed": 130663591936,
+        "status": "pass"
+      },
+      {
+        "detail": "Model recipes consume only memory above the operational reserve.",
+        "expected": ">= 12884901888 bytes safety reserve",
+        "name": "available_memory",
+        "observed": 126017781760,
+        "status": "pass"
+      },
+      {
+        "detail": "Swap is never counted as model capacity.",
+        "expected": "0 bytes used",
+        "name": "swap_usage",
+        "observed": 708866048,
+        "status": "fail"
+      },
+      {
+        "detail": "Device-mapper filesystems may require manual NVMe verification.",
+        "expected": "local NVMe-backed filesystem",
+        "name": "nvme_storage",
+        "observed": "/dev/nvme0n1p2",
+        "status": "pass"
+      },
+      {
+        "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+        "expected": ">= 549755813888 bytes free",
+        "name": "storage_capacity",
+        "observed": 1001100701696,
+        "status": "pass"
+      },
+      {
+        "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+        "expected": "same release and build stamp",
+        "name": "kernel_cache_version",
+        "observed": {
+          "sparklab": "0.1.2",
+          "sparklab-kernel-cache": "0.1.0+cu130"
+        },
+        "status": "fail"
+      }
+    ],
+    "failures": [
+      "swap_usage",
+      "kernel_cache_version"
+    ],
+    "memory": {
+      "available_bytes": 126017781760,
+      "cuda_free_bytes": 95374049280,
+      "physical_bytes": 130663591936,
+      "safe_available_bytes": 113132879872,
+      "safety_reserve_bytes": 12884901888,
+      "swap_total_bytes": 17179865088,
+      "swap_used_bytes": 708866048
+    },
+    "platform_failures": [],
+    "product": "SparkLab",
+    "profile": "gb10",
+    "ready": false,
+    "recommendations": [
+      "Resolve failed platform checks before loading a model.",
+      "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+      "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+    ],
+    "runtime": {
+      "compute_capability": [
+        12,
+        1
+      ],
+      "cuda": "13.0",
+      "dependencies": {
+        "flashinfer-python": "0.6.15.post1",
+        "sglang-kernel": "0.4.5",
+        "sparklab": "0.1.2",
+        "sparklab-kernel-cache": "0.1.0+cu130",
+        "torch": "2.11.0+cu130",
+        "triton": "3.6.0"
+      },
+      "gpu": "NVIDIA GB10",
+      "integrated_gpu": true
+    },
+    "schema_version": "1.0",
+    "snapshot": {
+      "block_device": "/dev/nvme0n1p2",
+      "compute_capability": [
+        12,
+        1
+      ],
+      "cuda_available": true,
+      "cuda_free_bytes": 95374049280,
+      "cuda_version": "13.0",
+      "dependencies": {
+        "flashinfer-python": "0.6.15.post1",
+        "sglang-kernel": "0.4.5",
+        "sparklab": "0.1.2",
+        "sparklab-kernel-cache": "0.1.0+cu130",
+        "torch": "2.11.0+cu130",
+        "triton": "3.6.0"
+      },
+      "filesystem": "ext4",
+      "gpu_name": "NVIDIA GB10",
+      "gpu_total_bytes": 130663591936,
+      "integrated_gpu": true,
+      "machine": "aarch64",
+      "memory_available_bytes": 126017781760,
+      "memory_total_bytes": 130663591936,
+      "nvme": true,
+      "os_name": "Linux",
+      "storage_free_bytes": 1001100701696,
+      "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+      "storage_total_bytes": 4031871553536,
+      "swap_free_bytes": 16470999040,
+      "swap_total_bytes": 17179865088
+    },
+    "status": "supported_not_ready",
+    "storage": {
+      "block_device": "/dev/nvme0n1p2",
+      "filesystem": "ext4",
+      "free_bytes": 1001100701696,
+      "nvme": true,
+      "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+      "total_bytes": 4031871553536
+    },
+    "supported": true,
+    "warnings": [],
+    "exit_code": 1
+  },
+  "configuration": {
+    "storage": "disk",
+    "attention_backend": "auto",
+    "qsa_fused_selection": true,
+    "page_size": 1,
+    "cache_type": "radix",
+    "max_seq_len": 8256,
+    "nvfp4_backend": "flashinfer",
+    "host_cache_gb": 0,
+    "requested_cache_size": 675,
+    "requested_cache_rate": null,
+    "memory_ratio": 0.9,
+    "requested_num_tokens": 2048,
+    "speculative_method": "auto",
+    "speculative_tokens": 0,
+    "speculative_draft_model": null,
+    "draft_sample_method": "greedy",
+    "dspark_confidence_threshold": 0,
+    "dspark_draft_cache_slots": 0,
+    "dspark_draft_cache_quotas": "",
+    "dsv4_kv_storage": "bf16",
+    "dsv4_index_storage": "bf16",
+    "qwen4_dense_storage": "bf16",
+    "qwen4_draft_vocab_size": 0,
+    "mamba_ssm_dtype": "float32",
+    "cpu_threads": 0,
+    "hybrid_fetch": -1,
+    "disk_read_workers": 20,
+    "cache_policy": "layer_lru",
+    "prefill_overlap": false,
+    "preload_all": false,
+    "prefill_hit_d2d": false,
+    "prefill_sparse_max_tokens": 256,
+    "shared_expert_overlap": true,
+    "startup_prefill_warmup": true,
+    "cuda_graph": false,
+    "request_timeout_s": 1800,
+    "prompt_padding_repeats": 0
+  },
+  "cache_geometry": {
+    "num_pages": 2048,
+    "page_size": 1,
+    "moe_cache_size": 675,
+    "num_mamba_slots": 0,
+    "num_experts": 256,
+    "num_moe_layers": 75,
+    "moe_cache_policy": "layer_lru",
+    "unit_bytes": {
+      "kv_per_token": 95232,
+      "moe_per_expert": 21233664,
+      "mamba_per_slot": 0,
+      "swa_per_token": 0
+    },
+    "swa_full_tokens_ratio": 0,
+    "swa_page_size": 0,
+    "num_swa_pages": 0,
+    "cache_budget_bytes": 62123642470,
+    "reasoning": null,
+    "limits": {
+      "kv_tokens": {
+        "min": 1,
+        "max": 652339
+      },
+      "moe_experts": {
+        "min": 256,
+        "max": 2925
+      },
+      "mamba_slots": {
+        "min": 0,
+        "max": 0
+      },
+      "swa_tokens": {
+        "min": 0,
+        "max": 0
+      }
+    }
+  },
+  "problem": 0,
+  "prompt_tokens": 54,
+  "first_request_ttft_ms": 50851.45789897069,
+  "first_request_completion_tokens": 64,
+  "first_request_finish_reason": "length",
+  "decode_steps": 63,
+  "decode_tok_s": 0.8434692770145924,
+  "ms_per_token": 1185.5796378730456,
+  "event_ms_p50": 1188.5948809795082,
+  "event_ms_p99": 1459.3694990035146,
+  "ttft_ms": 2215.868684987072,
+  "events": 64,
+  "completion_tokens": 64,
+  "finish_reason": "length",
+  "vram_gib": 33.8046875,
+  "sampling": {
+    "temperature": 0,
+    "top_p": 1,
+    "top_k": -1
+  },
+  "output_sha1": "e19ef21a678b",
+  "expected_answer": "70",
+  "extracted_answer": null,
+  "answer_correct": null,
+  "server_log": "/tmp/bench-serve-offload-95hxj6nf.log",
+  "gpu_telemetry": {
+    "samples": 75,
+    "duration_s": 76.90928703598911,
+    "swap_start_bytes": 696856576,
+    "memory_guard_gib": 0,
+    "memory_guard_triggered": false,
+    "swap_end_bytes": 696688640,
+    "swap_growth_bytes": 0,
+    "cgroup": {
+      "start": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86990848,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "end": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86986752,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "delta": {
+        "oom_kill": 0,
+        "swap_current_bytes": -4096
+      }
+    },
+    "power_w_avg": 14.738266666666664,
+    "power_w_peak": 15.16,
+    "temperature_c_peak": 43,
+    "utilization_pct_avg": 22.133333333333333,
+    "request_energy_j_est": 1133.5095814796168,
+    "mem_available_gib_min": 73.37863159179688,
+    "nvme_temperature_c_peak": 48.85,
+    "swap_in_pages_delta": 62,
+    "swap_out_pages_delta": 0,
+    "page_faults_delta": 733531,
+    "major_faults_delta": 19,
+    "oom_kill_delta": 0
+  },
+  "lifecycle_telemetry": {
+    "samples": 226,
+    "duration_s": 232.29931432602461,
+    "swap_start_bytes": 708861952,
+    "memory_guard_gib": 12,
+    "memory_guard_triggered": false,
+    "swap_end_bytes": 696688640,
+    "swap_growth_bytes": 0,
+    "cgroup": {
+      "start": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86990848,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "end": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86986752,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "delta": {
+        "oom_kill": 0,
+        "swap_current_bytes": -4096
+      }
+    },
+    "power_w_avg": 13.929601769911505,
+    "power_w_peak": 33.2,
+    "temperature_c_peak": 47,
+    "utilization_pct_avg": 17.141592920353983,
+    "request_energy_j_est": 3235.8369399850217,
+    "mem_available_gib_min": 73.07564926147461,
+    "nvme_temperature_c_peak": 48.85,
+    "swap_in_pages_delta": 11941,
+    "swap_out_pages_delta": 0,
+    "page_faults_delta": 12296825,
+    "major_faults_delta": 7302,
+    "oom_kill_delta": 0
+  },
+  "oom_markers": 0,
+  "provenance": {
+    "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+    "git_tracked_dirty": false,
+    "python": "3.11.15",
+    "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+    "packages": {
+      "torch": "2.11.0+cu130",
+      "triton": "3.6.0",
+      "flashinfer-python": "0.6.15.post1",
+      "sglang-kernel": "0.4.5",
+      "transformers": "5.16.1"
+    },
+    "gpu_driver": "NVIDIA GB10, 580.126.09"
+  },
+  "output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nFirst, convert to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7",
+  "moe": {
+    "active": 37800,
+    "missing": 28171,
+    "fetched": 0,
+    "calls": 4725,
+    "sparse_prefill_layers": 75,
+    "sparse_prefill_routes": 600,
+    "sparse_prefill_unique_rows": 600,
+    "sparse_prefill_fallback_layers": 0,
+    "shared_expert_overlap_calls": 4800,
+    "active_per_layer": 8,
+    "missing_per_layer": 5.962116402116402,
+    "miss_rate": 0.7452645502645503,
+    "fetched_per_layer": 0,
+    "fetch_rate": 0,
+    "per_layer": [
+      {
+        "layer": 0,
+        "steps": 63,
+        "active": 504,
+        "missing": 194,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.0793650793650795,
+        "miss_rate": 0.38492063492063494,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 1,
+        "steps": 63,
+        "active": 504,
+        "missing": 272,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.317460317460317,
+        "miss_rate": 0.5396825396825397,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 2,
+        "steps": 63,
+        "active": 504,
+        "missing": 241,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.8253968253968256,
+        "miss_rate": 0.4781746031746032,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 3,
+        "steps": 63,
+        "active": 504,
+        "missing": 398,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.317460317460317,
+        "miss_rate": 0.7896825396825397,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 4,
+        "steps": 63,
+        "active": 504,
+        "missing": 379,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.015873015873016,
+        "miss_rate": 0.751984126984127,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 5,
+        "steps": 63,
+        "active": 504,
+        "missing": 339,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.380952380952381,
+        "miss_rate": 0.6726190476190477,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 6,
+        "steps": 63,
+        "active": 504,
+        "missing": 402,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.380952380952381,
+        "miss_rate": 0.7976190476190477,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 7,
+        "steps": 63,
+        "active": 504,
+        "missing": 415,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.587301587301587,
+        "miss_rate": 0.8234126984126984,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 8,
+        "steps": 63,
+        "active": 504,
+        "missing": 406,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.444444444444445,
+        "miss_rate": 0.8055555555555556,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 9,
+        "steps": 63,
+        "active": 504,
+        "missing": 399,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.333333333333333,
+        "miss_rate": 0.7916666666666666,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 10,
+        "steps": 63,
+        "active": 504,
+        "missing": 398,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.317460317460317,
+        "miss_rate": 0.7896825396825397,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 11,
+        "steps": 63,
+        "active": 504,
+        "missing": 399,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.333333333333333,
+        "miss_rate": 0.7916666666666666,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 12,
+        "steps": 63,
+        "active": 504,
+        "missing": 402,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.380952380952381,
+        "miss_rate": 0.7976190476190477,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 13,
+        "steps": 63,
+        "active": 504,
+        "missing": 379,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.015873015873016,
+        "miss_rate": 0.751984126984127,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 14,
+        "steps": 63,
+        "active": 504,
+        "missing": 361,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.73015873015873,
+        "miss_rate": 0.7162698412698413,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 15,
+        "steps": 63,
+        "active": 504,
+        "missing": 365,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.7936507936507935,
+        "miss_rate": 0.7242063492063492,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 16,
+        "steps": 63,
+        "active": 504,
+        "missing": 354,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.619047619047619,
+        "miss_rate": 0.7023809523809523,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 17,
+        "steps": 63,
+        "active": 504,
+        "missing": 343,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.444444444444445,
+        "miss_rate": 0.6805555555555556,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 18,
+        "steps": 63,
+        "active": 504,
+        "missing": 351,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.571428571428571,
+        "miss_rate": 0.6964285714285714,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 19,
+        "steps": 63,
+        "active": 504,
+        "missing": 384,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.095238095238095,
+        "miss_rate": 0.7619047619047619,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 20,
+        "steps": 63,
+        "active": 504,
+        "missing": 426,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.761904761904762,
+        "miss_rate": 0.8452380952380952,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 21,
+        "steps": 63,
+        "active": 504,
+        "missing": 429,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.809523809523809,
+        "miss_rate": 0.8511904761904762,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 22,
+        "steps": 63,
+        "active": 504,
+        "missing": 411,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.523809523809524,
+        "miss_rate": 0.8154761904761905,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 23,
+        "steps": 63,
+        "active": 504,
+        "missing": 414,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.571428571428571,
+        "miss_rate": 0.8214285714285714,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 24,
+        "steps": 63,
+        "active": 504,
+        "missing": 405,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.428571428571429,
+        "miss_rate": 0.8035714285714286,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 25,
+        "steps": 63,
+        "active": 504,
+        "missing": 365,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.7936507936507935,
+        "miss_rate": 0.7242063492063492,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 26,
+        "steps": 63,
+        "active": 504,
+        "missing": 409,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.492063492063492,
+        "miss_rate": 0.8115079365079365,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 27,
+        "steps": 63,
+        "active": 504,
+        "missing": 408,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.476190476190476,
+        "miss_rate": 0.8095238095238095,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 28,
+        "steps": 63,
+        "active": 504,
+        "missing": 347,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.507936507936508,
+        "miss_rate": 0.6884920634920635,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 29,
+        "steps": 63,
+        "active": 504,
+        "missing": 362,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.746031746031746,
+        "miss_rate": 0.7182539682539683,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 30,
+        "steps": 63,
+        "active": 504,
+        "missing": 358,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.682539682539683,
+        "miss_rate": 0.7103174603174603,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 31,
+        "steps": 63,
+        "active": 504,
+        "missing": 399,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.333333333333333,
+        "miss_rate": 0.7916666666666666,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 32,
+        "steps": 63,
+        "active": 504,
+        "missing": 364,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.777777777777778,
+        "miss_rate": 0.7222222222222222,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 33,
+        "steps": 63,
+        "active": 504,
+        "missing": 389,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.174603174603175,
+        "miss_rate": 0.7718253968253969,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 34,
+        "steps": 63,
+        "active": 504,
+        "missing": 394,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.253968253968254,
+        "miss_rate": 0.7817460317460317,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 35,
+        "steps": 63,
+        "active": 504,
+        "missing": 373,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.920634920634921,
+        "miss_rate": 0.7400793650793651,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 36,
+        "steps": 63,
+        "active": 504,
+        "missing": 400,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.349206349206349,
+        "miss_rate": 0.7936507936507936,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 37,
+        "steps": 63,
+        "active": 504,
+        "missing": 393,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.238095238095238,
+        "miss_rate": 0.7797619047619048,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 38,
+        "steps": 63,
+        "active": 504,
+        "missing": 405,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.428571428571429,
+        "miss_rate": 0.8035714285714286,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 39,
+        "steps": 63,
+        "active": 504,
+        "missing": 379,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.015873015873016,
+        "miss_rate": 0.751984126984127,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 40,
+        "steps": 63,
+        "active": 504,
+        "missing": 416,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.603174603174603,
+        "miss_rate": 0.8253968253968254,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 41,
+        "steps": 63,
+        "active": 504,
+        "missing": 376,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.968253968253968,
+        "miss_rate": 0.746031746031746,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 42,
+        "steps": 63,
+        "active": 504,
+        "missing": 355,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.634920634920635,
+        "miss_rate": 0.7043650793650794,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 43,
+        "steps": 63,
+        "active": 504,
+        "missing": 381,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.0476190476190474,
+        "miss_rate": 0.7559523809523809,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 44,
+        "steps": 63,
+        "active": 504,
+        "missing": 393,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.238095238095238,
+        "miss_rate": 0.7797619047619048,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 45,
+        "steps": 63,
+        "active": 504,
+        "missing": 399,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.333333333333333,
+        "miss_rate": 0.7916666666666666,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 46,
+        "steps": 63,
+        "active": 504,
+        "missing": 389,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.174603174603175,
+        "miss_rate": 0.7718253968253969,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 47,
+        "steps": 63,
+        "active": 504,
+        "missing": 391,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.2063492063492065,
+        "miss_rate": 0.7757936507936508,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 48,
+        "steps": 63,
+        "active": 504,
+        "missing": 360,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.714285714285714,
+        "miss_rate": 0.7142857142857143,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 49,
+        "steps": 63,
+        "active": 504,
+        "missing": 366,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.809523809523809,
+        "miss_rate": 0.7261904761904762,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 50,
+        "steps": 63,
+        "active": 504,
+        "missing": 378,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6,
+        "miss_rate": 0.75,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 51,
+        "steps": 63,
+        "active": 504,
+        "missing": 405,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.428571428571429,
+        "miss_rate": 0.8035714285714286,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 52,
+        "steps": 63,
+        "active": 504,
+        "missing": 366,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.809523809523809,
+        "miss_rate": 0.7261904761904762,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 53,
+        "steps": 63,
+        "active": 504,
+        "missing": 339,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.380952380952381,
+        "miss_rate": 0.6726190476190477,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 54,
+        "steps": 63,
+        "active": 504,
+        "missing": 349,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.5396825396825395,
+        "miss_rate": 0.6924603174603174,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 55,
+        "steps": 63,
+        "active": 504,
+        "missing": 384,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.095238095238095,
+        "miss_rate": 0.7619047619047619,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 56,
+        "steps": 63,
+        "active": 504,
+        "missing": 379,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.015873015873016,
+        "miss_rate": 0.751984126984127,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 57,
+        "steps": 63,
+        "active": 504,
+        "missing": 357,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.666666666666667,
+        "miss_rate": 0.7083333333333334,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 58,
+        "steps": 63,
+        "active": 504,
+        "missing": 373,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.920634920634921,
+        "miss_rate": 0.7400793650793651,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 59,
+        "steps": 63,
+        "active": 504,
+        "missing": 362,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.746031746031746,
+        "miss_rate": 0.7182539682539683,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 60,
+        "steps": 63,
+        "active": 504,
+        "missing": 400,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.349206349206349,
+        "miss_rate": 0.7936507936507936,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 61,
+        "steps": 63,
+        "active": 504,
+        "missing": 369,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.857142857142857,
+        "miss_rate": 0.7321428571428571,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 62,
+        "steps": 63,
+        "active": 504,
+        "missing": 399,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.333333333333333,
+        "miss_rate": 0.7916666666666666,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 63,
+        "steps": 63,
+        "active": 504,
+        "missing": 392,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.222222222222222,
+        "miss_rate": 0.7777777777777778,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 64,
+        "steps": 63,
+        "active": 504,
+        "missing": 344,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.4603174603174605,
+        "miss_rate": 0.6825396825396826,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 65,
+        "steps": 63,
+        "active": 504,
+        "missing": 352,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.587301587301587,
+        "miss_rate": 0.6984126984126984,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 66,
+        "steps": 63,
+        "active": 504,
+        "missing": 385,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.111111111111111,
+        "miss_rate": 0.7638888888888888,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 67,
+        "steps": 63,
+        "active": 504,
+        "missing": 372,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.904761904761905,
+        "miss_rate": 0.7380952380952381,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 68,
+        "steps": 63,
+        "active": 504,
+        "missing": 359,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.698412698412699,
+        "miss_rate": 0.7123015873015873,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 69,
+        "steps": 63,
+        "active": 504,
+        "missing": 343,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.444444444444445,
+        "miss_rate": 0.6805555555555556,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 70,
+        "steps": 63,
+        "active": 504,
+        "missing": 373,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.920634920634921,
+        "miss_rate": 0.7400793650793651,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 71,
+        "steps": 63,
+        "active": 504,
+        "missing": 385,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.111111111111111,
+        "miss_rate": 0.7638888888888888,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 72,
+        "steps": 63,
+        "active": 504,
+        "missing": 372,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 5.904761904761905,
+        "miss_rate": 0.7380952380952381,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 73,
+        "steps": 63,
+        "active": 504,
+        "missing": 381,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.0476190476190474,
+        "miss_rate": 0.7559523809523809,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 74,
+        "steps": 63,
+        "active": 504,
+        "missing": 416,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 6.603174603174603,
+        "miss_rate": 0.8253968253968254,
+        "fetched_per_step": 0
+      }
+    ],
+    "disk": {
+      "cache_hits": 0,
+      "cache_misses": 28596,
+      "cache_evictions": 0,
+      "cache_bypasses": 425,
+      "read_ops": 114384,
+      "logical_bytes": 607197855744,
+      "physical_bytes": 607197855744,
+      "read_seconds": 55.64687462494476,
+      "cache_capacity_entries": 0,
+      "cache_capacity_bytes": 0,
+      "cache_allocated_bytes": 0,
+      "cache_occupancy_entries": 0,
+      "cache_occupancy_bytes": 0,
+      "staging_allocated_bytes": 5435817984,
+      "host_allocated_bytes": 5435817984,
+      "read_workers": 20,
+      "cache_policy": "layer_lru",
+      "staging_buffers": 1
+    }
+  }
+}

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-candidate256.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-candidate256.json
@@ -1,0 +1,1272 @@
+{
+  "schema_version": "1.0",
+  "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+  "backend": "offload",
+  "recipe": {
+    "slug": "glm-5.3",
+    "recipe_version": "0.1.0",
+    "model": "Inferact/GLM-5.3-NVFP4",
+    "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+    "intended_tier": "research",
+    "status_at_run": "experimental",
+    "deployment": {
+      "backend": "native",
+      "backend_api": "1.0",
+      "source_format": "safetensors",
+      "runtime_format": "ftw-nvfp4",
+      "quantization": "nvfp4",
+      "execution_policy": "nvme-moe",
+      "backend_options": {}
+    }
+  },
+  "checkpoint": {
+    "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+    "format": "ftw",
+    "bytes": 428713099264,
+    "fingerprint": "a0e799b03bceb4bf",
+    "quant_format": "nvfp4_b12x",
+    "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+    "external_artifacts": []
+  },
+  "platform": {
+    "checks": [
+      {
+        "detail": "SparkLab's supported runtime is Linux-only.",
+        "expected": "Linux / DGX OS",
+        "name": "operating_system",
+        "observed": "Linux",
+        "status": "pass"
+      },
+      {
+        "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+        "expected": "aarch64",
+        "name": "cpu_architecture",
+        "observed": "aarch64",
+        "status": "pass"
+      },
+      {
+        "detail": "CUDA must be visible to the Python runtime.",
+        "expected": "CUDA 13.x available",
+        "name": "cuda",
+        "observed": "13.0",
+        "status": "pass"
+      },
+      {
+        "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+        "expected": "13.x",
+        "name": "cuda_version",
+        "observed": "13.0",
+        "status": "pass"
+      },
+      {
+        "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+        "expected": "SM121 (12.1)",
+        "name": "compute_capability",
+        "observed": [
+          12,
+          1
+        ],
+        "status": "pass"
+      },
+      {
+        "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+        "expected": "NVIDIA GB10",
+        "name": "gpu_identity",
+        "observed": "NVIDIA GB10",
+        "status": "pass"
+      },
+      {
+        "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+        "expected": ">= 123480309760 bytes",
+        "name": "unified_memory",
+        "observed": 130663591936,
+        "status": "pass"
+      },
+      {
+        "detail": "Model recipes consume only memory above the operational reserve.",
+        "expected": ">= 12884901888 bytes safety reserve",
+        "name": "available_memory",
+        "observed": 124919910400,
+        "status": "pass"
+      },
+      {
+        "detail": "Swap is never counted as model capacity.",
+        "expected": "0 bytes used",
+        "name": "swap_usage",
+        "observed": 687828992,
+        "status": "fail"
+      },
+      {
+        "detail": "Device-mapper filesystems may require manual NVMe verification.",
+        "expected": "local NVMe-backed filesystem",
+        "name": "nvme_storage",
+        "observed": "/dev/nvme0n1p2",
+        "status": "pass"
+      },
+      {
+        "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+        "expected": ">= 549755813888 bytes free",
+        "name": "storage_capacity",
+        "observed": 1840902234112,
+        "status": "pass"
+      },
+      {
+        "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+        "expected": "same release and build stamp",
+        "name": "kernel_cache_version",
+        "observed": {
+          "sparklab": "0.1.2",
+          "sparklab-kernel-cache": "0.1.0+cu130"
+        },
+        "status": "fail"
+      }
+    ],
+    "failures": [
+      "swap_usage",
+      "kernel_cache_version"
+    ],
+    "memory": {
+      "available_bytes": 124919910400,
+      "cuda_free_bytes": 98849562624,
+      "physical_bytes": 130663591936,
+      "safe_available_bytes": 112035008512,
+      "safety_reserve_bytes": 12884901888,
+      "swap_total_bytes": 17179865088,
+      "swap_used_bytes": 687828992
+    },
+    "platform_failures": [],
+    "product": "SparkLab",
+    "profile": "gb10",
+    "ready": false,
+    "recommendations": [
+      "Resolve failed platform checks before loading a model.",
+      "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+      "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+    ],
+    "runtime": {
+      "compute_capability": [
+        12,
+        1
+      ],
+      "cuda": "13.0",
+      "dependencies": {
+        "flashinfer-python": "0.6.15.post1",
+        "sglang-kernel": "0.4.5",
+        "sparklab": "0.1.2",
+        "sparklab-kernel-cache": "0.1.0+cu130",
+        "torch": "2.11.0+cu130",
+        "triton": "3.6.0"
+      },
+      "gpu": "NVIDIA GB10",
+      "integrated_gpu": true
+    },
+    "schema_version": "1.0",
+    "snapshot": {
+      "block_device": "/dev/nvme0n1p2",
+      "compute_capability": [
+        12,
+        1
+      ],
+      "cuda_available": true,
+      "cuda_free_bytes": 98849562624,
+      "cuda_version": "13.0",
+      "dependencies": {
+        "flashinfer-python": "0.6.15.post1",
+        "sglang-kernel": "0.4.5",
+        "sparklab": "0.1.2",
+        "sparklab-kernel-cache": "0.1.0+cu130",
+        "torch": "2.11.0+cu130",
+        "triton": "3.6.0"
+      },
+      "filesystem": "ext4",
+      "gpu_name": "NVIDIA GB10",
+      "gpu_total_bytes": 130663591936,
+      "integrated_gpu": true,
+      "machine": "aarch64",
+      "memory_available_bytes": 124919910400,
+      "memory_total_bytes": 130663591936,
+      "nvme": true,
+      "os_name": "Linux",
+      "storage_free_bytes": 1840902234112,
+      "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+      "storage_total_bytes": 4031871553536,
+      "swap_free_bytes": 16492036096,
+      "swap_total_bytes": 17179865088
+    },
+    "status": "supported_not_ready",
+    "storage": {
+      "block_device": "/dev/nvme0n1p2",
+      "filesystem": "ext4",
+      "free_bytes": 1840902234112,
+      "nvme": true,
+      "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+      "total_bytes": 4031871553536
+    },
+    "supported": true,
+    "warnings": [],
+    "exit_code": 1
+  },
+  "configuration": {
+    "storage": "disk",
+    "attention_backend": "auto",
+    "qsa_fused_selection": true,
+    "page_size": 1,
+    "cache_type": "radix",
+    "max_seq_len": 8448,
+    "nvfp4_backend": "flashinfer",
+    "host_cache_gb": 0,
+    "requested_cache_size": 2850,
+    "requested_cache_rate": null,
+    "memory_ratio": 0.9,
+    "requested_num_tokens": 2048,
+    "speculative_method": "auto",
+    "speculative_tokens": 0,
+    "speculative_draft_model": null,
+    "draft_sample_method": "greedy",
+    "dspark_confidence_threshold": 0,
+    "dspark_draft_cache_slots": 0,
+    "dspark_draft_cache_quotas": "",
+    "dsv4_kv_storage": "bf16",
+    "dsv4_index_storage": "bf16",
+    "qwen4_dense_storage": "bf16",
+    "qwen4_draft_vocab_size": 0,
+    "mamba_ssm_dtype": "float32",
+    "cpu_threads": 0,
+    "hybrid_fetch": -1,
+    "disk_read_workers": 20,
+    "cache_policy": "layer_lru",
+    "prefill_overlap": false,
+    "preload_all": false,
+    "prefill_hit_d2d": false,
+    "prefill_sparse_max_tokens": 256,
+    "shared_expert_overlap": true,
+    "startup_prefill_warmup": true,
+    "cuda_graph": false,
+    "request_timeout_s": 1800,
+    "prompt_padding_repeats": 0
+  },
+  "cache_geometry": {
+    "num_pages": 2048,
+    "page_size": 1,
+    "moe_cache_size": 2850,
+    "num_mamba_slots": 0,
+    "num_experts": 256,
+    "num_moe_layers": 75,
+    "moe_cache_policy": "layer_lru",
+    "unit_bytes": {
+      "kv_per_token": 95232,
+      "moe_per_expert": 21233664,
+      "mamba_per_slot": 0,
+      "swa_per_token": 0
+    },
+    "swa_full_tokens_ratio": 0,
+    "swa_page_size": 0,
+    "num_swa_pages": 0,
+    "cache_budget_bytes": 65329021747,
+    "reasoning": null,
+    "limits": {
+      "kv_tokens": {
+        "min": 1,
+        "max": 685998
+      },
+      "moe_experts": {
+        "min": 256,
+        "max": 3076
+      },
+      "mamba_slots": {
+        "min": 0,
+        "max": 0
+      },
+      "swa_tokens": {
+        "min": 0,
+        "max": 0
+      }
+    }
+  },
+  "problem": 0,
+  "prompt_tokens": 54,
+  "first_request_ttft_ms": 25857.733732962515,
+  "first_request_completion_tokens": 256,
+  "first_request_finish_reason": "length",
+  "decode_steps": 255,
+  "decode_tok_s": 1.108134249894042,
+  "ms_per_token": 902.4177351215508,
+  "event_ms_p50": 900.7886429899372,
+  "event_ms_p99": 1194.7393250302412,
+  "ttft_ms": 1957.7306060236879,
+  "events": 256,
+  "completion_tokens": 256,
+  "finish_reason": "length",
+  "vram_gib": 76.9296875,
+  "sampling": {
+    "temperature": 0,
+    "top_p": 1,
+    "top_k": -1
+  },
+  "output_sha1": "5b69d85cc226",
+  "expected_answer": "70",
+  "extracted_answer": null,
+  "answer_correct": null,
+  "server_log": "/tmp/bench-serve-offload-nojk9b6i.log",
+  "gpu_telemetry": {
+    "samples": 224,
+    "duration_s": 232.0762283380027,
+    "swap_start_bytes": 687820800,
+    "memory_guard_gib": 0,
+    "memory_guard_triggered": false,
+    "swap_end_bytes": 687820800,
+    "swap_growth_bytes": 0,
+    "cgroup": {
+      "start": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86806528,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "end": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86806528,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "delta": {
+        "oom_kill": 0,
+        "swap_current_bytes": 0
+      }
+    },
+    "power_w_avg": 17.286607142857143,
+    "power_w_peak": 19.43,
+    "temperature_c_peak": 47,
+    "utilization_pct_avg": 36.32142857142857,
+    "request_energy_j_est": 4011.810586475063,
+    "mem_available_gib_min": 30.14874267578125,
+    "nvme_temperature_c_peak": 50.85,
+    "swap_in_pages_delta": 0,
+    "swap_out_pages_delta": 0,
+    "page_faults_delta": 2058202,
+    "major_faults_delta": 0,
+    "oom_kill_delta": 0
+  },
+  "lifecycle_telemetry": {
+    "samples": 521,
+    "duration_s": 539.8489408880123,
+    "swap_start_bytes": 687828992,
+    "memory_guard_gib": 12,
+    "memory_guard_triggered": false,
+    "swap_end_bytes": 687820800,
+    "swap_growth_bytes": 0,
+    "cgroup": {
+      "start": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86814720,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "end": {
+        "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+        "swap_max": "max",
+        "swap_current_bytes": 86806528,
+        "swap_peak_bytes": 1533071360,
+        "oom_kill": 0
+      },
+      "delta": {
+        "oom_kill": 0,
+        "swap_current_bytes": -8192
+      }
+    },
+    "power_w_avg": 16.67940499040307,
+    "power_w_peak": 23.48,
+    "temperature_c_peak": 47,
+    "utilization_pct_avg": 34.43953934740883,
+    "request_energy_j_est": 9004.359118711325,
+    "mem_available_gib_min": 29.69037628173828,
+    "nvme_temperature_c_peak": 50.85,
+    "swap_in_pages_delta": 5,
+    "swap_out_pages_delta": 0,
+    "page_faults_delta": 14237993,
+    "major_faults_delta": 2,
+    "oom_kill_delta": 0
+  },
+  "oom_markers": 0,
+  "provenance": {
+    "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+    "git_tracked_dirty": true,
+    "python": "3.11.15",
+    "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+    "packages": {
+      "torch": "2.11.0+cu130",
+      "triton": "3.6.0",
+      "flashinfer-python": "0.6.15.post1",
+      "sglang-kernel": "0.4.5",
+      "transformers": "5.16.1"
+    },
+    "gpu_driver": "NVIDIA GB10, 580.126.09"
+  },
+  "output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nIn base $b$:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = 9b + 7$\n\nWe need $(b+7) \\mid (9b + 7)$.\n\nNote that $9b + 7 = 9(b + 7) - 63 + 7 = 9(b+7) - 56$.\n\nSo $(b+7) \\mid (9b+7)$ iff $(b+7) \\mid 56$.\n\nSo $b + 7$ must be a divisor of 56, with $b > 9$, so $b + 7 > 16$.\n\nDivisors of 56: 1, 2, 4, 7, 8, 14, 28, 56.\n\nWe need $b + 7 > 16$, so $b + 7 \\in \\{28, 56\\}$, giving $b = 21$ or $b = 49$.\n\nCheck: $",
+  "moe": {
+    "active": 153000,
+    "missing": 68255,
+    "fetched": 0,
+    "calls": 19125,
+    "sparse_prefill_layers": 75,
+    "sparse_prefill_routes": 600,
+    "sparse_prefill_unique_rows": 600,
+    "sparse_prefill_fallback_layers": 0,
+    "shared_expert_overlap_calls": 19200,
+    "active_per_layer": 8,
+    "missing_per_layer": 3.568888888888889,
+    "miss_rate": 0.4461111111111111,
+    "fetched_per_layer": 0,
+    "fetch_rate": 0,
+    "per_layer": [
+      {
+        "layer": 0,
+        "steps": 255,
+        "active": 2040,
+        "missing": 0,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 0,
+        "miss_rate": 0,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 1,
+        "steps": 255,
+        "active": 2040,
+        "missing": 143,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 0.5607843137254902,
+        "miss_rate": 0.07009803921568628,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 2,
+        "steps": 255,
+        "active": 2040,
+        "missing": 135,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 0.5294117647058824,
+        "miss_rate": 0.0661764705882353,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 3,
+        "steps": 255,
+        "active": 2040,
+        "missing": 841,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.2980392156862743,
+        "miss_rate": 0.4122549019607843,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 4,
+        "steps": 255,
+        "active": 2040,
+        "missing": 815,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.196078431372549,
+        "miss_rate": 0.39950980392156865,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 5,
+        "steps": 255,
+        "active": 2040,
+        "missing": 751,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.9450980392156865,
+        "miss_rate": 0.3681372549019608,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 6,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1171,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.592156862745098,
+        "miss_rate": 0.5740196078431372,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 7,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1168,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.580392156862745,
+        "miss_rate": 0.5725490196078431,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 8,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1146,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.4941176470588236,
+        "miss_rate": 0.5617647058823529,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 9,
+        "steps": 255,
+        "active": 2040,
+        "missing": 984,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.8588235294117648,
+        "miss_rate": 0.4823529411764706,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 10,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1207,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.733333333333333,
+        "miss_rate": 0.5916666666666667,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 11,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1180,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.627450980392157,
+        "miss_rate": 0.5784313725490197,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 12,
+        "steps": 255,
+        "active": 2040,
+        "missing": 896,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5137254901960784,
+        "miss_rate": 0.4392156862745098,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 13,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1017,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.988235294117647,
+        "miss_rate": 0.4985294117647059,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 14,
+        "steps": 255,
+        "active": 2040,
+        "missing": 816,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.2,
+        "miss_rate": 0.4,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 15,
+        "steps": 255,
+        "active": 2040,
+        "missing": 961,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.768627450980392,
+        "miss_rate": 0.471078431372549,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 16,
+        "steps": 255,
+        "active": 2040,
+        "missing": 737,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.8901960784313725,
+        "miss_rate": 0.36127450980392156,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 17,
+        "steps": 255,
+        "active": 2040,
+        "missing": 534,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.0941176470588236,
+        "miss_rate": 0.26176470588235295,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 18,
+        "steps": 255,
+        "active": 2040,
+        "missing": 694,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.7215686274509805,
+        "miss_rate": 0.34019607843137256,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 19,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1063,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.1686274509803924,
+        "miss_rate": 0.5210784313725491,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 20,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1189,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.662745098039216,
+        "miss_rate": 0.582843137254902,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 21,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1263,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.952941176470588,
+        "miss_rate": 0.6191176470588236,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 22,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1269,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.976470588235294,
+        "miss_rate": 0.6220588235294118,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 23,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1175,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.607843137254902,
+        "miss_rate": 0.5759803921568627,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 24,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1169,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.584313725490196,
+        "miss_rate": 0.5730392156862745,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 25,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1051,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.12156862745098,
+        "miss_rate": 0.5151960784313725,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 26,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1050,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.117647058823529,
+        "miss_rate": 0.5147058823529411,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 27,
+        "steps": 255,
+        "active": 2040,
+        "missing": 952,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.7333333333333334,
+        "miss_rate": 0.4666666666666667,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 28,
+        "steps": 255,
+        "active": 2040,
+        "missing": 824,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.231372549019608,
+        "miss_rate": 0.403921568627451,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 29,
+        "steps": 255,
+        "active": 2040,
+        "missing": 837,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.2823529411764705,
+        "miss_rate": 0.4102941176470588,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 30,
+        "steps": 255,
+        "active": 2040,
+        "missing": 902,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.537254901960784,
+        "miss_rate": 0.442156862745098,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 31,
+        "steps": 255,
+        "active": 2040,
+        "missing": 855,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.3529411764705883,
+        "miss_rate": 0.41911764705882354,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 32,
+        "steps": 255,
+        "active": 2040,
+        "missing": 893,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5019607843137255,
+        "miss_rate": 0.4377450980392157,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 33,
+        "steps": 255,
+        "active": 2040,
+        "missing": 894,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5058823529411764,
+        "miss_rate": 0.43823529411764706,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 34,
+        "steps": 255,
+        "active": 2040,
+        "missing": 937,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.6745098039215685,
+        "miss_rate": 0.45931372549019606,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 35,
+        "steps": 255,
+        "active": 2040,
+        "missing": 912,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5764705882352943,
+        "miss_rate": 0.4470588235294118,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 36,
+        "steps": 255,
+        "active": 2040,
+        "missing": 939,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.6823529411764704,
+        "miss_rate": 0.4602941176470588,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 37,
+        "steps": 255,
+        "active": 2040,
+        "missing": 945,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.7058823529411766,
+        "miss_rate": 0.4632352941176471,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 38,
+        "steps": 255,
+        "active": 2040,
+        "missing": 923,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.619607843137255,
+        "miss_rate": 0.45245098039215687,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 39,
+        "steps": 255,
+        "active": 2040,
+        "missing": 949,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.7215686274509805,
+        "miss_rate": 0.46519607843137256,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 40,
+        "steps": 255,
+        "active": 2040,
+        "missing": 945,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.7058823529411766,
+        "miss_rate": 0.4632352941176471,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 41,
+        "steps": 255,
+        "active": 2040,
+        "missing": 964,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.780392156862745,
+        "miss_rate": 0.4725490196078431,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 42,
+        "steps": 255,
+        "active": 2040,
+        "missing": 801,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.1411764705882352,
+        "miss_rate": 0.3926470588235294,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 43,
+        "steps": 255,
+        "active": 2040,
+        "missing": 922,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.615686274509804,
+        "miss_rate": 0.4519607843137255,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 44,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1056,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.141176470588236,
+        "miss_rate": 0.5176470588235295,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 45,
+        "steps": 255,
+        "active": 2040,
+        "missing": 952,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.7333333333333334,
+        "miss_rate": 0.4666666666666667,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 46,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1001,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.925490196078431,
+        "miss_rate": 0.4906862745098039,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 47,
+        "steps": 255,
+        "active": 2040,
+        "missing": 865,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.392156862745098,
+        "miss_rate": 0.42401960784313725,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 48,
+        "steps": 255,
+        "active": 2040,
+        "missing": 905,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.549019607843137,
+        "miss_rate": 0.44362745098039214,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 49,
+        "steps": 255,
+        "active": 2040,
+        "missing": 909,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5647058823529414,
+        "miss_rate": 0.4455882352941177,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 50,
+        "steps": 255,
+        "active": 2040,
+        "missing": 937,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.6745098039215685,
+        "miss_rate": 0.45931372549019606,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 51,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1001,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.925490196078431,
+        "miss_rate": 0.4906862745098039,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 52,
+        "steps": 255,
+        "active": 2040,
+        "missing": 731,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.8666666666666667,
+        "miss_rate": 0.35833333333333334,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 53,
+        "steps": 255,
+        "active": 2040,
+        "missing": 720,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.823529411764706,
+        "miss_rate": 0.35294117647058826,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 54,
+        "steps": 255,
+        "active": 2040,
+        "missing": 701,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 2.7490196078431373,
+        "miss_rate": 0.34362745098039216,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 55,
+        "steps": 255,
+        "active": 2040,
+        "missing": 913,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5803921568627453,
+        "miss_rate": 0.44754901960784316,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 56,
+        "steps": 255,
+        "active": 2040,
+        "missing": 963,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.776470588235294,
+        "miss_rate": 0.47205882352941175,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 57,
+        "steps": 255,
+        "active": 2040,
+        "missing": 765,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3,
+        "miss_rate": 0.375,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 58,
+        "steps": 255,
+        "active": 2040,
+        "missing": 888,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.4823529411764707,
+        "miss_rate": 0.43529411764705883,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 59,
+        "steps": 255,
+        "active": 2040,
+        "missing": 910,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.5686274509803924,
+        "miss_rate": 0.44607843137254904,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 60,
+        "steps": 255,
+        "active": 2040,
+        "missing": 936,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.6705882352941175,
+        "miss_rate": 0.4588235294117647,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 61,
+        "steps": 255,
+        "active": 2040,
+        "missing": 844,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.3098039215686272,
+        "miss_rate": 0.4137254901960784,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 62,
+        "steps": 255,
+        "active": 2040,
+        "missing": 987,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.8705882352941177,
+        "miss_rate": 0.4838235294117647,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 63,
+        "steps": 255,
+        "active": 2040,
+        "missing": 940,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.6862745098039214,
+        "miss_rate": 0.46078431372549017,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 64,
+        "steps": 255,
+        "active": 2040,
+        "missing": 885,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.4705882352941178,
+        "miss_rate": 0.4338235294117647,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 65,
+        "steps": 255,
+        "active": 2040,
+        "missing": 944,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.7019607843137257,
+        "miss_rate": 0.4627450980392157,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 66,
+        "steps": 255,
+        "active": 2040,
+        "missing": 991,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.8862745098039215,
+        "miss_rate": 0.4857843137254902,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 67,
+        "steps": 255,
+        "active": 2040,
+        "missing": 882,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.458823529411765,
+        "miss_rate": 0.4323529411764706,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 68,
+        "steps": 255,
+        "active": 2040,
+        "missing": 878,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.443137254901961,
+        "miss_rate": 0.4303921568627451,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 69,
+        "steps": 255,
+        "active": 2040,
+        "missing": 773,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.0313725490196077,
+        "miss_rate": 0.37892156862745097,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 70,
+        "steps": 255,
+        "active": 2040,
+        "missing": 974,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.819607843137255,
+        "miss_rate": 0.4774509803921569,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 71,
+        "steps": 255,
+        "active": 2040,
+        "missing": 982,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 3.850980392156863,
+        "miss_rate": 0.48137254901960785,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 72,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1059,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.152941176470589,
+        "miss_rate": 0.5191176470588236,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 73,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1076,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.219607843137255,
+        "miss_rate": 0.5274509803921569,
+        "fetched_per_step": 0
+      },
+      {
+        "layer": 74,
+        "steps": 255,
+        "active": 2040,
+        "missing": 1068,
+        "fetched": 0,
+        "active_per_step": 8,
+        "missing_per_step": 4.188235294117647,
+        "miss_rate": 0.5235294117647059,
+        "fetched_per_step": 0
+      }
+    ],
+    "disk": {
+      "cache_hits": 0,
+      "cache_misses": 68615,
+      "cache_evictions": 0,
+      "cache_bypasses": 360,
+      "read_ops": 274460,
+      "logical_bytes": 1456947855360,
+      "physical_bytes": 1456947855360,
+      "read_seconds": 137.56837661581812,
+      "cache_capacity_entries": 0,
+      "cache_capacity_bytes": 0,
+      "cache_allocated_bytes": 0,
+      "cache_occupancy_entries": 0,
+      "cache_occupancy_bytes": 0,
+      "staging_allocated_bytes": 5435817984,
+      "host_allocated_bytes": 5435817984,
+      "read_workers": 20,
+      "cache_policy": "layer_lru",
+      "staging_buffers": 1
+    }
+  }
+}

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-short-sweep.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-short-sweep.json
@@ -1,0 +1,5109 @@
+{
+  "status": "exploratory_not_selected",
+  "notes": [
+    "64-token length-capped probes, not quality certification.",
+    "Original control SHA1 e19ef21a678b. Compact-path sizes do not have universal bit-exact output parity."
+  ],
+  "runs": [
+    {
+      "cache_slots": 675,
+      "measurement": {
+        "schema_version": "1.0",
+        "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+        "backend": "offload",
+        "recipe": {
+          "slug": "glm-5.3",
+          "recipe_version": "0.1.0",
+          "model": "Inferact/GLM-5.3-NVFP4",
+          "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+          "intended_tier": "research",
+          "status_at_run": "experimental",
+          "deployment": {
+            "backend": "native",
+            "backend_api": "1.0",
+            "source_format": "safetensors",
+            "runtime_format": "ftw-nvfp4",
+            "quantization": "nvfp4",
+            "execution_policy": "nvme-moe",
+            "backend_options": {}
+          }
+        },
+        "checkpoint": {
+          "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "format": "ftw",
+          "bytes": 428713099264,
+          "fingerprint": "a0e799b03bceb4bf",
+          "quant_format": "nvfp4_b12x",
+          "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+          "external_artifacts": []
+        },
+        "platform": {
+          "checks": [
+            {
+              "detail": "SparkLab's supported runtime is Linux-only.",
+              "expected": "Linux / DGX OS",
+              "name": "operating_system",
+              "observed": "Linux",
+              "status": "pass"
+            },
+            {
+              "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+              "expected": "aarch64",
+              "name": "cpu_architecture",
+              "observed": "aarch64",
+              "status": "pass"
+            },
+            {
+              "detail": "CUDA must be visible to the Python runtime.",
+              "expected": "CUDA 13.x available",
+              "name": "cuda",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+              "expected": "13.x",
+              "name": "cuda_version",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+              "expected": "SM121 (12.1)",
+              "name": "compute_capability",
+              "observed": [
+                12,
+                1
+              ],
+              "status": "pass"
+            },
+            {
+              "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+              "expected": "NVIDIA GB10",
+              "name": "gpu_identity",
+              "observed": "NVIDIA GB10",
+              "status": "pass"
+            },
+            {
+              "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+              "expected": ">= 123480309760 bytes",
+              "name": "unified_memory",
+              "observed": 130663591936,
+              "status": "pass"
+            },
+            {
+              "detail": "Model recipes consume only memory above the operational reserve.",
+              "expected": ">= 12884901888 bytes safety reserve",
+              "name": "available_memory",
+              "observed": 125911412736,
+              "status": "pass"
+            },
+            {
+              "detail": "Swap is never counted as model capacity.",
+              "expected": "0 bytes used",
+              "name": "swap_usage",
+              "observed": 687915008,
+              "status": "fail"
+            },
+            {
+              "detail": "Device-mapper filesystems may require manual NVMe verification.",
+              "expected": "local NVMe-backed filesystem",
+              "name": "nvme_storage",
+              "observed": "/dev/nvme0n1p2",
+              "status": "pass"
+            },
+            {
+              "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+              "expected": ">= 549755813888 bytes free",
+              "name": "storage_capacity",
+              "observed": 1001038065664,
+              "status": "pass"
+            },
+            {
+              "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+              "expected": "same release and build stamp",
+              "name": "kernel_cache_version",
+              "observed": {
+                "sparklab": "0.1.2",
+                "sparklab-kernel-cache": "0.1.0+cu130"
+              },
+              "status": "fail"
+            }
+          ],
+          "failures": [
+            "swap_usage",
+            "kernel_cache_version"
+          ],
+          "memory": {
+            "available_bytes": 125911412736,
+            "cuda_free_bytes": 95138279424,
+            "physical_bytes": 130663591936,
+            "safe_available_bytes": 113026510848,
+            "safety_reserve_bytes": 12884901888,
+            "swap_total_bytes": 17179865088,
+            "swap_used_bytes": 687915008
+          },
+          "platform_failures": [],
+          "product": "SparkLab",
+          "profile": "gb10",
+          "ready": false,
+          "recommendations": [
+            "Resolve failed platform checks before loading a model.",
+            "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+            "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+          ],
+          "runtime": {
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "gpu": "NVIDIA GB10",
+            "integrated_gpu": true
+          },
+          "schema_version": "1.0",
+          "snapshot": {
+            "block_device": "/dev/nvme0n1p2",
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda_available": true,
+            "cuda_free_bytes": 95138279424,
+            "cuda_version": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "filesystem": "ext4",
+            "gpu_name": "NVIDIA GB10",
+            "gpu_total_bytes": 130663591936,
+            "integrated_gpu": true,
+            "machine": "aarch64",
+            "memory_available_bytes": 125911412736,
+            "memory_total_bytes": 130663591936,
+            "nvme": true,
+            "os_name": "Linux",
+            "storage_free_bytes": 1001038065664,
+            "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "storage_total_bytes": 4031871553536,
+            "swap_free_bytes": 16491950080,
+            "swap_total_bytes": 17179865088
+          },
+          "status": "supported_not_ready",
+          "storage": {
+            "block_device": "/dev/nvme0n1p2",
+            "filesystem": "ext4",
+            "free_bytes": 1001038065664,
+            "nvme": true,
+            "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "total_bytes": 4031871553536
+          },
+          "supported": true,
+          "warnings": [],
+          "exit_code": 1
+        },
+        "configuration": {
+          "storage": "disk",
+          "attention_backend": "auto",
+          "qsa_fused_selection": true,
+          "page_size": 1,
+          "cache_type": "radix",
+          "max_seq_len": 8256,
+          "nvfp4_backend": "flashinfer",
+          "host_cache_gb": 0,
+          "requested_cache_size": 675,
+          "requested_cache_rate": null,
+          "memory_ratio": 0.9,
+          "requested_num_tokens": 2048,
+          "speculative_method": "auto",
+          "speculative_tokens": 0,
+          "speculative_draft_model": null,
+          "draft_sample_method": "greedy",
+          "dspark_confidence_threshold": 0,
+          "dspark_draft_cache_slots": 0,
+          "dspark_draft_cache_quotas": "",
+          "dsv4_kv_storage": "bf16",
+          "dsv4_index_storage": "bf16",
+          "qwen4_dense_storage": "bf16",
+          "qwen4_draft_vocab_size": 0,
+          "mamba_ssm_dtype": "float32",
+          "cpu_threads": 0,
+          "hybrid_fetch": -1,
+          "disk_read_workers": 20,
+          "cache_policy": "layer_lru",
+          "prefill_overlap": false,
+          "preload_all": false,
+          "prefill_hit_d2d": false,
+          "prefill_sparse_max_tokens": 256,
+          "shared_expert_overlap": true,
+          "startup_prefill_warmup": true,
+          "cuda_graph": false,
+          "request_timeout_s": 1800,
+          "prompt_padding_repeats": 0
+        },
+        "cache_geometry": {
+          "num_pages": 2048,
+          "page_size": 1,
+          "moe_cache_size": 675,
+          "num_mamba_slots": 0,
+          "num_experts": 256,
+          "num_moe_layers": 75,
+          "moe_cache_policy": "layer_lru",
+          "unit_bytes": {
+            "kv_per_token": 95232,
+            "moe_per_expert": 21233664,
+            "mamba_per_slot": 0,
+            "swa_per_token": 0
+          },
+          "swa_full_tokens_ratio": 0,
+          "swa_page_size": 0,
+          "num_swa_pages": 0,
+          "cache_budget_bytes": 62065204838,
+          "reasoning": null,
+          "limits": {
+            "kv_tokens": {
+              "min": 1,
+              "max": 651726
+            },
+            "moe_experts": {
+              "min": 256,
+              "max": 2922
+            },
+            "mamba_slots": {
+              "min": 0,
+              "max": 0
+            },
+            "swa_tokens": {
+              "min": 0,
+              "max": 0
+            }
+          }
+        },
+        "problem": 0,
+        "prompt_tokens": 54,
+        "first_request_ttft_ms": 25500.066237000283,
+        "first_request_completion_tokens": 64,
+        "first_request_finish_reason": "length",
+        "decode_steps": 63,
+        "decode_tok_s": 0.8457603186093946,
+        "ms_per_token": 1182.3680752062326,
+        "event_ms_p50": 1197.2787999548018,
+        "event_ms_p99": 1569.4865940022282,
+        "ttft_ms": 2538.649742025882,
+        "events": 64,
+        "completion_tokens": 64,
+        "finish_reason": "length",
+        "vram_gib": 33.765625,
+        "sampling": {
+          "temperature": 0,
+          "top_p": 1,
+          "top_k": -1
+        },
+        "output_sha1": "e19ef21a678b",
+        "expected_answer": "70",
+        "extracted_answer": null,
+        "answer_correct": null,
+        "server_log": "/tmp/bench-serve-offload-41662052.log",
+        "gpu_telemetry": {
+          "samples": 75,
+          "duration_s": 77.02941614895826,
+          "swap_start_bytes": 687906816,
+          "memory_guard_gib": 0,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687906816,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 14.8532,
+          "power_w_peak": 15.26,
+          "temperature_c_peak": 43,
+          "utilization_pct_avg": 22.04,
+          "request_energy_j_est": 1144.1333239437067,
+          "mem_available_gib_min": 73.50151062011719,
+          "nvme_temperature_c_peak": 48.85,
+          "swap_in_pages_delta": 1,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 676127,
+          "major_faults_delta": 1,
+          "oom_kill_delta": 0
+        },
+        "lifecycle_telemetry": {
+          "samples": 199,
+          "duration_s": 205.03988910798216,
+          "swap_start_bytes": 687915008,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687906816,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86859776,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": -8192
+            }
+          },
+          "power_w_avg": 14.227286432160804,
+          "power_w_peak": 34.83,
+          "temperature_c_peak": 43,
+          "utilization_pct_avg": 19.271356783919597,
+          "request_energy_j_est": 2917.1612323577506,
+          "mem_available_gib_min": 73.32402801513672,
+          "nvme_temperature_c_peak": 48.85,
+          "swap_in_pages_delta": 3,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 11572024,
+          "major_faults_delta": 2,
+          "oom_kill_delta": 0
+        },
+        "oom_markers": 0,
+        "provenance": {
+          "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+          "git_tracked_dirty": true,
+          "python": "3.11.15",
+          "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+          "packages": {
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0",
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "transformers": "5.16.1"
+          },
+          "gpu_driver": "NVIDIA GB10, 580.126.09"
+        },
+        "output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nFirst, convert to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7",
+        "moe": {
+          "active": 37800,
+          "missing": 28108,
+          "fetched": 0,
+          "calls": 4725,
+          "sparse_prefill_layers": 75,
+          "sparse_prefill_routes": 600,
+          "sparse_prefill_unique_rows": 600,
+          "sparse_prefill_fallback_layers": 0,
+          "shared_expert_overlap_calls": 4800,
+          "active_per_layer": 8,
+          "missing_per_layer": 5.948783068783069,
+          "miss_rate": 0.7435978835978836,
+          "fetched_per_layer": 0,
+          "fetch_rate": 0,
+          "per_layer": [
+            {
+              "layer": 0,
+              "steps": 63,
+              "active": 504,
+              "missing": 189,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3,
+              "miss_rate": 0.375,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 1,
+              "steps": 63,
+              "active": 504,
+              "missing": 271,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.301587301587301,
+              "miss_rate": 0.5376984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 2,
+              "steps": 63,
+              "active": 504,
+              "missing": 241,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8253968253968256,
+              "miss_rate": 0.4781746031746032,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 3,
+              "steps": 63,
+              "active": 504,
+              "missing": 398,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.317460317460317,
+              "miss_rate": 0.7896825396825397,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 4,
+              "steps": 63,
+              "active": 504,
+              "missing": 379,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.015873015873016,
+              "miss_rate": 0.751984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 5,
+              "steps": 63,
+              "active": 504,
+              "missing": 337,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.349206349206349,
+              "miss_rate": 0.6686507936507936,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 6,
+              "steps": 63,
+              "active": 504,
+              "missing": 403,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.396825396825397,
+              "miss_rate": 0.7996031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 7,
+              "steps": 63,
+              "active": 504,
+              "missing": 412,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.5396825396825395,
+              "miss_rate": 0.8174603174603174,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 8,
+              "steps": 63,
+              "active": 504,
+              "missing": 408,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.476190476190476,
+              "miss_rate": 0.8095238095238095,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 9,
+              "steps": 63,
+              "active": 504,
+              "missing": 404,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.412698412698413,
+              "miss_rate": 0.8015873015873016,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 10,
+              "steps": 63,
+              "active": 504,
+              "missing": 396,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.285714285714286,
+              "miss_rate": 0.7857142857142857,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 11,
+              "steps": 63,
+              "active": 504,
+              "missing": 399,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.333333333333333,
+              "miss_rate": 0.7916666666666666,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 12,
+              "steps": 63,
+              "active": 504,
+              "missing": 402,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.380952380952381,
+              "miss_rate": 0.7976190476190477,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 13,
+              "steps": 63,
+              "active": 504,
+              "missing": 379,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.015873015873016,
+              "miss_rate": 0.751984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 14,
+              "steps": 63,
+              "active": 504,
+              "missing": 353,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.603174603174603,
+              "miss_rate": 0.7003968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 15,
+              "steps": 63,
+              "active": 504,
+              "missing": 362,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.746031746031746,
+              "miss_rate": 0.7182539682539683,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 16,
+              "steps": 63,
+              "active": 504,
+              "missing": 353,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.603174603174603,
+              "miss_rate": 0.7003968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 17,
+              "steps": 63,
+              "active": 504,
+              "missing": 332,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.26984126984127,
+              "miss_rate": 0.6587301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 18,
+              "steps": 63,
+              "active": 504,
+              "missing": 341,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.412698412698413,
+              "miss_rate": 0.6765873015873016,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 19,
+              "steps": 63,
+              "active": 504,
+              "missing": 384,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.095238095238095,
+              "miss_rate": 0.7619047619047619,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 20,
+              "steps": 63,
+              "active": 504,
+              "missing": 423,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.714285714285714,
+              "miss_rate": 0.8392857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 21,
+              "steps": 63,
+              "active": 504,
+              "missing": 424,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.73015873015873,
+              "miss_rate": 0.8412698412698413,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 22,
+              "steps": 63,
+              "active": 504,
+              "missing": 409,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.492063492063492,
+              "miss_rate": 0.8115079365079365,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 23,
+              "steps": 63,
+              "active": 504,
+              "missing": 412,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.5396825396825395,
+              "miss_rate": 0.8174603174603174,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 24,
+              "steps": 63,
+              "active": 504,
+              "missing": 407,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.4603174603174605,
+              "miss_rate": 0.8075396825396826,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 25,
+              "steps": 63,
+              "active": 504,
+              "missing": 366,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.809523809523809,
+              "miss_rate": 0.7261904761904762,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 26,
+              "steps": 63,
+              "active": 504,
+              "missing": 404,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.412698412698413,
+              "miss_rate": 0.8015873015873016,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 27,
+              "steps": 63,
+              "active": 504,
+              "missing": 405,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.428571428571429,
+              "miss_rate": 0.8035714285714286,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 28,
+              "steps": 63,
+              "active": 504,
+              "missing": 351,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.571428571428571,
+              "miss_rate": 0.6964285714285714,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 29,
+              "steps": 63,
+              "active": 504,
+              "missing": 371,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.888888888888889,
+              "miss_rate": 0.7361111111111112,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 30,
+              "steps": 63,
+              "active": 504,
+              "missing": 362,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.746031746031746,
+              "miss_rate": 0.7182539682539683,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 31,
+              "steps": 63,
+              "active": 504,
+              "missing": 399,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.333333333333333,
+              "miss_rate": 0.7916666666666666,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 32,
+              "steps": 63,
+              "active": 504,
+              "missing": 369,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.857142857142857,
+              "miss_rate": 0.7321428571428571,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 33,
+              "steps": 63,
+              "active": 504,
+              "missing": 388,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.158730158730159,
+              "miss_rate": 0.7698412698412699,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 34,
+              "steps": 63,
+              "active": 504,
+              "missing": 394,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.253968253968254,
+              "miss_rate": 0.7817460317460317,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 35,
+              "steps": 63,
+              "active": 504,
+              "missing": 370,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.873015873015873,
+              "miss_rate": 0.7341269841269841,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 36,
+              "steps": 63,
+              "active": 504,
+              "missing": 399,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.333333333333333,
+              "miss_rate": 0.7916666666666666,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 37,
+              "steps": 63,
+              "active": 504,
+              "missing": 395,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.26984126984127,
+              "miss_rate": 0.7837301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 38,
+              "steps": 63,
+              "active": 504,
+              "missing": 400,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.349206349206349,
+              "miss_rate": 0.7936507936507936,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 39,
+              "steps": 63,
+              "active": 504,
+              "missing": 382,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.063492063492063,
+              "miss_rate": 0.7579365079365079,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 40,
+              "steps": 63,
+              "active": 504,
+              "missing": 418,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.634920634920635,
+              "miss_rate": 0.8293650793650794,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 41,
+              "steps": 63,
+              "active": 504,
+              "missing": 378,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6,
+              "miss_rate": 0.75,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 42,
+              "steps": 63,
+              "active": 504,
+              "missing": 356,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.650793650793651,
+              "miss_rate": 0.7063492063492064,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 43,
+              "steps": 63,
+              "active": 504,
+              "missing": 376,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.968253968253968,
+              "miss_rate": 0.746031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 44,
+              "steps": 63,
+              "active": 504,
+              "missing": 389,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.174603174603175,
+              "miss_rate": 0.7718253968253969,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 45,
+              "steps": 63,
+              "active": 504,
+              "missing": 397,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.301587301587301,
+              "miss_rate": 0.7876984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 46,
+              "steps": 63,
+              "active": 504,
+              "missing": 392,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.222222222222222,
+              "miss_rate": 0.7777777777777778,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 47,
+              "steps": 63,
+              "active": 504,
+              "missing": 390,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.190476190476191,
+              "miss_rate": 0.7738095238095238,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 48,
+              "steps": 63,
+              "active": 504,
+              "missing": 367,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.825396825396825,
+              "miss_rate": 0.7281746031746031,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 49,
+              "steps": 63,
+              "active": 504,
+              "missing": 365,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.7936507936507935,
+              "miss_rate": 0.7242063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 50,
+              "steps": 63,
+              "active": 504,
+              "missing": 381,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.0476190476190474,
+              "miss_rate": 0.7559523809523809,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 51,
+              "steps": 63,
+              "active": 504,
+              "missing": 389,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.174603174603175,
+              "miss_rate": 0.7718253968253969,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 52,
+              "steps": 63,
+              "active": 504,
+              "missing": 365,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.7936507936507935,
+              "miss_rate": 0.7242063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 53,
+              "steps": 63,
+              "active": 504,
+              "missing": 327,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.190476190476191,
+              "miss_rate": 0.6488095238095238,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 54,
+              "steps": 63,
+              "active": 504,
+              "missing": 346,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.492063492063492,
+              "miss_rate": 0.6865079365079365,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 55,
+              "steps": 63,
+              "active": 504,
+              "missing": 388,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.158730158730159,
+              "miss_rate": 0.7698412698412699,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 56,
+              "steps": 63,
+              "active": 504,
+              "missing": 378,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6,
+              "miss_rate": 0.75,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 57,
+              "steps": 63,
+              "active": 504,
+              "missing": 356,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.650793650793651,
+              "miss_rate": 0.7063492063492064,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 58,
+              "steps": 63,
+              "active": 504,
+              "missing": 378,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6,
+              "miss_rate": 0.75,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 59,
+              "steps": 63,
+              "active": 504,
+              "missing": 360,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.714285714285714,
+              "miss_rate": 0.7142857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 60,
+              "steps": 63,
+              "active": 504,
+              "missing": 393,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.238095238095238,
+              "miss_rate": 0.7797619047619048,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 61,
+              "steps": 63,
+              "active": 504,
+              "missing": 367,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.825396825396825,
+              "miss_rate": 0.7281746031746031,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 62,
+              "steps": 63,
+              "active": 504,
+              "missing": 405,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.428571428571429,
+              "miss_rate": 0.8035714285714286,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 63,
+              "steps": 63,
+              "active": 504,
+              "missing": 381,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.0476190476190474,
+              "miss_rate": 0.7559523809523809,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 64,
+              "steps": 63,
+              "active": 504,
+              "missing": 350,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.555555555555555,
+              "miss_rate": 0.6944444444444444,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 65,
+              "steps": 63,
+              "active": 504,
+              "missing": 358,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.682539682539683,
+              "miss_rate": 0.7103174603174603,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 66,
+              "steps": 63,
+              "active": 504,
+              "missing": 386,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.126984126984127,
+              "miss_rate": 0.7658730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 67,
+              "steps": 63,
+              "active": 504,
+              "missing": 374,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.936507936507937,
+              "miss_rate": 0.7420634920634921,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 68,
+              "steps": 63,
+              "active": 504,
+              "missing": 356,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.650793650793651,
+              "miss_rate": 0.7063492063492064,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 69,
+              "steps": 63,
+              "active": 504,
+              "missing": 343,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.444444444444445,
+              "miss_rate": 0.6805555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 70,
+              "steps": 63,
+              "active": 504,
+              "missing": 377,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.984126984126984,
+              "miss_rate": 0.748015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 71,
+              "steps": 63,
+              "active": 504,
+              "missing": 385,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.111111111111111,
+              "miss_rate": 0.7638888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 72,
+              "steps": 63,
+              "active": 504,
+              "missing": 374,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.936507936507937,
+              "miss_rate": 0.7420634920634921,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 73,
+              "steps": 63,
+              "active": 504,
+              "missing": 376,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.968253968253968,
+              "miss_rate": 0.746031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 74,
+              "steps": 63,
+              "active": 504,
+              "missing": 414,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.571428571428571,
+              "miss_rate": 0.8214285714285714,
+              "fetched_per_step": 0
+            }
+          ],
+          "disk": {
+            "cache_hits": 0,
+            "cache_misses": 28684,
+            "cache_evictions": 0,
+            "cache_bypasses": 576,
+            "read_ops": 114736,
+            "logical_bytes": 609066418176,
+            "physical_bytes": 609066418176,
+            "read_seconds": 56.04442551068496,
+            "cache_capacity_entries": 0,
+            "cache_capacity_bytes": 0,
+            "cache_allocated_bytes": 0,
+            "cache_occupancy_entries": 0,
+            "cache_occupancy_bytes": 0,
+            "staging_allocated_bytes": 5435817984,
+            "host_allocated_bytes": 5435817984,
+            "read_workers": 20,
+            "cache_policy": "layer_lru",
+            "staging_buffers": 1
+          }
+        }
+      }
+    },
+    {
+      "cache_slots": 1350,
+      "measurement": {
+        "schema_version": "1.0",
+        "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+        "backend": "offload",
+        "recipe": {
+          "slug": "glm-5.3",
+          "recipe_version": "0.1.0",
+          "model": "Inferact/GLM-5.3-NVFP4",
+          "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+          "intended_tier": "research",
+          "status_at_run": "experimental",
+          "deployment": {
+            "backend": "native",
+            "backend_api": "1.0",
+            "source_format": "safetensors",
+            "runtime_format": "ftw-nvfp4",
+            "quantization": "nvfp4",
+            "execution_policy": "nvme-moe",
+            "backend_options": {}
+          }
+        },
+        "checkpoint": {
+          "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "format": "ftw",
+          "bytes": 428713099264,
+          "fingerprint": "a0e799b03bceb4bf",
+          "quant_format": "nvfp4_b12x",
+          "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+          "external_artifacts": []
+        },
+        "platform": {
+          "checks": [
+            {
+              "detail": "SparkLab's supported runtime is Linux-only.",
+              "expected": "Linux / DGX OS",
+              "name": "operating_system",
+              "observed": "Linux",
+              "status": "pass"
+            },
+            {
+              "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+              "expected": "aarch64",
+              "name": "cpu_architecture",
+              "observed": "aarch64",
+              "status": "pass"
+            },
+            {
+              "detail": "CUDA must be visible to the Python runtime.",
+              "expected": "CUDA 13.x available",
+              "name": "cuda",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+              "expected": "13.x",
+              "name": "cuda_version",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+              "expected": "SM121 (12.1)",
+              "name": "compute_capability",
+              "observed": [
+                12,
+                1
+              ],
+              "status": "pass"
+            },
+            {
+              "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+              "expected": "NVIDIA GB10",
+              "name": "gpu_identity",
+              "observed": "NVIDIA GB10",
+              "status": "pass"
+            },
+            {
+              "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+              "expected": ">= 123480309760 bytes",
+              "name": "unified_memory",
+              "observed": 130663591936,
+              "status": "pass"
+            },
+            {
+              "detail": "Model recipes consume only memory above the operational reserve.",
+              "expected": ">= 12884901888 bytes safety reserve",
+              "name": "available_memory",
+              "observed": 126082408448,
+              "status": "pass"
+            },
+            {
+              "detail": "Swap is never counted as model capacity.",
+              "expected": "0 bytes used",
+              "name": "swap_usage",
+              "observed": 687906816,
+              "status": "fail"
+            },
+            {
+              "detail": "Device-mapper filesystems may require manual NVMe verification.",
+              "expected": "local NVMe-backed filesystem",
+              "name": "nvme_storage",
+              "observed": "/dev/nvme0n1p2",
+              "status": "pass"
+            },
+            {
+              "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+              "expected": ">= 549755813888 bytes free",
+              "name": "storage_capacity",
+              "observed": 1001042026496,
+              "status": "pass"
+            },
+            {
+              "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+              "expected": "same release and build stamp",
+              "name": "kernel_cache_version",
+              "observed": {
+                "sparklab": "0.1.2",
+                "sparklab-kernel-cache": "0.1.0+cu130"
+              },
+              "status": "fail"
+            }
+          ],
+          "failures": [
+            "swap_usage",
+            "kernel_cache_version"
+          ],
+          "memory": {
+            "available_bytes": 126082408448,
+            "cuda_free_bytes": 95218348032,
+            "physical_bytes": 130663591936,
+            "safe_available_bytes": 113197506560,
+            "safety_reserve_bytes": 12884901888,
+            "swap_total_bytes": 17179865088,
+            "swap_used_bytes": 687906816
+          },
+          "platform_failures": [],
+          "product": "SparkLab",
+          "profile": "gb10",
+          "ready": false,
+          "recommendations": [
+            "Resolve failed platform checks before loading a model.",
+            "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+            "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+          ],
+          "runtime": {
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "gpu": "NVIDIA GB10",
+            "integrated_gpu": true
+          },
+          "schema_version": "1.0",
+          "snapshot": {
+            "block_device": "/dev/nvme0n1p2",
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda_available": true,
+            "cuda_free_bytes": 95218348032,
+            "cuda_version": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "filesystem": "ext4",
+            "gpu_name": "NVIDIA GB10",
+            "gpu_total_bytes": 130663591936,
+            "integrated_gpu": true,
+            "machine": "aarch64",
+            "memory_available_bytes": 126082408448,
+            "memory_total_bytes": 130663591936,
+            "nvme": true,
+            "os_name": "Linux",
+            "storage_free_bytes": 1001042026496,
+            "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "storage_total_bytes": 4031871553536,
+            "swap_free_bytes": 16491958272,
+            "swap_total_bytes": 17179865088
+          },
+          "status": "supported_not_ready",
+          "storage": {
+            "block_device": "/dev/nvme0n1p2",
+            "filesystem": "ext4",
+            "free_bytes": 1001042026496,
+            "nvme": true,
+            "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "total_bytes": 4031871553536
+          },
+          "supported": true,
+          "warnings": [],
+          "exit_code": 1
+        },
+        "configuration": {
+          "storage": "disk",
+          "attention_backend": "auto",
+          "qsa_fused_selection": true,
+          "page_size": 1,
+          "cache_type": "radix",
+          "max_seq_len": 8256,
+          "nvfp4_backend": "flashinfer",
+          "host_cache_gb": 0,
+          "requested_cache_size": 1350,
+          "requested_cache_rate": null,
+          "memory_ratio": 0.9,
+          "requested_num_tokens": 2048,
+          "speculative_method": "auto",
+          "speculative_tokens": 0,
+          "speculative_draft_model": null,
+          "draft_sample_method": "greedy",
+          "dspark_confidence_threshold": 0,
+          "dspark_draft_cache_slots": 0,
+          "dspark_draft_cache_quotas": "",
+          "dsv4_kv_storage": "bf16",
+          "dsv4_index_storage": "bf16",
+          "qwen4_dense_storage": "bf16",
+          "qwen4_draft_vocab_size": 0,
+          "mamba_ssm_dtype": "float32",
+          "cpu_threads": 0,
+          "hybrid_fetch": -1,
+          "disk_read_workers": 20,
+          "cache_policy": "layer_lru",
+          "prefill_overlap": false,
+          "preload_all": false,
+          "prefill_hit_d2d": false,
+          "prefill_sparse_max_tokens": 256,
+          "shared_expert_overlap": true,
+          "startup_prefill_warmup": true,
+          "cuda_graph": false,
+          "request_timeout_s": 1800,
+          "prompt_padding_repeats": 0
+        },
+        "cache_geometry": {
+          "num_pages": 2048,
+          "page_size": 1,
+          "moe_cache_size": 1350,
+          "num_mamba_slots": 0,
+          "num_experts": 256,
+          "num_moe_layers": 75,
+          "moe_cache_policy": "layer_lru",
+          "unit_bytes": {
+            "kv_per_token": 95232,
+            "moe_per_expert": 21233664,
+            "mamba_per_slot": 0,
+            "swa_per_token": 0
+          },
+          "swa_full_tokens_ratio": 0,
+          "swa_page_size": 0,
+          "num_swa_pages": 0,
+          "cache_budget_bytes": 61876579532,
+          "reasoning": null,
+          "limits": {
+            "kv_tokens": {
+              "min": 1,
+              "max": 649745
+            },
+            "moe_experts": {
+              "min": 256,
+              "max": 2914
+            },
+            "mamba_slots": {
+              "min": 0,
+              "max": 0
+            },
+            "swa_tokens": {
+              "min": 0,
+              "max": 0
+            }
+          }
+        },
+        "problem": 0,
+        "prompt_tokens": 54,
+        "first_request_ttft_ms": 25874.93056996027,
+        "first_request_completion_tokens": 64,
+        "first_request_finish_reason": "length",
+        "decode_steps": 63,
+        "decode_tok_s": 0.9000188685093883,
+        "ms_per_token": 1111.0878171434344,
+        "event_ms_p50": 1110.1693090167828,
+        "event_ms_p99": 1423.9899259991944,
+        "ttft_ms": 2518.284319958184,
+        "events": 64,
+        "completion_tokens": 64,
+        "finish_reason": "length",
+        "vram_gib": 47.26171875,
+        "sampling": {
+          "temperature": 0,
+          "top_p": 1,
+          "top_k": -1
+        },
+        "output_sha1": "e04fe1589d9a",
+        "expected_answer": "70",
+        "extracted_answer": null,
+        "answer_correct": null,
+        "server_log": "/tmp/bench-serve-offload-xnxmv998.log",
+        "gpu_telemetry": {
+          "samples": 71,
+          "duration_s": 72.51877632696414,
+          "swap_start_bytes": 687906816,
+          "memory_guard_gib": 0,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687902720,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 16.808028169014086,
+          "power_w_peak": 17.68,
+          "temperature_c_peak": 46,
+          "utilization_pct_avg": 31.12676056338028,
+          "request_energy_j_est": 1218.8976352860452,
+          "mem_available_gib_min": 60.42804718017578,
+          "nvme_temperature_c_peak": 49.85,
+          "swap_in_pages_delta": 1,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 687998,
+          "major_faults_delta": 1,
+          "oom_kill_delta": 0
+        },
+        "lifecycle_telemetry": {
+          "samples": 212,
+          "duration_s": 219.19663248001598,
+          "swap_start_bytes": 687906816,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687902720,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 16.183962264150942,
+          "power_w_peak": 24.22,
+          "temperature_c_peak": 47,
+          "utilization_pct_avg": 29.589622641509433,
+          "request_energy_j_est": 3547.470028485541,
+          "mem_available_gib_min": 60.10727310180664,
+          "nvme_temperature_c_peak": 49.85,
+          "swap_in_pages_delta": 1,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 11842690,
+          "major_faults_delta": 2,
+          "oom_kill_delta": 0
+        },
+        "oom_markers": 0,
+        "provenance": {
+          "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+          "git_tracked_dirty": true,
+          "python": "3.11.15",
+          "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+          "packages": {
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0",
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "transformers": "5.16.1"
+          },
+          "gpu_driver": "NVIDIA GB10, 580.126.09"
+        },
+        "output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nIn base $b$:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = ",
+        "moe": {
+          "active": 37800,
+          "missing": 23547,
+          "fetched": 0,
+          "calls": 4725,
+          "sparse_prefill_layers": 75,
+          "sparse_prefill_routes": 600,
+          "sparse_prefill_unique_rows": 600,
+          "sparse_prefill_fallback_layers": 0,
+          "shared_expert_overlap_calls": 4800,
+          "active_per_layer": 8,
+          "missing_per_layer": 4.983492063492063,
+          "miss_rate": 0.6229365079365079,
+          "fetched_per_layer": 0,
+          "fetch_rate": 0,
+          "per_layer": [
+            {
+              "layer": 0,
+              "steps": 63,
+              "active": 504,
+              "missing": 42,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0.6666666666666666,
+              "miss_rate": 0.08333333333333333,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 1,
+              "steps": 63,
+              "active": 504,
+              "missing": 147,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.3333333333333335,
+              "miss_rate": 0.2916666666666667,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 2,
+              "steps": 63,
+              "active": 504,
+              "missing": 118,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 1.873015873015873,
+              "miss_rate": 0.23412698412698413,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 3,
+              "steps": 63,
+              "active": 504,
+              "missing": 347,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.507936507936508,
+              "miss_rate": 0.6884920634920635,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 4,
+              "steps": 63,
+              "active": 504,
+              "missing": 340,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.396825396825397,
+              "miss_rate": 0.6746031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 5,
+              "steps": 63,
+              "active": 504,
+              "missing": 299,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.746031746031746,
+              "miss_rate": 0.5932539682539683,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 6,
+              "steps": 63,
+              "active": 504,
+              "missing": 381,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.0476190476190474,
+              "miss_rate": 0.7559523809523809,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 7,
+              "steps": 63,
+              "active": 504,
+              "missing": 378,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6,
+              "miss_rate": 0.75,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 8,
+              "steps": 63,
+              "active": 504,
+              "missing": 365,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.7936507936507935,
+              "miss_rate": 0.7242063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 9,
+              "steps": 63,
+              "active": 504,
+              "missing": 332,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.26984126984127,
+              "miss_rate": 0.6587301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 10,
+              "steps": 63,
+              "active": 504,
+              "missing": 368,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.841269841269841,
+              "miss_rate": 0.7301587301587301,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 11,
+              "steps": 63,
+              "active": 504,
+              "missing": 374,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.936507936507937,
+              "miss_rate": 0.7420634920634921,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 12,
+              "steps": 63,
+              "active": 504,
+              "missing": 349,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.5396825396825395,
+              "miss_rate": 0.6924603174603174,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 13,
+              "steps": 63,
+              "active": 504,
+              "missing": 319,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.063492063492063,
+              "miss_rate": 0.6329365079365079,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 14,
+              "steps": 63,
+              "active": 504,
+              "missing": 288,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.571428571428571,
+              "miss_rate": 0.5714285714285714,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 15,
+              "steps": 63,
+              "active": 504,
+              "missing": 297,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.714285714285714,
+              "miss_rate": 0.5892857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 16,
+              "steps": 63,
+              "active": 504,
+              "missing": 278,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.412698412698413,
+              "miss_rate": 0.5515873015873016,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 17,
+              "steps": 63,
+              "active": 504,
+              "missing": 260,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.126984126984127,
+              "miss_rate": 0.5158730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 18,
+              "steps": 63,
+              "active": 504,
+              "missing": 259,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.111111111111111,
+              "miss_rate": 0.5138888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 19,
+              "steps": 63,
+              "active": 504,
+              "missing": 334,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.301587301587301,
+              "miss_rate": 0.6626984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 20,
+              "steps": 63,
+              "active": 504,
+              "missing": 386,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.126984126984127,
+              "miss_rate": 0.7658730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 21,
+              "steps": 63,
+              "active": 504,
+              "missing": 399,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.333333333333333,
+              "miss_rate": 0.7916666666666666,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 22,
+              "steps": 63,
+              "active": 504,
+              "missing": 380,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6.031746031746032,
+              "miss_rate": 0.753968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 23,
+              "steps": 63,
+              "active": 504,
+              "missing": 378,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 6,
+              "miss_rate": 0.75,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 24,
+              "steps": 63,
+              "active": 504,
+              "missing": 350,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.555555555555555,
+              "miss_rate": 0.6944444444444444,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 25,
+              "steps": 63,
+              "active": 504,
+              "missing": 320,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.079365079365079,
+              "miss_rate": 0.6349206349206349,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 26,
+              "steps": 63,
+              "active": 504,
+              "missing": 363,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.761904761904762,
+              "miss_rate": 0.7202380952380952,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 27,
+              "steps": 63,
+              "active": 504,
+              "missing": 350,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.555555555555555,
+              "miss_rate": 0.6944444444444444,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 28,
+              "steps": 63,
+              "active": 504,
+              "missing": 266,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.222222222222222,
+              "miss_rate": 0.5277777777777778,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 29,
+              "steps": 63,
+              "active": 504,
+              "missing": 299,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.746031746031746,
+              "miss_rate": 0.5932539682539683,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 30,
+              "steps": 63,
+              "active": 504,
+              "missing": 297,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.714285714285714,
+              "miss_rate": 0.5892857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 31,
+              "steps": 63,
+              "active": 504,
+              "missing": 322,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.111111111111111,
+              "miss_rate": 0.6388888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 32,
+              "steps": 63,
+              "active": 504,
+              "missing": 292,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.634920634920635,
+              "miss_rate": 0.5793650793650794,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 33,
+              "steps": 63,
+              "active": 504,
+              "missing": 328,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.2063492063492065,
+              "miss_rate": 0.6507936507936508,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 34,
+              "steps": 63,
+              "active": 504,
+              "missing": 325,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.158730158730159,
+              "miss_rate": 0.6448412698412699,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 35,
+              "steps": 63,
+              "active": 504,
+              "missing": 305,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.841269841269841,
+              "miss_rate": 0.6051587301587301,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 36,
+              "steps": 63,
+              "active": 504,
+              "missing": 343,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.444444444444445,
+              "miss_rate": 0.6805555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 37,
+              "steps": 63,
+              "active": 504,
+              "missing": 331,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.253968253968254,
+              "miss_rate": 0.6567460317460317,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 38,
+              "steps": 63,
+              "active": 504,
+              "missing": 348,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.523809523809524,
+              "miss_rate": 0.6904761904761905,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 39,
+              "steps": 63,
+              "active": 504,
+              "missing": 327,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.190476190476191,
+              "miss_rate": 0.6488095238095238,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 40,
+              "steps": 63,
+              "active": 504,
+              "missing": 348,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.523809523809524,
+              "miss_rate": 0.6904761904761905,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 41,
+              "steps": 63,
+              "active": 504,
+              "missing": 302,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.7936507936507935,
+              "miss_rate": 0.5992063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 42,
+              "steps": 63,
+              "active": 504,
+              "missing": 275,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.365079365079365,
+              "miss_rate": 0.5456349206349206,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 43,
+              "steps": 63,
+              "active": 504,
+              "missing": 302,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.7936507936507935,
+              "miss_rate": 0.5992063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 44,
+              "steps": 63,
+              "active": 504,
+              "missing": 328,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.2063492063492065,
+              "miss_rate": 0.6507936507936508,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 45,
+              "steps": 63,
+              "active": 504,
+              "missing": 342,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.428571428571429,
+              "miss_rate": 0.6785714285714286,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 46,
+              "steps": 63,
+              "active": 504,
+              "missing": 321,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.095238095238095,
+              "miss_rate": 0.6369047619047619,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 47,
+              "steps": 63,
+              "active": 504,
+              "missing": 308,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.888888888888889,
+              "miss_rate": 0.6111111111111112,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 48,
+              "steps": 63,
+              "active": 504,
+              "missing": 291,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.619047619047619,
+              "miss_rate": 0.5773809523809523,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 49,
+              "steps": 63,
+              "active": 504,
+              "missing": 305,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.841269841269841,
+              "miss_rate": 0.6051587301587301,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 50,
+              "steps": 63,
+              "active": 504,
+              "missing": 313,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.968253968253968,
+              "miss_rate": 0.621031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 51,
+              "steps": 63,
+              "active": 504,
+              "missing": 342,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.428571428571429,
+              "miss_rate": 0.6785714285714286,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 52,
+              "steps": 63,
+              "active": 504,
+              "missing": 294,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.666666666666667,
+              "miss_rate": 0.5833333333333334,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 53,
+              "steps": 63,
+              "active": 504,
+              "missing": 263,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.174603174603175,
+              "miss_rate": 0.5218253968253969,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 54,
+              "steps": 63,
+              "active": 504,
+              "missing": 272,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.317460317460317,
+              "miss_rate": 0.5396825396825397,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 55,
+              "steps": 63,
+              "active": 504,
+              "missing": 311,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.936507936507937,
+              "miss_rate": 0.6170634920634921,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 56,
+              "steps": 63,
+              "active": 504,
+              "missing": 317,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.031746031746032,
+              "miss_rate": 0.628968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 57,
+              "steps": 63,
+              "active": 504,
+              "missing": 295,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.682539682539683,
+              "miss_rate": 0.5853174603174603,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 58,
+              "steps": 63,
+              "active": 504,
+              "missing": 299,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.746031746031746,
+              "miss_rate": 0.5932539682539683,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 59,
+              "steps": 63,
+              "active": 504,
+              "missing": 302,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.7936507936507935,
+              "miss_rate": 0.5992063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 60,
+              "steps": 63,
+              "active": 504,
+              "missing": 323,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.126984126984127,
+              "miss_rate": 0.6408730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 61,
+              "steps": 63,
+              "active": 504,
+              "missing": 315,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5,
+              "miss_rate": 0.625,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 62,
+              "steps": 63,
+              "active": 504,
+              "missing": 332,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.26984126984127,
+              "miss_rate": 0.6587301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 63,
+              "steps": 63,
+              "active": 504,
+              "missing": 312,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.9523809523809526,
+              "miss_rate": 0.6190476190476191,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 64,
+              "steps": 63,
+              "active": 504,
+              "missing": 283,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.492063492063492,
+              "miss_rate": 0.5615079365079365,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 65,
+              "steps": 63,
+              "active": 504,
+              "missing": 311,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.936507936507937,
+              "miss_rate": 0.6170634920634921,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 66,
+              "steps": 63,
+              "active": 504,
+              "missing": 320,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.079365079365079,
+              "miss_rate": 0.6349206349206349,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 67,
+              "steps": 63,
+              "active": 504,
+              "missing": 317,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.031746031746032,
+              "miss_rate": 0.628968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 68,
+              "steps": 63,
+              "active": 504,
+              "missing": 313,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.968253968253968,
+              "miss_rate": 0.621031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 69,
+              "steps": 63,
+              "active": 504,
+              "missing": 275,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.365079365079365,
+              "miss_rate": 0.5456349206349206,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 70,
+              "steps": 63,
+              "active": 504,
+              "missing": 337,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.349206349206349,
+              "miss_rate": 0.6686507936507936,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 71,
+              "steps": 63,
+              "active": 504,
+              "missing": 348,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.523809523809524,
+              "miss_rate": 0.6904761904761905,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 72,
+              "steps": 63,
+              "active": 504,
+              "missing": 343,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.444444444444445,
+              "miss_rate": 0.6805555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 73,
+              "steps": 63,
+              "active": 504,
+              "missing": 342,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.428571428571429,
+              "miss_rate": 0.6785714285714286,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 74,
+              "steps": 63,
+              "active": 504,
+              "missing": 362,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.746031746031746,
+              "miss_rate": 0.7182539682539683,
+              "fetched_per_step": 0
+            }
+          ],
+          "disk": {
+            "cache_hits": 0,
+            "cache_misses": 24034,
+            "cache_evictions": 0,
+            "cache_bypasses": 487,
+            "read_ops": 96136,
+            "logical_bytes": 510329880576,
+            "physical_bytes": 510329880576,
+            "read_seconds": 47.17330106254667,
+            "cache_capacity_entries": 0,
+            "cache_capacity_bytes": 0,
+            "cache_allocated_bytes": 0,
+            "cache_occupancy_entries": 0,
+            "cache_occupancy_bytes": 0,
+            "staging_allocated_bytes": 5435817984,
+            "host_allocated_bytes": 5435817984,
+            "read_workers": 20,
+            "cache_policy": "layer_lru",
+            "staging_buffers": 1
+          }
+        }
+      }
+    },
+    {
+      "cache_slots": 2700,
+      "measurement": {
+        "schema_version": "1.0",
+        "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+        "backend": "offload",
+        "recipe": {
+          "slug": "glm-5.3",
+          "recipe_version": "0.1.0",
+          "model": "Inferact/GLM-5.3-NVFP4",
+          "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+          "intended_tier": "research",
+          "status_at_run": "experimental",
+          "deployment": {
+            "backend": "native",
+            "backend_api": "1.0",
+            "source_format": "safetensors",
+            "runtime_format": "ftw-nvfp4",
+            "quantization": "nvfp4",
+            "execution_policy": "nvme-moe",
+            "backend_options": {}
+          }
+        },
+        "checkpoint": {
+          "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "format": "ftw",
+          "bytes": 428713099264,
+          "fingerprint": "a0e799b03bceb4bf",
+          "quant_format": "nvfp4_b12x",
+          "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+          "external_artifacts": []
+        },
+        "platform": {
+          "checks": [
+            {
+              "detail": "SparkLab's supported runtime is Linux-only.",
+              "expected": "Linux / DGX OS",
+              "name": "operating_system",
+              "observed": "Linux",
+              "status": "pass"
+            },
+            {
+              "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+              "expected": "aarch64",
+              "name": "cpu_architecture",
+              "observed": "aarch64",
+              "status": "pass"
+            },
+            {
+              "detail": "CUDA must be visible to the Python runtime.",
+              "expected": "CUDA 13.x available",
+              "name": "cuda",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+              "expected": "13.x",
+              "name": "cuda_version",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+              "expected": "SM121 (12.1)",
+              "name": "compute_capability",
+              "observed": [
+                12,
+                1
+              ],
+              "status": "pass"
+            },
+            {
+              "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+              "expected": "NVIDIA GB10",
+              "name": "gpu_identity",
+              "observed": "NVIDIA GB10",
+              "status": "pass"
+            },
+            {
+              "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+              "expected": ">= 123480309760 bytes",
+              "name": "unified_memory",
+              "observed": 130663591936,
+              "status": "pass"
+            },
+            {
+              "detail": "Model recipes consume only memory above the operational reserve.",
+              "expected": ">= 12884901888 bytes safety reserve",
+              "name": "available_memory",
+              "observed": 126078672896,
+              "status": "pass"
+            },
+            {
+              "detail": "Swap is never counted as model capacity.",
+              "expected": "0 bytes used",
+              "name": "swap_usage",
+              "observed": 687865856,
+              "status": "fail"
+            },
+            {
+              "detail": "Device-mapper filesystems may require manual NVMe verification.",
+              "expected": "local NVMe-backed filesystem",
+              "name": "nvme_storage",
+              "observed": "/dev/nvme0n1p2",
+              "status": "pass"
+            },
+            {
+              "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+              "expected": ">= 549755813888 bytes free",
+              "name": "storage_capacity",
+              "observed": 1840911843328,
+              "status": "pass"
+            },
+            {
+              "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+              "expected": "same release and build stamp",
+              "name": "kernel_cache_version",
+              "observed": {
+                "sparklab": "0.1.2",
+                "sparklab-kernel-cache": "0.1.0+cu130"
+              },
+              "status": "fail"
+            }
+          ],
+          "failures": [
+            "swap_usage",
+            "kernel_cache_version"
+          ],
+          "memory": {
+            "available_bytes": 126078672896,
+            "cuda_free_bytes": 99701248000,
+            "physical_bytes": 130663591936,
+            "safe_available_bytes": 113193771008,
+            "safety_reserve_bytes": 12884901888,
+            "swap_total_bytes": 17179865088,
+            "swap_used_bytes": 687865856
+          },
+          "platform_failures": [],
+          "product": "SparkLab",
+          "profile": "gb10",
+          "ready": false,
+          "recommendations": [
+            "Resolve failed platform checks before loading a model.",
+            "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+            "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+          ],
+          "runtime": {
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "gpu": "NVIDIA GB10",
+            "integrated_gpu": true
+          },
+          "schema_version": "1.0",
+          "snapshot": {
+            "block_device": "/dev/nvme0n1p2",
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda_available": true,
+            "cuda_free_bytes": 99701248000,
+            "cuda_version": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "filesystem": "ext4",
+            "gpu_name": "NVIDIA GB10",
+            "gpu_total_bytes": 130663591936,
+            "integrated_gpu": true,
+            "machine": "aarch64",
+            "memory_available_bytes": 126078672896,
+            "memory_total_bytes": 130663591936,
+            "nvme": true,
+            "os_name": "Linux",
+            "storage_free_bytes": 1840911843328,
+            "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "storage_total_bytes": 4031871553536,
+            "swap_free_bytes": 16491999232,
+            "swap_total_bytes": 17179865088
+          },
+          "status": "supported_not_ready",
+          "storage": {
+            "block_device": "/dev/nvme0n1p2",
+            "filesystem": "ext4",
+            "free_bytes": 1840911843328,
+            "nvme": true,
+            "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "total_bytes": 4031871553536
+          },
+          "supported": true,
+          "warnings": [],
+          "exit_code": 1
+        },
+        "configuration": {
+          "storage": "disk",
+          "attention_backend": "auto",
+          "qsa_fused_selection": true,
+          "page_size": 1,
+          "cache_type": "radix",
+          "max_seq_len": 8256,
+          "nvfp4_backend": "flashinfer",
+          "host_cache_gb": 0,
+          "requested_cache_size": 2700,
+          "requested_cache_rate": null,
+          "memory_ratio": 0.9,
+          "requested_num_tokens": 2048,
+          "speculative_method": "auto",
+          "speculative_tokens": 0,
+          "speculative_draft_model": null,
+          "draft_sample_method": "greedy",
+          "dspark_confidence_threshold": 0,
+          "dspark_draft_cache_slots": 0,
+          "dspark_draft_cache_quotas": "",
+          "dsv4_kv_storage": "bf16",
+          "dsv4_index_storage": "bf16",
+          "qwen4_dense_storage": "bf16",
+          "qwen4_draft_vocab_size": 0,
+          "mamba_ssm_dtype": "float32",
+          "cpu_threads": 0,
+          "hybrid_fetch": -1,
+          "disk_read_workers": 20,
+          "cache_policy": "layer_lru",
+          "prefill_overlap": false,
+          "preload_all": false,
+          "prefill_hit_d2d": false,
+          "prefill_sparse_max_tokens": 256,
+          "shared_expert_overlap": true,
+          "startup_prefill_warmup": true,
+          "cuda_graph": false,
+          "request_timeout_s": 1800,
+          "prompt_padding_repeats": 0
+        },
+        "cache_geometry": {
+          "num_pages": 2048,
+          "page_size": 1,
+          "moe_cache_size": 2700,
+          "num_mamba_slots": 0,
+          "num_experts": 256,
+          "num_moe_layers": 75,
+          "moe_cache_policy": "layer_lru",
+          "unit_bytes": {
+            "kv_per_token": 95232,
+            "moe_per_expert": 21233664,
+            "mamba_per_slot": 0,
+            "swa_per_token": 0
+          },
+          "swa_full_tokens_ratio": 0,
+          "swa_page_size": 0,
+          "num_swa_pages": 0,
+          "cache_budget_bytes": 65581077708,
+          "reasoning": null,
+          "limits": {
+            "kv_tokens": {
+              "min": 1,
+              "max": 688645
+            },
+            "moe_experts": {
+              "min": 256,
+              "max": 3088
+            },
+            "mamba_slots": {
+              "min": 0,
+              "max": 0
+            },
+            "swa_tokens": {
+              "min": 0,
+              "max": 0
+            }
+          }
+        },
+        "problem": 0,
+        "prompt_tokens": 54,
+        "first_request_ttft_ms": 26079.58870899165,
+        "first_request_completion_tokens": 64,
+        "first_request_finish_reason": "length",
+        "decode_steps": 63,
+        "decode_tok_s": 1.1107494145856398,
+        "ms_per_token": 900.2930695876584,
+        "event_ms_p50": 907.0741650066338,
+        "event_ms_p99": 1172.2852729726583,
+        "ttft_ms": 2113.3181679761037,
+        "events": 64,
+        "completion_tokens": 64,
+        "finish_reason": "length",
+        "vram_gib": 73.9609375,
+        "sampling": {
+          "temperature": 0,
+          "top_p": 1,
+          "top_k": -1
+        },
+        "output_sha1": "e04fe1589d9a",
+        "expected_answer": "70",
+        "extracted_answer": null,
+        "answer_correct": null,
+        "server_log": "/tmp/bench-serve-offload-s178r2r4.log",
+        "gpu_telemetry": {
+          "samples": 57,
+          "duration_s": 58.83374026796082,
+          "swap_start_bytes": 687865856,
+          "memory_guard_gib": 0,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687865856,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 16.74280701754386,
+          "power_w_peak": 17.72,
+          "temperature_c_peak": 44,
+          "utilization_pct_avg": 36.1578947368421,
+          "request_energy_j_est": 985.0419594267672,
+          "mem_available_gib_min": 33.19923400878906,
+          "nvme_temperature_c_peak": 45.85,
+          "swap_in_pages_delta": 1,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 500810,
+          "major_faults_delta": 1,
+          "oom_kill_delta": 0
+        },
+        "lifecycle_telemetry": {
+          "samples": 186,
+          "duration_s": 192.7011232880177,
+          "swap_start_bytes": 687865856,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687865856,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 15.605,
+          "power_w_peak": 22.98,
+          "temperature_c_peak": 44,
+          "utilization_pct_avg": 31.77956989247312,
+          "request_energy_j_est": 3007.101028909516,
+          "mem_available_gib_min": 32.861061096191406,
+          "nvme_temperature_c_peak": 45.85,
+          "swap_in_pages_delta": 2,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 11567070,
+          "major_faults_delta": 2,
+          "oom_kill_delta": 0
+        },
+        "oom_markers": 0,
+        "provenance": {
+          "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+          "git_tracked_dirty": true,
+          "python": "3.11.15",
+          "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+          "packages": {
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0",
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "transformers": "5.16.1"
+          },
+          "gpu_driver": "NVIDIA GB10, 580.126.09"
+        },
+        "output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nIn base $b$:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7 = ",
+        "moe": {
+          "active": 37800,
+          "missing": 17117,
+          "fetched": 0,
+          "calls": 4725,
+          "sparse_prefill_layers": 75,
+          "sparse_prefill_routes": 600,
+          "sparse_prefill_unique_rows": 600,
+          "sparse_prefill_fallback_layers": 0,
+          "shared_expert_overlap_calls": 4800,
+          "active_per_layer": 8,
+          "missing_per_layer": 3.6226455026455024,
+          "miss_rate": 0.4528306878306878,
+          "fetched_per_layer": 0,
+          "fetch_rate": 0,
+          "per_layer": [
+            {
+              "layer": 0,
+              "steps": 63,
+              "active": 504,
+              "missing": 0,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0,
+              "miss_rate": 0,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 1,
+              "steps": 63,
+              "active": 504,
+              "missing": 37,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0.5873015873015873,
+              "miss_rate": 0.07341269841269842,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 2,
+              "steps": 63,
+              "active": 504,
+              "missing": 50,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0.7936507936507936,
+              "miss_rate": 0.0992063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 3,
+              "steps": 63,
+              "active": 504,
+              "missing": 248,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.9365079365079363,
+              "miss_rate": 0.49206349206349204,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 4,
+              "steps": 63,
+              "active": 504,
+              "missing": 217,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4444444444444446,
+              "miss_rate": 0.4305555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 5,
+              "steps": 63,
+              "active": 504,
+              "missing": 198,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.142857142857143,
+              "miss_rate": 0.39285714285714285,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 6,
+              "steps": 63,
+              "active": 504,
+              "missing": 300,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.761904761904762,
+              "miss_rate": 0.5952380952380952,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 7,
+              "steps": 63,
+              "active": 504,
+              "missing": 297,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.714285714285714,
+              "miss_rate": 0.5892857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 8,
+              "steps": 63,
+              "active": 504,
+              "missing": 286,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.5396825396825395,
+              "miss_rate": 0.5674603174603174,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 9,
+              "steps": 63,
+              "active": 504,
+              "missing": 233,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6984126984126986,
+              "miss_rate": 0.4623015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 10,
+              "steps": 63,
+              "active": 504,
+              "missing": 303,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.809523809523809,
+              "miss_rate": 0.6011904761904762,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 11,
+              "steps": 63,
+              "active": 504,
+              "missing": 275,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.365079365079365,
+              "miss_rate": 0.5456349206349206,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 12,
+              "steps": 63,
+              "active": 504,
+              "missing": 227,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6031746031746033,
+              "miss_rate": 0.4503968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 13,
+              "steps": 63,
+              "active": 504,
+              "missing": 226,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5873015873015874,
+              "miss_rate": 0.44841269841269843,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 14,
+              "steps": 63,
+              "active": 504,
+              "missing": 193,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0634920634920637,
+              "miss_rate": 0.38293650793650796,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 15,
+              "steps": 63,
+              "active": 504,
+              "missing": 172,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.7301587301587302,
+              "miss_rate": 0.3412698412698413,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 16,
+              "steps": 63,
+              "active": 504,
+              "missing": 148,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.3492063492063493,
+              "miss_rate": 0.29365079365079366,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 17,
+              "steps": 63,
+              "active": 504,
+              "missing": 125,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 1.9841269841269842,
+              "miss_rate": 0.24801587301587302,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 18,
+              "steps": 63,
+              "active": 504,
+              "missing": 154,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.4444444444444446,
+              "miss_rate": 0.3055555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 19,
+              "steps": 63,
+              "active": 504,
+              "missing": 207,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.2857142857142856,
+              "miss_rate": 0.4107142857142857,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 20,
+              "steps": 63,
+              "active": 504,
+              "missing": 303,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.809523809523809,
+              "miss_rate": 0.6011904761904762,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 21,
+              "steps": 63,
+              "active": 504,
+              "missing": 307,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.873015873015873,
+              "miss_rate": 0.6091269841269841,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 22,
+              "steps": 63,
+              "active": 504,
+              "missing": 324,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.142857142857143,
+              "miss_rate": 0.6428571428571429,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 23,
+              "steps": 63,
+              "active": 504,
+              "missing": 287,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.555555555555555,
+              "miss_rate": 0.5694444444444444,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 24,
+              "steps": 63,
+              "active": 504,
+              "missing": 251,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.984126984126984,
+              "miss_rate": 0.498015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 25,
+              "steps": 63,
+              "active": 504,
+              "missing": 256,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.063492063492063,
+              "miss_rate": 0.5079365079365079,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 26,
+              "steps": 63,
+              "active": 504,
+              "missing": 280,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.444444444444445,
+              "miss_rate": 0.5555555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 27,
+              "steps": 63,
+              "active": 504,
+              "missing": 274,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.349206349206349,
+              "miss_rate": 0.5436507936507936,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 28,
+              "steps": 63,
+              "active": 504,
+              "missing": 194,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0793650793650795,
+              "miss_rate": 0.38492063492063494,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 29,
+              "steps": 63,
+              "active": 504,
+              "missing": 192,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0476190476190474,
+              "miss_rate": 0.38095238095238093,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 30,
+              "steps": 63,
+              "active": 504,
+              "missing": 216,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4285714285714284,
+              "miss_rate": 0.42857142857142855,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 31,
+              "steps": 63,
+              "active": 504,
+              "missing": 220,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.492063492063492,
+              "miss_rate": 0.4365079365079365,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 32,
+              "steps": 63,
+              "active": 504,
+              "missing": 210,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.3333333333333335,
+              "miss_rate": 0.4166666666666667,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 33,
+              "steps": 63,
+              "active": 504,
+              "missing": 219,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4761904761904763,
+              "miss_rate": 0.43452380952380953,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 34,
+              "steps": 63,
+              "active": 504,
+              "missing": 241,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8253968253968256,
+              "miss_rate": 0.4781746031746032,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 35,
+              "steps": 63,
+              "active": 504,
+              "missing": 225,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5714285714285716,
+              "miss_rate": 0.44642857142857145,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 36,
+              "steps": 63,
+              "active": 504,
+              "missing": 258,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.095238095238095,
+              "miss_rate": 0.5119047619047619,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 37,
+              "steps": 63,
+              "active": 504,
+              "missing": 223,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5396825396825395,
+              "miss_rate": 0.44246031746031744,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 38,
+              "steps": 63,
+              "active": 504,
+              "missing": 259,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.111111111111111,
+              "miss_rate": 0.5138888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 39,
+              "steps": 63,
+              "active": 504,
+              "missing": 253,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.015873015873016,
+              "miss_rate": 0.501984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 40,
+              "steps": 63,
+              "active": 504,
+              "missing": 266,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.222222222222222,
+              "miss_rate": 0.5277777777777778,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 41,
+              "steps": 63,
+              "active": 504,
+              "missing": 239,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7936507936507935,
+              "miss_rate": 0.4742063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 42,
+              "steps": 63,
+              "active": 504,
+              "missing": 202,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.2063492063492065,
+              "miss_rate": 0.4007936507936508,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 43,
+              "steps": 63,
+              "active": 504,
+              "missing": 216,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4285714285714284,
+              "miss_rate": 0.42857142857142855,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 44,
+              "steps": 63,
+              "active": 504,
+              "missing": 261,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.142857142857143,
+              "miss_rate": 0.5178571428571429,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 45,
+              "steps": 63,
+              "active": 504,
+              "missing": 262,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.158730158730159,
+              "miss_rate": 0.5198412698412699,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 46,
+              "steps": 63,
+              "active": 504,
+              "missing": 238,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7777777777777777,
+              "miss_rate": 0.4722222222222222,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 47,
+              "steps": 63,
+              "active": 504,
+              "missing": 234,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7142857142857144,
+              "miss_rate": 0.4642857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 48,
+              "steps": 63,
+              "active": 504,
+              "missing": 242,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8412698412698414,
+              "miss_rate": 0.4801587301587302,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 49,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 50,
+              "steps": 63,
+              "active": 504,
+              "missing": 234,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7142857142857144,
+              "miss_rate": 0.4642857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 51,
+              "steps": 63,
+              "active": 504,
+              "missing": 266,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.222222222222222,
+              "miss_rate": 0.5277777777777778,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 52,
+              "steps": 63,
+              "active": 504,
+              "missing": 212,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.365079365079365,
+              "miss_rate": 0.42063492063492064,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 53,
+              "steps": 63,
+              "active": 504,
+              "missing": 190,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.015873015873016,
+              "miss_rate": 0.376984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 54,
+              "steps": 63,
+              "active": 504,
+              "missing": 191,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0317460317460316,
+              "miss_rate": 0.37896825396825395,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 55,
+              "steps": 63,
+              "active": 504,
+              "missing": 233,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6984126984126986,
+              "miss_rate": 0.4623015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 56,
+              "steps": 63,
+              "active": 504,
+              "missing": 254,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.031746031746032,
+              "miss_rate": 0.503968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 57,
+              "steps": 63,
+              "active": 504,
+              "missing": 201,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.1904761904761907,
+              "miss_rate": 0.39880952380952384,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 58,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 59,
+              "steps": 63,
+              "active": 504,
+              "missing": 257,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.079365079365079,
+              "miss_rate": 0.5099206349206349,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 60,
+              "steps": 63,
+              "active": 504,
+              "missing": 240,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8095238095238093,
+              "miss_rate": 0.47619047619047616,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 61,
+              "steps": 63,
+              "active": 504,
+              "missing": 225,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5714285714285716,
+              "miss_rate": 0.44642857142857145,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 62,
+              "steps": 63,
+              "active": 504,
+              "missing": 251,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.984126984126984,
+              "miss_rate": 0.498015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 63,
+              "steps": 63,
+              "active": 504,
+              "missing": 241,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8253968253968256,
+              "miss_rate": 0.4781746031746032,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 64,
+              "steps": 63,
+              "active": 504,
+              "missing": 209,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.3174603174603177,
+              "miss_rate": 0.4146825396825397,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 65,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 66,
+              "steps": 63,
+              "active": 504,
+              "missing": 249,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.9523809523809526,
+              "miss_rate": 0.49404761904761907,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 67,
+              "steps": 63,
+              "active": 504,
+              "missing": 238,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7777777777777777,
+              "miss_rate": 0.4722222222222222,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 68,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 69,
+              "steps": 63,
+              "active": 504,
+              "missing": 195,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0952380952380953,
+              "miss_rate": 0.3869047619047619,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 70,
+              "steps": 63,
+              "active": 504,
+              "missing": 255,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.0476190476190474,
+              "miss_rate": 0.5059523809523809,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 71,
+              "steps": 63,
+              "active": 504,
+              "missing": 267,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.238095238095238,
+              "miss_rate": 0.5297619047619048,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 72,
+              "steps": 63,
+              "active": 504,
+              "missing": 262,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.158730158730159,
+              "miss_rate": 0.5198412698412699,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 73,
+              "steps": 63,
+              "active": 504,
+              "missing": 245,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.888888888888889,
+              "miss_rate": 0.4861111111111111,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 74,
+              "steps": 63,
+              "active": 504,
+              "missing": 266,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.222222222222222,
+              "miss_rate": 0.5277777777777778,
+              "fetched_per_step": 0
+            }
+          ],
+          "disk": {
+            "cache_hits": 0,
+            "cache_misses": 17493,
+            "cache_evictions": 0,
+            "cache_bypasses": 376,
+            "read_ops": 69972,
+            "logical_bytes": 371440484352,
+            "physical_bytes": 371440484352,
+            "read_seconds": 34.89355509309098,
+            "cache_capacity_entries": 0,
+            "cache_capacity_bytes": 0,
+            "cache_allocated_bytes": 0,
+            "cache_occupancy_entries": 0,
+            "cache_occupancy_bytes": 0,
+            "staging_allocated_bytes": 5435817984,
+            "host_allocated_bytes": 5435817984,
+            "read_workers": 20,
+            "cache_policy": "layer_lru",
+            "staging_buffers": 1
+          }
+        }
+      }
+    },
+    {
+      "cache_slots": 2850,
+      "measurement": {
+        "schema_version": "1.0",
+        "model": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+        "backend": "offload",
+        "recipe": {
+          "slug": "glm-5.3",
+          "recipe_version": "0.1.0",
+          "model": "Inferact/GLM-5.3-NVFP4",
+          "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8",
+          "intended_tier": "research",
+          "status_at_run": "experimental",
+          "deployment": {
+            "backend": "native",
+            "backend_api": "1.0",
+            "source_format": "safetensors",
+            "runtime_format": "ftw-nvfp4",
+            "quantization": "nvfp4",
+            "execution_policy": "nvme-moe",
+            "backend_options": {}
+          }
+        },
+        "checkpoint": {
+          "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+          "format": "ftw",
+          "bytes": 428713099264,
+          "fingerprint": "a0e799b03bceb4bf",
+          "quant_format": "nvfp4_b12x",
+          "source_model_path": "$HOME/models/models/glm-5.3/source/ce67b36f3669",
+          "external_artifacts": []
+        },
+        "platform": {
+          "checks": [
+            {
+              "detail": "SparkLab's supported runtime is Linux-only.",
+              "expected": "Linux / DGX OS",
+              "name": "operating_system",
+              "observed": "Linux",
+              "status": "pass"
+            },
+            {
+              "detail": "GB10 pairs the Blackwell GPU with a Grace ARM64 CPU.",
+              "expected": "aarch64",
+              "name": "cpu_architecture",
+              "observed": "aarch64",
+              "status": "pass"
+            },
+            {
+              "detail": "CUDA must be visible to the Python runtime.",
+              "expected": "CUDA 13.x available",
+              "name": "cuda",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "SparkLab's GB10 kernel contract targets CUDA 13.",
+              "expected": "13.x",
+              "name": "cuda_version",
+              "observed": "13.0",
+              "status": "pass"
+            },
+            {
+              "detail": "Architecture-specific kernels must fail closed on a different GPU.",
+              "expected": "SM121 (12.1)",
+              "name": "compute_capability",
+              "observed": [
+                12,
+                1
+              ],
+              "status": "pass"
+            },
+            {
+              "detail": "SM121 is authoritative; the device name is retained as supporting evidence.",
+              "expected": "NVIDIA GB10",
+              "name": "gpu_identity",
+              "observed": "NVIDIA GB10",
+              "status": "pass"
+            },
+            {
+              "detail": "The 128 GB product profile exposes roughly 119 GiB to Linux.",
+              "expected": ">= 123480309760 bytes",
+              "name": "unified_memory",
+              "observed": 130663591936,
+              "status": "pass"
+            },
+            {
+              "detail": "Model recipes consume only memory above the operational reserve.",
+              "expected": ">= 12884901888 bytes safety reserve",
+              "name": "available_memory",
+              "observed": 126088863744,
+              "status": "pass"
+            },
+            {
+              "detail": "Swap is never counted as model capacity.",
+              "expected": "0 bytes used",
+              "name": "swap_usage",
+              "observed": 687865856,
+              "status": "fail"
+            },
+            {
+              "detail": "Device-mapper filesystems may require manual NVMe verification.",
+              "expected": "local NVMe-backed filesystem",
+              "name": "nvme_storage",
+              "observed": "/dev/nvme0n1p2",
+              "status": "pass"
+            },
+            {
+              "detail": "Large FTW and Kimi K3 workflows require substantial local capacity.",
+              "expected": ">= 549755813888 bytes free",
+              "name": "storage_capacity",
+              "observed": 1840910213120,
+              "status": "pass"
+            },
+            {
+              "detail": "The prebuilt CUDA kernels must come from the same SparkLab release and, when stamped, the same source build.",
+              "expected": "same release and build stamp",
+              "name": "kernel_cache_version",
+              "observed": {
+                "sparklab": "0.1.2",
+                "sparklab-kernel-cache": "0.1.0+cu130"
+              },
+              "status": "fail"
+            }
+          ],
+          "failures": [
+            "swap_usage",
+            "kernel_cache_version"
+          ],
+          "memory": {
+            "available_bytes": 126088863744,
+            "cuda_free_bytes": 99701325824,
+            "physical_bytes": 130663591936,
+            "safe_available_bytes": 113203961856,
+            "safety_reserve_bytes": 12884901888,
+            "swap_total_bytes": 17179865088,
+            "swap_used_bytes": 687865856
+          },
+          "platform_failures": [],
+          "product": "SparkLab",
+          "profile": "gb10",
+          "ready": false,
+          "recommendations": [
+            "Resolve failed platform checks before loading a model.",
+            "Finish active workloads and return swap usage to zero before starting a certified recipe.",
+            "Reinstall sparklab and sparklab-kernel-cache as a matched wheel pair before loading a model."
+          ],
+          "runtime": {
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "gpu": "NVIDIA GB10",
+            "integrated_gpu": true
+          },
+          "schema_version": "1.0",
+          "snapshot": {
+            "block_device": "/dev/nvme0n1p2",
+            "compute_capability": [
+              12,
+              1
+            ],
+            "cuda_available": true,
+            "cuda_free_bytes": 99701325824,
+            "cuda_version": "13.0",
+            "dependencies": {
+              "flashinfer-python": "0.6.15.post1",
+              "sglang-kernel": "0.4.5",
+              "sparklab": "0.1.2",
+              "sparklab-kernel-cache": "0.1.0+cu130",
+              "torch": "2.11.0+cu130",
+              "triton": "3.6.0"
+            },
+            "filesystem": "ext4",
+            "gpu_name": "NVIDIA GB10",
+            "gpu_total_bytes": 130663591936,
+            "integrated_gpu": true,
+            "machine": "aarch64",
+            "memory_available_bytes": 126088863744,
+            "memory_total_bytes": 130663591936,
+            "nvme": true,
+            "os_name": "Linux",
+            "storage_free_bytes": 1840910213120,
+            "storage_path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "storage_total_bytes": 4031871553536,
+            "swap_free_bytes": 16491999232,
+            "swap_total_bytes": 17179865088
+          },
+          "status": "supported_not_ready",
+          "storage": {
+            "block_device": "/dev/nvme0n1p2",
+            "filesystem": "ext4",
+            "free_bytes": 1840910213120,
+            "nvme": true,
+            "path": "$HOME/models/models/glm-5.3/prepared/0.1.0-b12x",
+            "total_bytes": 4031871553536
+          },
+          "supported": true,
+          "warnings": [],
+          "exit_code": 1
+        },
+        "configuration": {
+          "storage": "disk",
+          "attention_backend": "auto",
+          "qsa_fused_selection": true,
+          "page_size": 1,
+          "cache_type": "radix",
+          "max_seq_len": 8256,
+          "nvfp4_backend": "flashinfer",
+          "host_cache_gb": 0,
+          "requested_cache_size": 2850,
+          "requested_cache_rate": null,
+          "memory_ratio": 0.9,
+          "requested_num_tokens": 2048,
+          "speculative_method": "auto",
+          "speculative_tokens": 0,
+          "speculative_draft_model": null,
+          "draft_sample_method": "greedy",
+          "dspark_confidence_threshold": 0,
+          "dspark_draft_cache_slots": 0,
+          "dspark_draft_cache_quotas": "",
+          "dsv4_kv_storage": "bf16",
+          "dsv4_index_storage": "bf16",
+          "qwen4_dense_storage": "bf16",
+          "qwen4_draft_vocab_size": 0,
+          "mamba_ssm_dtype": "float32",
+          "cpu_threads": 0,
+          "hybrid_fetch": -1,
+          "disk_read_workers": 20,
+          "cache_policy": "layer_lru",
+          "prefill_overlap": false,
+          "preload_all": false,
+          "prefill_hit_d2d": false,
+          "prefill_sparse_max_tokens": 256,
+          "shared_expert_overlap": true,
+          "startup_prefill_warmup": true,
+          "cuda_graph": false,
+          "request_timeout_s": 1800,
+          "prompt_padding_repeats": 0
+        },
+        "cache_geometry": {
+          "num_pages": 2048,
+          "page_size": 1,
+          "moe_cache_size": 2850,
+          "num_mamba_slots": 0,
+          "num_experts": 256,
+          "num_moe_layers": 75,
+          "moe_cache_policy": "layer_lru",
+          "unit_bytes": {
+            "kv_per_token": 95232,
+            "moe_per_expert": 21233664,
+            "mamba_per_slot": 0,
+            "swa_per_token": 0
+          },
+          "swa_full_tokens_ratio": 0,
+          "swa_page_size": 0,
+          "num_swa_pages": 0,
+          "cache_budget_bytes": 65424736665,
+          "reasoning": null,
+          "limits": {
+            "kv_tokens": {
+              "min": 1,
+              "max": 687003
+            },
+            "moe_experts": {
+              "min": 256,
+              "max": 3081
+            },
+            "mamba_slots": {
+              "min": 0,
+              "max": 0
+            },
+            "swa_tokens": {
+              "min": 0,
+              "max": 0
+            }
+          }
+        },
+        "problem": 0,
+        "prompt_tokens": 54,
+        "first_request_ttft_ms": 26089.101823978126,
+        "first_request_completion_tokens": 64,
+        "first_request_finish_reason": "length",
+        "decode_steps": 63,
+        "decode_tok_s": 1.1135217403323914,
+        "ms_per_token": 898.0516174758252,
+        "event_ms_p50": 913.2006819709204,
+        "event_ms_p99": 1181.0185690410435,
+        "ttft_ms": 2089.2167650163174,
+        "events": 64,
+        "completion_tokens": 64,
+        "finish_reason": "length",
+        "vram_gib": 76.9296875,
+        "sampling": {
+          "temperature": 0,
+          "top_p": 1,
+          "top_k": -1
+        },
+        "output_sha1": "e19ef21a678b",
+        "expected_answer": "70",
+        "extracted_answer": null,
+        "answer_correct": null,
+        "server_log": "/tmp/bench-serve-offload-j8anel3r.log",
+        "gpu_telemetry": {
+          "samples": 57,
+          "duration_s": 58.66741303901654,
+          "swap_start_bytes": 687865856,
+          "memory_guard_gib": 0,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687865856,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 17.00982456140351,
+          "power_w_peak": 18.28,
+          "temperature_c_peak": 46,
+          "utilization_pct_avg": 35.36842105263158,
+          "request_energy_j_est": 997.9224032650679,
+          "mem_available_gib_min": 30.153446197509766,
+          "nvme_temperature_c_peak": 48.85,
+          "swap_in_pages_delta": 1,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 519472,
+          "major_faults_delta": 1,
+          "oom_kill_delta": 0
+        },
+        "lifecycle_telemetry": {
+          "samples": 186,
+          "duration_s": 193.06395530700684,
+          "swap_start_bytes": 687865856,
+          "memory_guard_gib": 12,
+          "memory_guard_triggered": false,
+          "swap_end_bytes": 687865856,
+          "swap_growth_bytes": 0,
+          "cgroup": {
+            "start": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "end": {
+              "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-4412f8c4-65fa-456d-867b-c3415fc39811.scope",
+              "swap_max": "max",
+              "swap_current_bytes": 86851584,
+              "swap_peak_bytes": 1533071360,
+              "oom_kill": 0
+            },
+            "delta": {
+              "oom_kill": 0,
+              "swap_current_bytes": 0
+            }
+          },
+          "power_w_avg": 16.142258064516128,
+          "power_w_peak": 24,
+          "temperature_c_peak": 46,
+          "utilization_pct_avg": 32.376344086021504,
+          "request_energy_j_est": 3116.4881895219123,
+          "mem_available_gib_min": 29.89889144897461,
+          "nvme_temperature_c_peak": 48.85,
+          "swap_in_pages_delta": 2,
+          "swap_out_pages_delta": 0,
+          "page_faults_delta": 11584700,
+          "major_faults_delta": 2,
+          "oom_kill_delta": 0
+        },
+        "oom_markers": 0,
+        "provenance": {
+          "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+          "git_tracked_dirty": true,
+          "python": "3.11.15",
+          "platform": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+          "packages": {
+            "torch": "2.11.0+cu130",
+            "triton": "3.6.0",
+            "flashinfer-python": "0.6.15.post1",
+            "sglang-kernel": "0.4.5",
+            "transformers": "5.16.1"
+          },
+          "gpu_driver": "NVIDIA GB10, 580.126.09"
+        },
+        "output_text": "We need to find integer bases $b > 9$ such that $17_b$ divides $97_b$.\n\nFirst, convert to base 10:\n- $17_b = 1 \\cdot b + 7 = b + 7$\n- $97_b = 9 \\cdot b + 7",
+        "moe": {
+          "active": 37800,
+          "missing": 17118,
+          "fetched": 0,
+          "calls": 4725,
+          "sparse_prefill_layers": 75,
+          "sparse_prefill_routes": 600,
+          "sparse_prefill_unique_rows": 600,
+          "sparse_prefill_fallback_layers": 0,
+          "shared_expert_overlap_calls": 4800,
+          "active_per_layer": 8,
+          "missing_per_layer": 3.6228571428571428,
+          "miss_rate": 0.45285714285714285,
+          "fetched_per_layer": 0,
+          "fetch_rate": 0,
+          "per_layer": [
+            {
+              "layer": 0,
+              "steps": 63,
+              "active": 504,
+              "missing": 0,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0,
+              "miss_rate": 0,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 1,
+              "steps": 63,
+              "active": 504,
+              "missing": 40,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0.6349206349206349,
+              "miss_rate": 0.07936507936507936,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 2,
+              "steps": 63,
+              "active": 504,
+              "missing": 51,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 0.8095238095238095,
+              "miss_rate": 0.10119047619047619,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 3,
+              "steps": 63,
+              "active": 504,
+              "missing": 239,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7936507936507935,
+              "miss_rate": 0.4742063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 4,
+              "steps": 63,
+              "active": 504,
+              "missing": 216,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4285714285714284,
+              "miss_rate": 0.42857142857142855,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 5,
+              "steps": 63,
+              "active": 504,
+              "missing": 193,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0634920634920637,
+              "miss_rate": 0.38293650793650796,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 6,
+              "steps": 63,
+              "active": 504,
+              "missing": 285,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.523809523809524,
+              "miss_rate": 0.5654761904761905,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 7,
+              "steps": 63,
+              "active": 504,
+              "missing": 302,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.7936507936507935,
+              "miss_rate": 0.5992063492063492,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 8,
+              "steps": 63,
+              "active": 504,
+              "missing": 287,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.555555555555555,
+              "miss_rate": 0.5694444444444444,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 9,
+              "steps": 63,
+              "active": 504,
+              "missing": 259,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.111111111111111,
+              "miss_rate": 0.5138888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 10,
+              "steps": 63,
+              "active": 504,
+              "missing": 292,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.634920634920635,
+              "miss_rate": 0.5793650793650794,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 11,
+              "steps": 63,
+              "active": 504,
+              "missing": 274,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.349206349206349,
+              "miss_rate": 0.5436507936507936,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 12,
+              "steps": 63,
+              "active": 504,
+              "missing": 227,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6031746031746033,
+              "miss_rate": 0.4503968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 13,
+              "steps": 63,
+              "active": 504,
+              "missing": 218,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4603174603174605,
+              "miss_rate": 0.43253968253968256,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 14,
+              "steps": 63,
+              "active": 504,
+              "missing": 199,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.1587301587301586,
+              "miss_rate": 0.3948412698412698,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 15,
+              "steps": 63,
+              "active": 504,
+              "missing": 126,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2,
+              "miss_rate": 0.25,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 16,
+              "steps": 63,
+              "active": 504,
+              "missing": 157,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.492063492063492,
+              "miss_rate": 0.3115079365079365,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 17,
+              "steps": 63,
+              "active": 504,
+              "missing": 112,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 1.7777777777777777,
+              "miss_rate": 0.2222222222222222,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 18,
+              "steps": 63,
+              "active": 504,
+              "missing": 143,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.2698412698412698,
+              "miss_rate": 0.2837301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 19,
+              "steps": 63,
+              "active": 504,
+              "missing": 203,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.2222222222222223,
+              "miss_rate": 0.4027777777777778,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 20,
+              "steps": 63,
+              "active": 504,
+              "missing": 307,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.873015873015873,
+              "miss_rate": 0.6091269841269841,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 21,
+              "steps": 63,
+              "active": 504,
+              "missing": 317,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 5.031746031746032,
+              "miss_rate": 0.628968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 22,
+              "steps": 63,
+              "active": 504,
+              "missing": 310,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.920634920634921,
+              "miss_rate": 0.6150793650793651,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 23,
+              "steps": 63,
+              "active": 504,
+              "missing": 290,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.603174603174603,
+              "miss_rate": 0.5753968253968254,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 24,
+              "steps": 63,
+              "active": 504,
+              "missing": 251,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.984126984126984,
+              "miss_rate": 0.498015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 25,
+              "steps": 63,
+              "active": 504,
+              "missing": 232,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6825396825396823,
+              "miss_rate": 0.4603174603174603,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 26,
+              "steps": 63,
+              "active": 504,
+              "missing": 275,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.365079365079365,
+              "miss_rate": 0.5456349206349206,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 27,
+              "steps": 63,
+              "active": 504,
+              "missing": 275,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.365079365079365,
+              "miss_rate": 0.5456349206349206,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 28,
+              "steps": 63,
+              "active": 504,
+              "missing": 187,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.9682539682539684,
+              "miss_rate": 0.37103174603174605,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 29,
+              "steps": 63,
+              "active": 504,
+              "missing": 206,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.2698412698412698,
+              "miss_rate": 0.4087301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 30,
+              "steps": 63,
+              "active": 504,
+              "missing": 212,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.365079365079365,
+              "miss_rate": 0.42063492063492064,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 31,
+              "steps": 63,
+              "active": 504,
+              "missing": 230,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6507936507936507,
+              "miss_rate": 0.45634920634920634,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 32,
+              "steps": 63,
+              "active": 504,
+              "missing": 209,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.3174603174603177,
+              "miss_rate": 0.4146825396825397,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 33,
+              "steps": 63,
+              "active": 504,
+              "missing": 238,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7777777777777777,
+              "miss_rate": 0.4722222222222222,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 34,
+              "steps": 63,
+              "active": 504,
+              "missing": 234,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7142857142857144,
+              "miss_rate": 0.4642857142857143,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 35,
+              "steps": 63,
+              "active": 504,
+              "missing": 223,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5396825396825395,
+              "miss_rate": 0.44246031746031744,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 36,
+              "steps": 63,
+              "active": 504,
+              "missing": 265,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.2063492063492065,
+              "miss_rate": 0.5257936507936508,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 37,
+              "steps": 63,
+              "active": 504,
+              "missing": 243,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.857142857142857,
+              "miss_rate": 0.48214285714285715,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 38,
+              "steps": 63,
+              "active": 504,
+              "missing": 260,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.126984126984127,
+              "miss_rate": 0.5158730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 39,
+              "steps": 63,
+              "active": 504,
+              "missing": 261,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.142857142857143,
+              "miss_rate": 0.5178571428571429,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 40,
+              "steps": 63,
+              "active": 504,
+              "missing": 286,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.5396825396825395,
+              "miss_rate": 0.5674603174603174,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 41,
+              "steps": 63,
+              "active": 504,
+              "missing": 250,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.9682539682539684,
+              "miss_rate": 0.49603174603174605,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 42,
+              "steps": 63,
+              "active": 504,
+              "missing": 193,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0634920634920637,
+              "miss_rate": 0.38293650793650796,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 43,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 44,
+              "steps": 63,
+              "active": 504,
+              "missing": 259,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.111111111111111,
+              "miss_rate": 0.5138888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 45,
+              "steps": 63,
+              "active": 504,
+              "missing": 269,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.26984126984127,
+              "miss_rate": 0.5337301587301587,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 46,
+              "steps": 63,
+              "active": 504,
+              "missing": 241,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8253968253968256,
+              "miss_rate": 0.4781746031746032,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 47,
+              "steps": 63,
+              "active": 504,
+              "missing": 246,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.9047619047619047,
+              "miss_rate": 0.4880952380952381,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 48,
+              "steps": 63,
+              "active": 504,
+              "missing": 230,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6507936507936507,
+              "miss_rate": 0.45634920634920634,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 49,
+              "steps": 63,
+              "active": 504,
+              "missing": 217,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.4444444444444446,
+              "miss_rate": 0.4305555555555556,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 50,
+              "steps": 63,
+              "active": 504,
+              "missing": 232,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6825396825396823,
+              "miss_rate": 0.4603174603174603,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 51,
+              "steps": 63,
+              "active": 504,
+              "missing": 262,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.158730158730159,
+              "miss_rate": 0.5198412698412699,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 52,
+              "steps": 63,
+              "active": 504,
+              "missing": 200,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.1746031746031744,
+              "miss_rate": 0.3968253968253968,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 53,
+              "steps": 63,
+              "active": 504,
+              "missing": 203,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.2222222222222223,
+              "miss_rate": 0.4027777777777778,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 54,
+              "steps": 63,
+              "active": 504,
+              "missing": 187,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 2.9682539682539684,
+              "miss_rate": 0.37103174603174605,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 55,
+              "steps": 63,
+              "active": 504,
+              "missing": 236,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.746031746031746,
+              "miss_rate": 0.46825396825396826,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 56,
+              "steps": 63,
+              "active": 504,
+              "missing": 260,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.126984126984127,
+              "miss_rate": 0.5158730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 57,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 58,
+              "steps": 63,
+              "active": 504,
+              "missing": 240,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8095238095238093,
+              "miss_rate": 0.47619047619047616,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 59,
+              "steps": 63,
+              "active": 504,
+              "missing": 241,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.8253968253968256,
+              "miss_rate": 0.4781746031746032,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 60,
+              "steps": 63,
+              "active": 504,
+              "missing": 233,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6984126984126986,
+              "miss_rate": 0.4623015873015873,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 61,
+              "steps": 63,
+              "active": 504,
+              "missing": 214,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.3968253968253967,
+              "miss_rate": 0.4246031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 62,
+              "steps": 63,
+              "active": 504,
+              "missing": 252,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4,
+              "miss_rate": 0.5,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 63,
+              "steps": 63,
+              "active": 504,
+              "missing": 235,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.7301587301587302,
+              "miss_rate": 0.4662698412698413,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 64,
+              "steps": 63,
+              "active": 504,
+              "missing": 231,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6666666666666665,
+              "miss_rate": 0.4583333333333333,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 65,
+              "steps": 63,
+              "active": 504,
+              "missing": 214,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.3968253968253967,
+              "miss_rate": 0.4246031746031746,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 66,
+              "steps": 63,
+              "active": 504,
+              "missing": 255,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.0476190476190474,
+              "miss_rate": 0.5059523809523809,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 67,
+              "steps": 63,
+              "active": 504,
+              "missing": 230,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.6507936507936507,
+              "miss_rate": 0.45634920634920634,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 68,
+              "steps": 63,
+              "active": 504,
+              "missing": 222,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.5238095238095237,
+              "miss_rate": 0.44047619047619047,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 69,
+              "steps": 63,
+              "active": 504,
+              "missing": 192,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 3.0476190476190474,
+              "miss_rate": 0.38095238095238093,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 70,
+              "steps": 63,
+              "active": 504,
+              "missing": 260,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.126984126984127,
+              "miss_rate": 0.5158730158730159,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 71,
+              "steps": 63,
+              "active": 504,
+              "missing": 259,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.111111111111111,
+              "miss_rate": 0.5138888888888888,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 72,
+              "steps": 63,
+              "active": 504,
+              "missing": 253,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.015873015873016,
+              "miss_rate": 0.501984126984127,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 73,
+              "steps": 63,
+              "active": 504,
+              "missing": 257,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.079365079365079,
+              "miss_rate": 0.5099206349206349,
+              "fetched_per_step": 0
+            },
+            {
+              "layer": 74,
+              "steps": 63,
+              "active": 504,
+              "missing": 267,
+              "fetched": 0,
+              "active_per_step": 8,
+              "missing_per_step": 4.238095238095238,
+              "miss_rate": 0.5297619047619048,
+              "fetched_per_step": 0
+            }
+          ],
+          "disk": {
+            "cache_hits": 0,
+            "cache_misses": 17479,
+            "cache_evictions": 0,
+            "cache_bypasses": 361,
+            "read_ops": 69916,
+            "logical_bytes": 371143213056,
+            "physical_bytes": 371143213056,
+            "read_seconds": 34.86309778149007,
+            "cache_capacity_entries": 0,
+            "cache_capacity_bytes": 0,
+            "cache_allocated_bytes": 0,
+            "cache_occupancy_entries": 0,
+            "cache_occupancy_bytes": 0,
+            "staging_allocated_bytes": 5435817984,
+            "host_allocated_bytes": 5435817984,
+            "read_workers": 20,
+            "cache_policy": "layer_lru",
+            "staging_buffers": 1
+          }
+        }
+      }
+    }
+  ]
+}

--- a/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002.json
+++ b/benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002.json
@@ -1,0 +1,159 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-GLM53-RESEARCH-OPT-002",
+  "status": "measured",
+  "recipe": {
+    "slug": "glm-5.3",
+    "recipe_version": "0.1.0",
+    "revision": "ce67b36f3669192b5bb233819f0fda6c8a9837f8"
+  },
+  "engine": {
+    "git_revision": "c6d4956c06f64a1ef9a9e52efd01fa693992fd58",
+    "git_tracked_dirty": true,
+    "note": "Measured on the base revision with the cache/backend and benchmark changes in this PR; not a clean-base measurement."
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "cuda": "13.0"
+  },
+  "checkpoint": {
+    "full_model": true,
+    "format": "ftw-nvfp4-b12x",
+    "fingerprint": "a0e799b03bceb4bf",
+    "bytes": 428713099264,
+    "source_bytes": 464867183339
+  },
+  "configuration": {
+    "storage": "disk",
+    "attention_backend": "auto",
+    "qsa_fused_selection": true,
+    "page_size": 1,
+    "cache_type": "radix",
+    "max_seq_len": 8448,
+    "nvfp4_backend": "flashinfer",
+    "host_cache_gb": 0,
+    "requested_cache_size": 2850,
+    "requested_cache_rate": null,
+    "memory_ratio": 0.9,
+    "requested_num_tokens": 2048,
+    "speculative_method": "auto",
+    "speculative_tokens": 0,
+    "speculative_draft_model": null,
+    "draft_sample_method": "greedy",
+    "dspark_confidence_threshold": 0,
+    "dspark_draft_cache_slots": 0,
+    "dspark_draft_cache_quotas": "",
+    "dsv4_kv_storage": "bf16",
+    "dsv4_index_storage": "bf16",
+    "qwen4_dense_storage": "bf16",
+    "qwen4_draft_vocab_size": 0,
+    "mamba_ssm_dtype": "float32",
+    "cpu_threads": 0,
+    "hybrid_fetch": -1,
+    "disk_read_workers": 20,
+    "cache_policy": "layer_lru",
+    "prefill_overlap": false,
+    "preload_all": false,
+    "prefill_hit_d2d": false,
+    "prefill_sparse_max_tokens": 256,
+    "shared_expert_overlap": true,
+    "startup_prefill_warmup": true,
+    "cuda_graph": false,
+    "request_timeout_s": 1800,
+    "prompt_padding_repeats": 0
+  },
+  "metrics": {
+    "decode_tokens_per_second": 1.108134249894042,
+    "decode_milliseconds_per_token": 902.4177351215508,
+    "warm_ttft_seconds": 1.9577306060236879,
+    "first_request_ttft_seconds": 25.857733732962515,
+    "latency_p50_milliseconds": 900.7886429899372,
+    "latency_p99_milliseconds": 1194.7393250302412,
+    "expert_cache_miss_rate_percent": 44.611111111111114,
+    "physical_io_gib": 1356.888427734375,
+    "minimum_mem_available_gib": 29.69037628173828,
+    "swap_growth_bytes": 0
+  },
+  "stability": {
+    "requested_completion_tokens": 256,
+    "returned_completion_tokens": 256,
+    "timed_decode_steps": 255,
+    "swap_in_pages": 5,
+    "swap_out_pages": 0,
+    "swap_growth_bytes": 0,
+    "oom_count": 0
+  },
+  "validation": {
+    "output_correctness": false,
+    "output_correctness_evaluated": true,
+    "output_hash_algorithm": "sha1-prefix",
+    "output_hash": "5b69d85cc226",
+    "output_hash_probe_tokens": 256,
+    "matched_native_control": false,
+    "memory_bounded": true,
+    "nvme_behavior": "bounded",
+    "reasoning_parser": false,
+    "tool_parser": false,
+    "coding_agent_task": false
+  },
+  "quality_checks": {
+    "scope": "Two normal-EOS AIME smoke checks, not certification; 1024-token cap. Separate from the length-capped performance measurement.",
+    "candidate": [
+      {
+        "problem": 0,
+        "correct": true,
+        "expected": "70",
+        "answer": "70",
+        "completion_tokens": 841,
+        "finish_reason": "stop",
+        "decode_tokens_per_second": 1.0909148006551304,
+        "output_hash": "4bb42da2c07f"
+      },
+      {
+        "problem": 1,
+        "correct": false,
+        "expected": "588",
+        "answer": null,
+        "completion_tokens": 1024,
+        "finish_reason": "length",
+        "decode_tokens_per_second": 1.0862605696737095,
+        "output_hash": "ec60faef3dd1"
+      }
+    ],
+    "control": [
+      {
+        "problem": 0,
+        "cache_slots": 675,
+        "correct": true,
+        "completion_tokens": 844,
+        "finish_reason": "stop",
+        "decode_tokens_per_second": 0.8154427770982812,
+        "output_hash": "0afcf524b5d1"
+      }
+    ]
+  },
+  "admission": {
+    "tier": "research",
+    "passed": false,
+    "reasons": [
+      "AIME problem 1 reached its token cap without a final answer; broader quality is not established.",
+      "Reasoning-parser, tool-parser, and coding-agent certification gates were not run."
+    ]
+  },
+  "source_report": "exps/exp_research_cache_optimization.md",
+  "raw_evidence": [
+    "GB10-GLM53-RESEARCH-OPT-002-baseline64.json",
+    "GB10-GLM53-RESEARCH-OPT-002-short-sweep.json",
+    "GB10-GLM53-RESEARCH-OPT-002-candidate256.json",
+    "GB10-GLM53-RESEARCH-OPT-002-aime2850.json",
+    "GB10-GLM53-RESEARCH-OPT-002-aime675.json"
+  ],
+  "limitations": [
+    "Portfolio metrics come from one 256-token run, not the longer normal-EOS quality requests.",
+    "Greedy text differs across cache layouts; bit-exact parity is not claimed.",
+    "Pre-existing swap use was present, although there was no scoped swap-out or OOM.",
+    "Prepared weights are unchanged; routed experts are NVFP4 and large resident projections are per-row W8A16 FP8.",
+    "Kimi K3 acquisition and end-to-end optimization have not started."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,7 +38,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 14.02 | 0.515 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 7.77 | 6.395 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
-| [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW | `glm-5.3` | Experimental fallback | 0.81 | 2.530 |
+| [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW | `glm-5.3` | Experimental fallback | 1.11 | 1.958 |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
 Model links point to the selected source or published FTW checkpoint. Qwen3.6, GLM-5.3,
@@ -77,7 +77,7 @@ to the current NVIDIA checkpoint. Its selected MTP3 metric is batch-one.
 | DeepSeek V4 Flash | The selected three-trial DSpark5 burst profile reaches 14.02 tok/s with replay-free compressor-prefix commits. This fixes the previous first-rejection carry shortcut; target-only remains the default and full certification is pending. | [GB10-DSV4-PREFIX-006](../benchmarks/gb10/results/GB10-DSV4-PREFIX-006.json) |
 | GLM-5.3 Flash | The opt-in MTP3 profile reached a median 7.77 tok/s with no rejection replay, 3.4% above its fresh baseline and identical output across three trials. NVMe sensitivity and the remaining certification gates keep it Experimental. | [target-only](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json), [MTP sweep](../benchmarks/gb10/results/GB10-GLM53-MTP-004.json), [optimized MTP3](../benchmarks/gb10/results/GB10-GLM53-OPT-005.json), [KDA state commits](../benchmarks/gb10/results/GB10-GLM53-OPT-006.json) |
 | GLM-5.2 | Below Frontier speed and recorded swap growth, so it remains Experimental. | [Experiment](../exps/exp_glm5_2_gb10.md) |
-| GLM-5.3 | Correctness is not established; the measured output reached its length cap before answering. | [GB10-GLM53-RESEARCH-001](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json) |
+| GLM-5.3 | Larger expert cache measured 1.11 tok/s and 1.958 s warm TTFT. A separate completed-answer check passed; a second problem reached its token cap. Broader quality and certification remain unverified. | [GB10-GLM53-RESEARCH-OPT-002](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002.json) |
 | Kimi K3 | Complete-checkpoint serving was measured, but correctness and cross-run determinism are not established. | [GB10-KIMI-001](../benchmarks/gb10/results/GB10-KIMI-001.json) |
 
 ## Running a recipe

--- a/docs/models/glm-5.3.md
+++ b/docs/models/glm-5.3.md
@@ -5,10 +5,21 @@ NVMe-backed inference. The pinned Inferact checkpoint declares the same
 `glm_moe_dsa` architecture and runtime dimensions as GLM-5.2, so SparkLab uses
 the existing GLM-5.2 execution path.
 
-The complete checkpoint has been measured on one NVIDIA GB10 at 0.813 decode
-tok/s and 2.530 seconds warm TTFT. The selected output reached its 256-token cap
-before stating the expected final answer, so this remains a bounded performance
-result rather than a correctness or certification claim.
+The complete checkpoint measured **1.11 decode tok/s** and **1.958 seconds warm
+TTFT** on one NVIDIA GB10 with a 2,850-slot expert cache: about 36% faster than
+the previous 256-token result. First-request TTFT was 25.858 seconds.
+
+In separate normal-EOS checks, AIME problem 0 completed correctly at 1.091 tok/s
+(675-slot control: 0.815 tok/s). Problem 1 reached its 1,024-token cap without a
+final answer. Cache layouts can change the generated text; no bit-exact parity
+or broad quality certification is claimed. The recipe remains Experimental.
+
+The selected run retained at least 29.7 GiB available memory, with no scoped
+OOM or swap-out. It used one request at a time, 2,048 KV tokens, FlashInfer b12x,
+layer-LRU caching, route-only sparse prefill, and eager execution. The published
+weights and recipe artifact version are unchanged; no checkpoint conversion is
+needed for the cache optimization. Runtime admission reserves a conservative
+96 GiB for the profile, separate from the planner's safety reserve.
 
 ## Install SparkLab
 
@@ -38,7 +49,7 @@ Review the exact storage and runtime admission output from `plan` before continu
 ## Run
 
 ```bash
-sparklab run glm-5.3 --root /path/to/models
+SPARKLAB_DISK_READ_WORKERS=20 sparklab run glm-5.3 --root /path/to/models
 ```
 
 Wait for the API to listen on `127.0.0.1:1919`, then verify it:
@@ -48,6 +59,8 @@ curl http://127.0.0.1:1919/health
 curl http://127.0.0.1:1919/v1/models
 ```
 
-Expect Research-tier throughput. See the
-[GLM-5.3 experiment](../../exps/exp_glm5_3_full_gb10.md) and the
+The measured profile used 20 disk readers, set explicitly above. Expect
+Research-tier throughput. See the
+[cache optimization evidence](../../exps/exp_research_cache_optimization.md),
+[original GLM-5.3 experiment](../../exps/exp_glm5_3_full_gb10.md), and the
 [quick start](../quickstart.md) for more detail.

--- a/exps/exp_research_cache_optimization.md
+++ b/exps/exp_research_cache_optimization.md
@@ -1,0 +1,258 @@
+# Research-tier cache optimization — GLM selected, Kimi pending
+
+Order: full GLM-5.3 first, then Kimi K3. This is not GLM-5.3 Flash.
+The GLM 2,850-slot profile is selected for the Experimental recipe and portfolio:
+1.11 tok/s, 1.958 s warm TTFT. This is not Research certification. Kimi K3
+acquisition and end-to-end optimization have not started.
+
+## Selected result and answer checks
+
+The comparable 256-token result improves decode throughput by 36.4% over
+the historical selected 0.812615 tok/s run. The README keeps only the scalar
+portfolio values; methodology and limitations remain here and in the model page.
+
+| Normal-EOS check | Cache slots | Tokens | Decode tok/s | Result |
+|---|---:|---:|---:|---|
+| AIME problem 0 | 2850 | 841 | 1.090915 | Correct final answer 70, EOS |
+| AIME problem 1 | 2850 | 1024 | 1.086261 | Token cap, no final answer |
+| AIME problem 0 control | 675 | 844 | 0.815443 | Correct final answer 70, EOS |
+
+The selected profile retained at least 29.496 GiB available RAM through both
+answer checks, with zero scoped swap-out and OOM-kill deltas. Text differs from
+the control; only the completed answer for problem 0 agrees. Two smoke checks
+do not establish general quality or certification. No Kimi metrics are changed.
+
+Summary: [GB10-GLM53-RESEARCH-OPT-002](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002.json).
+Raw answer checks:
+[candidate](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-aime2850.json),
+[control](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-aime675.json).
+Machine-specific home prefixes in checked-in raw evidence are replaced by
+`$HOME`; numerical measurements are unchanged.
+
+Recipe artifact version 0.1.0 and the pinned FTW are retained: this changes the
+runtime profile, not the checkpoint representation. Runtime admission uses a
+conservative 96-GiB estimate plus the planner's separate safety reserve. The
+20-reader setting used for measurements is explicit in the model's run command.
+
+Pre-PR verification after integrating the current main branch:
+
+- CPU workflow suite: 1,122 passed, 75 skipped.
+- CUDA offload/NVFP4 suites: 55 passed, four skipped.
+- CPU interpretation of the actual layer-LRU Triton kernel: three passed.
+- CLI, README, and model-table regression tests agree with recipe metrics.
+
+These regression runs do not replace the hardware performance evidence above.
+
+## GLM-5.3 fresh control, 2026-09-06
+
+Raw evidence: [64-token control](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-baseline64.json).
+The original process exited normally before the CPU-only changes below.
+Engine revision `c6d4956c06f64a1ef9a9e52efd01fa693992fd58`, tracked tree clean.
+FTW fingerprint `a0e799b03bceb4bf`.
+
+Configuration: 675 layer-LRU slots, FlashInfer b12x experts, disk storage,
+20 readers, zero host expert LRU, 2,048 KV tokens, memory ratio 0.90,
+sparse prefill threshold 256, shared-expert overlap, eager execution.
+AIME-25 problem 0, greedy, 64 output tokens, one warmup and one measured request.
+
+| Measurement | Control |
+|---|---:|
+| Decode | 0.843469 tok/s |
+| Warm TTFT | 2.215869 s |
+| First-request TTFT | 50.8515 s |
+| Expert miss rate | 74.5265% |
+| Measured-request physical expert reads | 565.50 GiB |
+| Minimum available RAM over server lifecycle | 73.076 GiB |
+| Swap-out pages / scoped OOM-kill delta | 0 / 0 |
+
+Output SHA1 `e19ef21a678b` matches the earlier 64-token experiment. The response
+is length-capped, so this is output reproducibility, not a completed quality pass.
+The disk counter includes the measured request's prefill and decode, not startup
+or the first request. Pre-existing swap-in activity remains a caveat.
+
+## Candidate changes (validation recorded below)
+
+1. Remove the redundant `torch.unique` assertion in layer-LRU decode admission.
+   `unique_count <= query_count <= cache_capacity` already follows from the
+   shape check. The old assertion introduced a dynamic-output GPU operation
+   and host synchronization on every offloaded layer.
+2. Preserve all current query routes when their count exceeds the layer quota.
+   The previous CPU reference raises `no evictable slot` when the cache is full;
+   the GPU kernel can encounter an all-MAX victim score and select a live slot.
+   Prefer the existing quota-based victims, then borrow the globally oldest
+   non-current slot only when no preferred victim exists.
+3. Let opt-in sparse prefill use the total cache capacity, not equal per-layer
+   quota, as its route-set capacity limit. This relies on change 2. Kimi's
+   top-16 routing exceeds the default 896/92 = 9–10 protected slots/layer;
+   the old quota gate forces even one-token prefills to load all 896 experts.
+   Larger GLM prompts also encounter this gate. The optimal token threshold
+   and cache-pollution tradeoff still need measurements.
+
+CPU verification:
+
+```bash
+CUDA_VISIBLE_DEVICES='' OMP_NUM_THREADS=1 .venv/bin/python -m pytest \
+  tests/moe/test_offload.py -q
+# 36 passed, 4 CUDA tests skipped
+CUDA_VISIBLE_DEVICES='' TRITON_INTERPRET=1 OMP_NUM_THREADS=1 \
+  .venv/bin/python -m pytest tests/moe/test_layer_lru_interpreter.py -q
+# 3 passed: actual Triton kernel interpreted on CPU, versus CPU reference
+```
+
+The regression was observed failing before the fix. Interpreter cases cover
+unequal quotas, full cache, full-layer queries, repeated routes, ownership,
+copy plans, LRU timestamps, and subsequent quota reclamation. CPU tests do not
+prove compiled CUDA execution, numerical output parity, or end-to-end speed.
+
+## Experiment chronology and benchmark coordination
+
+### Checkpoint cleanup plan (2026-09-06)
+
+Kimi's pinned repository is accessible at
+`793f1f8436cd7de11e7912c41b3d49d4c9e4d11c`: 214 files, 194 FTW shards,
+1,610,940,993,828 bytes including metadata. Before cleanup, disk free space was
+1,001,042,706,432 bytes, insufficient for acquisition plus its safety margin.
+
+Validated deletion targets, with physical allocated bytes (hard links counted
+once across the two Inferact directories):
+
+| Exact directory | Allocated bytes |
+|---|---:|
+| `$HOME/models/models/glm-5.3/source/ce67b36f3669` | 475478843392 |
+| `$HOME/models/qwen38-nvidia/source/fab0aecb760c` | 132734746624 |
+| `$HOME/.sparklab/models/qwen3.8-flash-next/prepared/0.5.0` | 180456607744 |
+| `$HOME/.sparklab/models/qwen3.8-flash-next/prepared/0.5.0-fp8-ple` | 51200557056 |
+
+Their canonical paths equal the explicit paths above; no active model server,
+benchmark, or open target files were found. Current GLM FTW
+`a0e799b03bceb4bf` and NVIDIA Qwen FTW `94e1ee0daa442357` passed the native artifact
+validator, including all shard sizes and NVIDIA's two local sidecars. Neither
+prepared tree contains symlinks into the source downloads. Both prepared trees
+are retained. The Inferact variants (`47e11ddb878adf4c`) are superseded by NVIDIA.
+Original sources can be downloaded again at the recipe's pinned revisions;
+the experimental Inferact FP8-PLE variant requires regeneration, not trash restore.
+
+DeepSeek's source is deliberately retained: its validator rejects a duplicated
+name shared by `weight` and `speculative_weight` entries. This is a separate
+validation issue, not evidence that the source is expendable.
+
+Cleanup completed with non-forced recursive removal of exactly the four listed
+directories. Free space afterward: **1,840,911,863,808 bytes** (about 1.67 TiB).
+The standard Inferact FTW is recoverable from
+`oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW@5ab790b83f149a96594237a35905d84be24599a3`;
+its original source revision is `103a7608316173ca6edd49929544244de7ffda70`.
+The experimental FP8-PLE variant must be regenerated. These were deletions,
+not moves to trash; no current prepared artifact was removed.
+
+### GPU validation and first isolation runs
+
+The initial offload suite passed **40/40 on CUDA**. The first route-first
+64-token GLM run measured 0.839516 tok/s with output hash `e04fe1589d9a`, different
+from the control; the sweep stopped automatically. Restricting sparse prefill to
+one token restored hash `e19ef21a678b` at 0.846710 tok/s and 2.498334 s warm TTFT.
+This isolates the text difference to multi-token prefill, not the decode fix.
+The restriction makes synthetic startup warmup scan complete expert layers and
+is an isolation setting, not a selected recipe.
+
+The next, 1,350-slot run failed in the donor W4A16 descriptor construction:
+`OverflowError: Value overflow: 4246732800 exceeds range of l`.
+The flattened GLM gate/up bank exceeds int32 extent at **683 slots**. This is
+not memory exhaustion. Its backend exited before a usable measurement. The
+queue was stopped; the failed benchmark and shutting-down API were terminated.
+
+Two further candidate fixes now have targeted GPU tests:
+
+- `materialize_routed_layer` loads only selected experts at logical positions
+  in an E-row view, preserving the old b12x prefill geometry. Inverse maps and
+  copy plans cover overlapping source/destination slots; the numerical test
+  exactly matches full-layer prefill after overwriting the cache with another
+  layer to expose missing copies.
+- Above the descriptor limit, b12x gathers routed rows from the large GPU cache
+  into a bounded compute bank. Batch-one decode avoids `torch.unique`; copying
+  stays on-device. The targeted test forces this path with a small threshold
+  and exactly matches ordinary decode. The extra memory traffic must be
+  included in end-to-end measurements, not assumed free.
+
+The stable-layout/large-cache candidate ran sequentially with the original
+256-token sparse threshold and 12-GiB memory guard. Raw local paths:
+`/tmp/glm53-opt-stable2-cache{675,1350,2700,2850}-64.jsonl`.
+These initial short probes were not sufficient for recipe selection.
+
+The stable-layout 675-slot run reproduced the control hash `e19ef21a678b` at
+0.845760 tok/s, 2.538650 s warm TTFT, and **25.500066 s first-request TTFT**
+(control: 50.8515 s). At 1,350 slots, the compact path measured 0.900019 tok/s,
+62.2937% misses, 475.282 GiB measured-request reads, and 60.107 GiB minimum
+available RAM; its output hash `e04fe1589d9a` differed, so the queue stopped.
+
+Synthetic probes at GLM's actual 6,144-hidden / 2,048-intermediate dimensions,
+top-8 routing, and 675 physical slots reproduced small compact-path numerical
+differences. Three seeds had relative RMS deltas of 0.000133–0.000638;
+FP32-reference relative RMS errors were 0.00404–0.00445 for both paths, with
+no material worsening in these probes. This is not end-to-end quality proof.
+Larger-cache exploratory runs compare against the 1,350-slot compact-path hash,
+not the original hash. Completed-answer checks remain required before selection.
+
+### Larger-cache short probes
+
+| Cache slots | Decode tok/s | Warm TTFT s | Lifecycle minimum available GiB | Output SHA1 |
+|---|---:|---:|---:|---|
+| 675, control | 0.843469 | 2.215869 | 73.076 | `e19ef21a678b` |
+| 675, candidate | 0.845760 | 2.538650 | — | `e19ef21a678b` |
+| 1350 | 0.900019 | 2.518284 | 60.107 | `e04fe1589d9a` |
+| 2700 | 1.110749 | 2.113318 | 32.861 | `e04fe1589d9a` |
+| 2850 | 1.113522 | 2.089217 | 29.899 | `e19ef21a678b` |
+
+All are 64-token probes, not completed-answer checks. The 2,700/2,850 runs
+recorded zero swap-out, swap growth, and OOM-kill deltas. The latter reproduced
+the original control prefix but differed from the 1,350-slot comparison hash,
+so the exploratory sweep stopped as designed. Cache size changes route
+placement as well as bank geometry; no global bit-exactness is claimed.
+The 2,700 run's miss rate was 45.2831%, down from 74.5265% in the control.
+
+A GPU-copy microbenchmark used actual GLM packed row sizes and eight routes.
+Allocating `index_select` took 1.548 ms; the fastest fused-copy setting took
+1.523 ms (20 timed iterations, medians). This small isolated difference does
+not justify extra buffer-lifetime complexity; no fused-copy change was made.
+Local evidence: `/tmp/probe-glm53-gather.log`.
+
+### Longer validation
+
+Cleanup waited for the user's explicit “finished” confirmation and is now
+complete as recorded above. The 2,850-slot 256-token trial completed:
+
+- Decode **1.108134 tok/s**, warm TTFT **1.957731 s**, first TTFT 25.857734 s.
+- Minimum lifecycle available memory 29.690 GiB; zero swap-out and OOM-kill
+  deltas, no memory-guard stop.
+- Miss rate 44.61%; measured-request physical reads 1,356.89 GiB.
+- Output SHA1 `5b69d85cc226`, different from the published 256-token control
+  `bdbf1a17f134`; still length-capped, with no final answer established.
+- About 36.4% higher throughput and 22.6% lower warm TTFT than the historical
+  selected 256-token run. This is one candidate run, not a repeated result.
+
+Raw evidence is retained in
+[`GB10-GLM53-RESEARCH-OPT-002-candidate256.json`](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-candidate256.json).
+The four short candidate runs are retained in
+[`GB10-GLM53-RESEARCH-OPT-002-short-sweep.json`](../benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002-short-sweep.json).
+The latest CPU regression run passed 43 tests, with five CUDA tests skipped.
+
+A bounded sequential completed-answer queue finished after the performance
+process exited and the GPU was confirmed idle. It ran normal-EOS AIME
+problems 0 and 1 at 2,850 slots, then problem 0 at 675 slots, each with a
+1,024-token output cap and the 12-GiB lifecycle memory guard. Local queue:
+`/tmp/glm53-completed-answer-queue.py`; progress:
+`/tmp/glm53-completed-answer-queue.log`; result paths:
+`/tmp/glm53-opt-stable2-cache{2850,675}-aime1024.jsonl`.
+The queue performed no recipe promotion or checkpoint acquisition. Incorrect
+or capped responses are retained for comparison with the control, while
+process/memory failures stop the queue. Kimi acquisition has not started.
+
+- Keep a 12-GiB available-memory guard over startup and both requests. Stop
+  on memory pressure, swap-out growth, process failure, or output differences.
+- The 256-token performance and normal-EOS smoke checks are complete above.
+  Broader quality, context, parser, and endurance validation remain outstanding.
+- Further tuning can measure disk-reader count and cache size beyond this
+  selected profile. Whole-model CUDA graphs remain unsupported for disk offload.
+- Acquire Kimi's pinned FTW and repeat the correctness/performance process.
+  Post-cleanup free disk is about 1.67 TiB, sufficient for its 1.465-TiB
+  download with about 214 GiB remaining. Do not overlap download disk traffic
+  with GPU model performance measurements.

--- a/python/sparklab/layers/moe.py
+++ b/python/sparklab/layers/moe.py
@@ -456,10 +456,31 @@ class OffloadMoELayer(MoELayer):
             # K. Prefill can have hundreds of repeated routes, so compact to <= E ids
             # first, then map the original route matrix through slot_for_id.
             unique_ids = torch.unique(raw_ids).to(torch.int32).contiguous()
-            quota = cache.cache_size // cache.num_layers + (
-                self.layer_id < cache.cache_size % cache.num_layers
-            )
-            if cache.cache_policy != "layer_lru" or unique_ids.numel() <= quota:
+            if (
+                cache.quant_format == "nvfp4_b12x"
+                and cache.cache_policy == "layer_lru"
+                and unique_ids.numel() > int(cache.layer_quotas[self.layer_id].item())
+            ):
+                # Keep the original full-layer GEMM's E-row view and logical ids,
+                # but fetch only routed rows. Passing the larger persistent-cache
+                # extent to b12x changes its launch geometry and can change output.
+                cache.materialize_routed_layer(self.layer_id, unique_ids)
+                cache.sparse_prefill_layers += 1
+                cache.sparse_prefill_routes += raw_ids.numel()
+                cache.sparse_prefill_unique_rows += unique_ids.numel()
+                cache.copy_missing()
+                return self._expert_gemm(
+                    cache, hidden_states, topk_weights, raw_ids,
+                    views=cache.bank_views(self.num_experts),
+                    n=self.num_experts,
+                    alphas=cache.alphas_for_layer(self.layer_id),
+                    is_prefill=True,
+                )
+            # Layer quotas are a reuse policy, not the simultaneous-route limit:
+            # layer-LRU can borrow slots while pinning every route in this query.
+            # Using the quota here forces even one-token Kimi top-16 prefills to
+            # scan all 896 experts when the protected quota is only 9-10 slots.
+            if unique_ids.numel() <= cache.cache_size:
                 cache.ensure_experts(self.layer_id, unique_ids, is_prefill=True)
                 cache.sparse_prefill_layers += 1
                 cache.sparse_prefill_routes += raw_ids.numel()

--- a/python/sparklab/moe/nvfp4_backends.py
+++ b/python/sparklab/moe/nvfp4_backends.py
@@ -702,6 +702,9 @@ def _b12x_small_workspace(device: torch.device) -> torch.Tensor:
     return ws
 
 
+_B12X_MAX_FLAT_INT32_ELEMENTS = 2**31 - 1
+
+
 def b12x_fused_experts(
     hidden_states: torch.Tensor,
     gate_up_q: torch.Tensor,
@@ -738,6 +741,40 @@ def b12x_fused_experts(
 
     assert activation == "silu", "b12x backend supports gated silu only"
     assert not apply_router_weight_on_input
+    if any(
+        bank.numel() * bank.element_size() // 4 > _B12X_MAX_FLAT_INT32_ELEMENTS
+        for bank in (gate_up_q, gate_up_s, down_q, down_s)
+    ):
+        # The donor's flattened packed-weight descriptors use int32 extents.
+        # GLM's gate/up bank crosses that limit at 683 cache slots. Keep the
+        # large persistent cache, but gather just this call's routed rows into
+        # a bounded compute bank. All copies remain on-device; weights and
+        # router weights are unchanged. For decode, avoid dynamic torch.unique
+        # and its host synchronization by gathering one row per route.
+        if hidden_states.size(0) == 1:
+            slots = topk_ids.reshape(-1).long()
+            topk_ids = torch.arange(
+                slots.numel(), dtype=torch.int32, device=topk_ids.device,
+            ).view_as(topk_ids)
+        else:
+            slots, inverse = torch.unique(topk_ids.reshape(-1), return_inverse=True)
+            slots = slots.long()
+            topk_ids = inverse.to(torch.int32).view_as(topk_ids)
+        if any(
+            slots.numel() * (bank.numel() // bank.size(0)) * bank.element_size() // 4
+            > _B12X_MAX_FLAT_INT32_ELEMENTS
+            for bank in (gate_up_q, gate_up_s, down_q, down_s)
+        ):
+            raise ValueError(
+                "b12x routed expert bank still exceeds its int32 descriptor limit; "
+                "reduce the prefill chunk size"
+            )
+        gate_up_q = gate_up_q.index_select(0, slots)
+        gate_up_s = gate_up_s.index_select(0, slots)
+        gate_up_alpha = gate_up_alpha.index_select(0, slots)
+        down_q = down_q.index_select(0, slots)
+        down_s = down_s.index_select(0, slots)
+        down_alpha = down_alpha.index_select(0, slots)
     num_experts = gate_up_q.size(0)
     hidden_size = hidden_states.size(-1)
     # down bank is the prepared w2 == [E, K_tiles, ...] with K_tiles == intermediate//16.

--- a/python/sparklab/moe/offload_cache.py
+++ b/python/sparklab/moe/offload_cache.py
@@ -1018,6 +1018,49 @@ class OffloadMoeCache:
                 torch.bincount(owners.long(), minlength=self.num_layers).to(torch.int32)
             )
 
+    def materialize_routed_layer(self, layer_id: int, expert_ids: torch.Tensor) -> None:
+        """Stage unique routed rows at their logical expert-id positions.
+
+        Unlike persistent-slot admission, this retains the E-row GEMM geometry
+        of full-layer prefill. Only selected rows are read/copied. This matters
+        for b12x, whose launch geometry depends on the weight-bank extent and
+        whose persistent-cache view can produce different rounding in prefill.
+        Non-routed rows in that view must never be used by the following GEMM.
+        The caller supplies unique, valid layer-local ids (normally torch.unique).
+        Prefill-only: dynamic indexing here is not CUDA-graph capture safe.
+        """
+        assert not self.fully_resident
+        assert expert_ids.ndim == 1 and expert_ids.numel() <= self.num_experts
+        ids = expert_ids.long()
+        self._pending_src_layer = layer_id
+        self._pending_is_prefill = True
+        self._pending_disk_stage_layer = None
+
+        # Snapshot before invalidating: source and destination slots can overlap,
+        # including cycles where a selected expert occupies another's target slot.
+        previous = self.slot_for_id[layer_id]
+        previous_slots = previous[previous >= 0].long()
+        displaced = self.id_of_slot[ids].clone()
+        other = displaced[(displaced >= 0) & (displaced // self.num_experts != layer_id)]
+        self.id_of_slot[previous_slots] = -1
+        self.usage[previous_slots] = 0
+        previous.fill_(-1)
+        self.slot_for_id.view(-1)[other.long()] = -1
+
+        self.step.add_(1)
+        self.id_of_slot[ids] = (layer_id * self.num_experts + ids).int()
+        self.slot_for_id[layer_id, ids] = ids.int()
+        self.usage[ids] = self.step
+        n = expert_ids.numel()
+        self.src_indices[:n].copy_(expert_ids)
+        self.evict_slots[:n].copy_(expert_ids)
+        self.num_indices.fill_(n)
+        if self.cache_policy == "layer_lru":
+            owners = self.id_of_slot[self.id_of_slot >= 0] // self.num_experts
+            self.layer_counts.copy_(
+                torch.bincount(owners.long(), minlength=self.num_layers).to(torch.int32)
+            )
+
     def reset(self) -> None:
         if self.fully_resident:
             # Weight ownership is immutable. Warmup/graph teardown may reset dynamic

--- a/python/sparklab/moe/offload_kernels.py
+++ b/python/sparklab/moe/offload_kernels.py
@@ -52,13 +52,17 @@ def layer_lru_ensure(cache, layer_id: int, expert_ids: torch.Tensor, *, stats=No
     Every layer owns ``cache_size // num_layers`` protected slots (the remainder is
     distributed to the first layers). Empty slots are freely borrowed. Once full,
     victims come from layers above quota; when none is above quota, a request replaces
-    within its own layer. Counts stay device-side, so decode remains graph-capturable.
+    within its own layer. A query larger than its layer's quota can temporarily
+    borrow protected slots from other layers, but never evicts a current route.
+    Counts stay device-side, so decode remains graph-capturable.
     """
-    if not expert_ids.is_cuda:
-        return _layer_lru_ensure_cpu(cache, layer_id, expert_ids, stats=stats)
     K = expert_ids.numel()
     C = cache.cache_size
-    assert K <= C and (not __debug__ or int(torch.unique(expert_ids).numel()) <= C)
+    # The number of unique routes cannot exceed K. Calling torch.unique here
+    # redundantly synchronizes the GPU once per MoE layer on every decode step.
+    assert K <= C, "layer-LRU query exceeds the total slot capacity"
+    if not expert_ids.is_cuda:
+        return _layer_lru_ensure_cpu(cache, layer_id, expert_ids, stats=stats)
     _layer_lru_ensure_kernel[(1,)](
         expert_ids,
         cache.slot_for_id,
@@ -111,6 +115,13 @@ def _layer_lru_ensure_cpu(cache, layer_id: int, expert_ids: torch.Tensor, *, sta
             owner = old // cache.num_experts if old >= 0 else -1
             if old < 0 or owner in over or (not over and owner == layer_id):
                 candidates.append(slot)
+        if not candidates:
+            # Quotas protect reuse, not at the expense of the current query.
+            # This occurs when top-k (or a sparse prefill) exceeds the quota.
+            candidates = [
+                slot for slot in range(cache.cache_size)
+                if int(cache.usage[slot]) != step
+            ]
         assert candidates, "layer-LRU has no evictable slot for this query"
         victim = min(candidates, key=lambda slot: (int(cache.usage[slot]), slot))
         old = int(cache.id_of_slot[victim])
@@ -207,6 +218,11 @@ def _layer_lru_ensure_kernel(
                 & ((owners < 0) | (owner_count > owner_quota) | ((~any_over) & (owner == layer_id)))
             )
             score = tl.where(eligible, usage, USAGE_MAX)
+            if tl.min(score, axis=0) == USAGE_MAX:
+                # Every preferred victim is pinned by this query. Fall back to
+                # global LRU among non-current routes instead of selecting slot
+                # zero from an all-MAX score vector and corrupting a live route.
+                score = usage
             victim = tl.argmin(score, axis=0).to(tl.int32)
             old = tl.load(id_of_slot_ptr + victim)
             old_layer = old // num_experts

--- a/python/sparklab/recipes/glm-5.3.json
+++ b/python/sparklab/recipes/glm-5.3.json
@@ -19,19 +19,33 @@
   "status": "experimental",
   "implementation": "available",
   "portfolio_role": "fallback",
-  "deployment": {"backend": "native", "backend_api": "1.0", "source_format": "safetensors", "runtime_format": "ftw-nvfp4", "quantization": "nvfp4", "execution_policy": "nvme-moe", "backend_options": {}},
+  "deployment": {
+    "backend": "native", "backend_api": "1.0", "source_format": "safetensors",
+    "runtime_format": "ftw-nvfp4", "quantization": "nvfp4", "execution_policy": "nvme-moe",
+    "backend_options": {
+      "moe_backend": "offload", "moe_storage": "disk", "moe_host_cache_gb": 0,
+      "memory_ratio": 0.90, "moe_cache_size": 2850, "moe_cache_policy": "layer_lru",
+      "nvfp4_backend": "flashinfer", "moe_prefill_sparse_max_tokens": 256,
+      "moe_prefill_overlap": false, "moe_shared_expert_overlap": true,
+      "cuda_graph_max_bs": 0, "cache_type": "radix", "page_size": 1,
+      "max_running_req": 1, "num_tokens": 2048
+    }
+  },
   "profile": "research",
   "description": "Measured GLM-5.2-compatible Research fallback for complete-model NVMe inference.",
+  "runtime_memory": {"total_bytes": 103079215104},
   "performance": {
-    "decode_tokens_per_second": 0.8126153861203544,
-    "warm_ttft_seconds": 2.530337787233293,
-    "evidence": "GB10-GLM53-RESEARCH-001",
-    "note": "Selected 256-token b12x trial; no OOM or swap-out growth, but the length-capped output did not establish correctness."
+    "decode_tokens_per_second": 1.108134249894042,
+    "warm_ttft_seconds": 1.9577306060236879,
+    "evidence": "GB10-GLM53-RESEARCH-OPT-002",
+    "note": "Selected 256-token b12x trial with 2850 layer-LRU slots and 20 disk readers; no OOM or swap-out. Separate answer checks completed problem 0 correctly but capped problem 1."
   },
-  "evidence": ["GB10-GLM53-RESEARCH-001"],
+  "evidence": ["GB10-GLM53-RESEARCH-001", "GB10-GLM53-RESEARCH-OPT-002"],
   "limitations": [
-    "The 256-token output hit the length cap before stating the expected final answer, so output correctness is not established.",
-    "The measured request had zero swap-out growth but began with pre-existing swap use and read 7,882 swap-in pages.",
+    "The portfolio uses a single 256-token performance trial, not an aggregate quality score. Set SPARKLAB_DISK_READ_WORKERS=20 to reproduce its reader count.",
+    "A separate normal-EOS check completed AIME problem 0 correctly; problem 1 reached its 1024-token cap without a final answer. Broader quality is not established.",
+    "Changing cache layout can change greedy text; bit-exact output parity is not claimed.",
+    "The measured run had zero swap-out or OOM but began with pre-existing swap use. The profile is batch one with 2048 KV tokens.",
     "The prepared artifact preserves routed experts as NVFP4 but converts large resident BF16 projections to per-row W8A16 FP8.",
     "No context, endurance, API, reasoning-parser, tool-parser, coding-agent, or quality certification is claimed."
   ]

--- a/tests/moe/test_layer_lru_interpreter.py
+++ b/tests/moe/test_layer_lru_interpreter.py
@@ -1,0 +1,75 @@
+"""CPU execution of the actual Triton admission kernel, without touching the GPU.
+
+Run with CUDA_VISIBLE_DEVICES='' TRITON_INTERPRET=1 pytest <this file>.
+CUDA parity tests in test_offload.py remain required before promoting a recipe.
+"""
+
+import os
+
+import pytest
+import torch
+import triton
+
+from sparklab.moe.offload_cache import OffloadMoeCache
+from sparklab.moe.offload_kernels import _layer_lru_ensure_kernel, layer_lru_ensure
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TRITON_INTERPRET") != "1", reason="requires TRITON_INTERPRET=1"
+)
+
+
+def _interpret(cache, layer, ids):
+    _layer_lru_ensure_kernel[(1,)](
+        ids, cache.slot_for_id, cache.id_of_slot, cache.usage, cache.step,
+        cache.layer_counts, cache.layer_quotas, ids,
+        cache.src_indices, cache.evict_slots, cache.num_indices, None,
+        layer, ids.numel(), cache.num_layers, cache.num_experts, cache.cache_size,
+        BLOCK_K=triton.next_power_of_2(ids.numel()),
+        BLOCK_L=triton.next_power_of_2(cache.num_layers),
+        BLOCK_C=triton.next_power_of_2(cache.cache_size),
+        USAGE_MAX=torch.iinfo(cache.usage.dtype).max,
+        COLLECT_STATS=False,
+    )
+
+
+@pytest.mark.parametrize("seed", [0, 7, 42])
+def test_layer_lru_interpreted_kernel_matches_reference(seed, monkeypatch):
+    from triton.runtime import interpreter
+
+    # Triton 3.6's interpreter uses int(ndarray) for loop bounds; NumPy 2.4
+    # requires extracting the scalar explicitly. Keep this compatibility shim
+    # confined to the CPU test, without changing the production kernel.
+    original_patch = interpreter._patch_lang_tensor
+
+    def patch_tensor(tensor, scope):
+        original_patch(tensor, scope)
+        scope.set_attr(tensor, "__index__", lambda value: int(value.handle.data.item()))
+
+    monkeypatch.setattr(interpreter, "_patch_lang_tensor", patch_tensor)
+    reference = OffloadMoeCache(3, 8, 12, torch.device("cpu"), cache_policy="layer_lru")
+    interpreted = OffloadMoeCache(3, 8, 12, torch.device("cpu"), cache_policy="layer_lru")
+    # Include unequal quotas: admission must use the actual reservations.
+    for cache in (reference, interpreted):
+        cache.reserve_layer_quotas({2: 6})
+    generator = torch.Generator().manual_seed(seed)
+    queries = [(layer, torch.arange(quota, dtype=torch.int32))
+               for layer, quota in enumerate(reference.layer_quotas.tolist())]
+    # Full-layer requests force borrowing below protected quotas. Later small
+    # queries must reclaim loans without evicting any route in their own query.
+    queries += [(layer, torch.arange(8, dtype=torch.int32)) for layer in range(3)]
+    for i in range(24):
+        queries.append((i % 3, torch.randint(
+            0, 8, (1 + i % 9,), dtype=torch.int32, generator=generator,
+        )))
+    for layer, raw in queries:
+        expected, actual = raw.clone(), raw.clone()
+        layer_lru_ensure(reference, layer, expected)
+        _interpret(interpreted, layer, actual)
+        assert torch.equal(actual, expected)
+        assert torch.equal(interpreted.id_of_slot[actual.long()], layer * 8 + raw)
+        for name in ("slot_for_id", "id_of_slot", "usage", "step", "layer_counts", "num_indices"):
+            assert torch.equal(getattr(interpreted, name), getattr(reference, name)), name
+        n = int(reference.num_indices.item())
+        assert torch.equal(interpreted.src_indices[:n], reference.src_indices[:n])
+        assert torch.equal(interpreted.evict_slots[:n], reference.evict_slots[:n])

--- a/tests/moe/test_nvfp4_backends.py
+++ b/tests/moe/test_nvfp4_backends.py
@@ -513,7 +513,7 @@ def test_nvfp4_backend_selection():
 
 
 @cuda
-def test_b12x_decode_matches_dequant_reference():
+def test_b12x_decode_matches_dequant_reference(monkeypatch):
     """sm_120 + CUDA>=13 only: the flashinfer b12x W4A16 fused MoE over the slot cache
     vs the dequant reference (skipped on hardware/toolkits where b12x cannot run)."""
     from sparklab.moe.nvfp4_backends import (
@@ -554,6 +554,19 @@ def test_b12x_decode_matches_dequant_reference():
         hidden, gu_p, gu_s, g1, dn_p, dn_s, g2, topk_weights, ids, "silu", False
     )
     _assert_close(out, ref)
+    # Exercise the large-cache descriptor workaround without allocating tens of
+    # GiB in a unit test. Two routed rows fit; the original eight-row bank does not.
+    import sparklab.moe.nvfp4_backends as backends
+
+    row_elements = max(
+        bank[0].numel() * bank.element_size() // 4
+        for bank in (gu_p, gu_s, dn_p, dn_s)
+    )
+    monkeypatch.setattr(backends, "_B12X_MAX_FLAT_INT32_ELEMENTS", TOPK * row_elements)
+    compact = b12x_fused_experts(
+        hidden, gu_p, gu_s, g1, dn_p, dn_s, g2, topk_weights, ids, "silu", False
+    )
+    torch.testing.assert_close(compact, out, rtol=0, atol=0)
 
 
 @cuda
@@ -604,6 +617,52 @@ def test_b12x_sparse_prefill_slot_ids_match_dequant_reference():
 
     assert int(cache.num_indices.item()) == 4
     _assert_close(out, ref)
+
+
+@cuda
+def test_b12x_routed_materialization_matches_full_prefill_exactly():
+    """Sparse I/O with the original logical E-row GEMM layout, above quota."""
+    from sparklab.moe.nvfp4_backends import (
+        _b12x_unusable_reason, b12x_fused_experts, b12x_repack_sources_inplace,
+    )
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    device = torch.device("cuda")
+    reason = _b12x_unusable_reason(torch.cuda.get_device_capability(device))
+    if reason is not None:
+        pytest.skip(reason)
+    sources = _make_native_sources(device, seed=17)
+    cfg = types.SimpleNamespace(hidden_size=H, moe_intermediate_size=I)
+    packed = b12x_repack_sources_inplace(sources, cfg, device, chunk=6)
+    cache = OffloadMoeCache(
+        L, E, 12, device, cache_policy="layer_lru", quant_format="nvfp4_b12x",
+    )
+    cache.set_bank_sources({name: packed[name] for name in cache.bank_schema})
+    cache.set_alphas(packed["gate_up_alpha"], packed["down_alpha"])
+    torch.manual_seed(17)
+    hidden = torch.randn(54, H, dtype=torch.bfloat16, device=device) / 4
+    weights = torch.rand(54, TOPK, dtype=torch.float32, device=device)
+    raw = (torch.arange(54 * TOPK, device=device).reshape(54, TOPK) % 7).int()
+
+    def run():
+        gu_p, gu_s, dn_p, dn_s = cache.bank_views(E)
+        g1, g2 = cache.alphas_for_layer(0)
+        return b12x_fused_experts(
+            hidden, gu_p, gu_s, g1, dn_p, dn_s, g2, weights, raw, "silu", False,
+        ).clone()
+
+    cache.materialize_layer(0)
+    cache.copy_missing()
+    reference = run()
+    # Overwrite with another layer so a missing staged row cannot pass by luck.
+    cache.materialize_layer(1)
+    cache.copy_missing()
+    unique_ids = torch.unique(raw).int()
+    cache.materialize_routed_layer(0, unique_ids)
+    cache.copy_missing()
+    actual = run()
+    assert int(cache.num_indices.item()) == 7 < E
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)
 
 
 @cuda

--- a/tests/moe/test_offload.py
+++ b/tests/moe/test_offload.py
@@ -183,6 +183,70 @@ def test_layer_lru_supports_exact_per_layer_quotas_cpu():
     assert cache.layer_quotas.tolist() == [4, 4, 7, 5]
 
 
+def _exercise_layer_lru_above_quota(cache):
+    # Kimi's top-16 routing exceeds its default 9-10 slots/layer. Model this
+    # with a full cache, two protected slots/layer, and four simultaneous routes.
+    for layer in range(3):
+        cache.ensure_experts(
+            layer, torch.tensor([0, 1], dtype=torch.int32, device=cache.device)
+        )
+    for layer in (0, 1, 2, 0):
+        raw = torch.tensor([0, 1, 2, 3, 0], dtype=torch.int32, device=cache.device)
+        slots = raw.clone()
+        cache.ensure_experts(layer, slots)
+        assert slots.unique().numel() == 4
+        assert torch.equal(cache.id_of_slot[slots.long()], layer * 4 + raw)
+        assert torch.equal(cache.slot_for_id[layer, raw.long()], slots)
+        assert int(cache.layer_counts.sum()) == cache.cache_size
+        owners = cache.id_of_slot // cache.num_experts
+        assert torch.equal(
+            torch.bincount(owners.long(), minlength=cache.num_layers).int(),
+            cache.layer_counts,
+        )
+
+
+def test_layer_lru_above_quota_keeps_every_current_route_cpu():
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    cache = OffloadMoeCache(3, 4, 6, torch.device("cpu"), cache_policy="layer_lru")
+    _exercise_layer_lru_above_quota(cache)
+
+
+def test_layer_lru_cuda_dispatch_does_not_sync_for_unique(monkeypatch):
+    from types import SimpleNamespace
+
+    from sparklab.moe import offload_kernels
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    cache = OffloadMoeCache(3, 4, 6, torch.device("cpu"), cache_policy="layer_lru")
+    query = SimpleNamespace(is_cuda=True, numel=lambda: 4)
+    calls = []
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            return lambda *args, **kwargs: calls.append((grid, args, kwargs))
+
+    monkeypatch.setattr(offload_kernels, "_layer_lru_ensure_kernel", FakeKernel())
+    monkeypatch.setattr(
+        torch, "unique", lambda *_: pytest.fail("decode admission must not call unique")
+    )
+    offload_kernels.layer_lru_ensure(cache, 0, query)
+    assert len(calls) == 1
+    assert calls[0][1][0] is query
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_layer_lru_above_quota_cuda_matches_cpu():
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    cpu = OffloadMoeCache(3, 4, 6, torch.device("cpu"), cache_policy="layer_lru")
+    gpu = OffloadMoeCache(3, 4, 6, torch.device("cuda"), cache_policy="layer_lru")
+    _exercise_layer_lru_above_quota(cpu)
+    _exercise_layer_lru_above_quota(gpu)
+    for name in ("slot_for_id", "id_of_slot", "usage", "layer_counts"):
+        assert torch.equal(getattr(cpu, name), getattr(gpu, name).cpu())
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_layer_lru_cuda_matches_cpu_reference():
     from sparklab.moe.offload_cache import OffloadMoeCache
@@ -195,6 +259,43 @@ def test_layer_lru_cuda_matches_cpu_reference():
     assert torch.equal(gpu.id_of_slot.cpu(), cpu.id_of_slot)
     assert torch.equal(gpu.usage.cpu(), cpu.usage)
     assert torch.equal(gpu.layer_counts.cpu(), cpu.layer_counts)
+
+
+@pytest.mark.parametrize("device_type", ["cpu", "cuda"])
+def test_materialize_routed_layer_preserves_inverse_maps_and_payload(device_type):
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    if device_type == "cuda" and not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    device = torch.device(device_type)
+    cache = OffloadMoeCache(3, 4, 6, device, cache_policy="layer_lru")
+    for layer, routes in ((0, [3, 2, 1]), (1, [0, 1]), (2, [1])):
+        cache.ensure_experts(layer, torch.tensor(routes, dtype=torch.int32, device=device))
+    payload = cache.id_of_slot.clone()
+    for layer, routes in ((0, [0, 2]), (1, [0, 3]), (2, [1, 2]), (2, [0, 1, 3])):
+        ids = torch.tensor(routes, dtype=torch.int32, device=device)
+        cache.materialize_routed_layer(layer, ids)
+        n = int(cache.num_indices.item())
+        assert n == len(routes)
+        assert torch.equal(cache.src_indices[:n], ids)
+        assert torch.equal(cache.evict_slots[:n], ids)
+        # Stand in for bank copying: an expert's payload is its flat logical id.
+        payload[cache.evict_slots[:n].long()] = layer * 4 + cache.src_indices[:n]
+        valid = cache.id_of_slot >= 0
+        owners = cache.id_of_slot[valid]
+        assert torch.equal(payload[valid], owners)
+        slots = torch.arange(cache.cache_size, device=device)[valid]
+        assert torch.equal(cache.slot_for_id.view(-1)[owners.long()].long(), slots)
+        mapped = cache.slot_for_id.view(-1) >= 0
+        assert torch.equal(
+            cache.id_of_slot[cache.slot_for_id.view(-1)[mapped].long()].long(),
+            torch.arange(12, device=device)[mapped],
+        )
+        assert torch.equal(cache.slot_for_id[layer, ids.long()], ids)
+        assert torch.equal(
+            torch.bincount((owners // 4).long(), minlength=3).int(), cache.layer_counts,
+        )
+        assert cache._pending_src_layer == layer and cache._pending_is_prefill
 
 
 def test_layer_lru_rejects_prefill_buffer_slot_borrowing():
@@ -410,6 +511,56 @@ def test_offload_moe_layer_sparse_prefill_routes_through_persistent_cache(monkey
     assert cache.sparse_prefill_routes == 2
     assert cache.sparse_prefill_unique_rows == 2
     assert int(cache.num_indices.item()) == 2
+
+
+@pytest.mark.parametrize("quant_format", ["bf16", "nvfp4", "fp8_block", "nvfp4_b12x"])
+def test_sparse_prefill_above_layer_quota_loads_only_routes(monkeypatch, quant_format):
+    from sparklab.moe.offload_cache import OffloadMoeCache
+
+    layer, _ = _make_layer_and_cache()
+    cache = OffloadMoeCache(
+        3, 4, 6, torch.device("cpu"), cache_policy="layer_lru",
+        quant_format=quant_format, prefill_sparse_max_tokens=4,
+    )
+    layer.offload_cache = cache
+    for lid in range(3):
+        cache.ensure_experts(lid, torch.tensor([0, 1], dtype=torch.int32))
+    raw = torch.tensor([[0, 2], [2, 3]], dtype=torch.int32)
+    weights = torch.tensor([[0.7, 0.3], [0.4, 0.6]])
+    hidden = torch.randn(2, 8)
+    copied = []
+    monkeypatch.setattr(
+        cache, "materialize_layer",
+        lambda *_: pytest.fail("above-quota routes must not scan the whole layer"),
+    )
+    monkeypatch.setattr(
+        cache, "copy_missing",
+        lambda: copied.extend(cache.src_indices[:int(cache.num_indices.item())].tolist()),
+    )
+    monkeypatch.setattr(cache, "alphas_for_slots", lambda *_: None)
+    monkeypatch.setattr(cache, "alphas_for_layer", lambda *_: None)
+    # This test exercises admission and routing dispatch, not quantized GEMMs.
+    monkeypatch.setattr(cache, "bank_views", lambda *args: ())
+
+    def fake_gemm(got_cache, got_hidden, got_weights, ids, **kwargs):
+        assert got_cache is cache and got_hidden is hidden and got_weights is weights
+        assert kwargs["is_prefill"]
+        if quant_format in ("nvfp4", "fp8_block"):
+            assert torch.equal(ids, raw)
+            slots = kwargs["prefill_slot_map"][ids.long()]
+        else:
+            assert kwargs.get("prefill_slot_map") is None
+            slots = ids
+        assert torch.equal(cache.id_of_slot[slots.long()], raw)
+        return hidden
+
+    monkeypatch.setattr(layer, "_expert_gemm", fake_gemm)
+    assert layer._prefill_routed(hidden, weights, raw.clone()) is hidden
+    assert copied == ([0, 2, 3] if quant_format == "nvfp4_b12x" else [2, 3])
+    assert cache.sparse_prefill_layers == 1
+    assert cache.sparse_prefill_unique_rows == 3
+    assert cache.sparse_prefill_routes == 4
+    assert cache.sparse_prefill_fallback_layers == 0
 
 
 def test_native_nvfp4_sparse_prefill_sorts_logical_ids_and_maps_slots(monkeypatch):

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -216,10 +216,16 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert glm53.deployment.quantization == "nvfp4"
     assert glm53.deployment.runtime_format == "ftw-nvfp4"
     assert glm53.performance.decode_tokens_per_second == pytest.approx(
-        0.8126153861203544
+        1.108134249894042
     )
-    assert glm53.performance.warm_ttft_seconds == pytest.approx(2.530337787233293)
-    assert glm53.evidence == ("GB10-GLM53-RESEARCH-001",)
+    assert glm53.performance.warm_ttft_seconds == pytest.approx(1.9577306060236879)
+    assert glm53.evidence == ("GB10-GLM53-RESEARCH-001", "GB10-GLM53-RESEARCH-OPT-002")
+    assert glm53.deployment.backend_options["moe_cache_size"] == 2850
+    assert glm53.deployment.backend_options["moe_cache_policy"] == "layer_lru"
+    assert glm53.deployment.backend_options["nvfp4_backend"] == "flashinfer"
+    assert glm53.deployment.backend_options["num_tokens"] == 2048
+    assert glm53.deployment.backend_options["cuda_graph_max_bs"] == 0
+    assert glm53.runtime_memory["total_bytes"] == 96 * 2**30
     assert deepseek.source_bytes == 166878536440
     assert deepseek.prepared_bytes == 168424579072
     assert qwen.execution_policy == glm.execution_policy == "nvme-moe"
@@ -341,11 +347,11 @@ def test_glm53_full_recipe_points_to_measured_failed_research_evidence():
     )
     assert recipe.runtime_artifact.bytes == 428713099264
     assert recipe.runtime_artifact.fingerprint == "a0e799b03bceb4bf"
-    assert recipe.performance.evidence == "GB10-GLM53-RESEARCH-001"
+    assert recipe.performance.evidence == "GB10-GLM53-RESEARCH-OPT-002"
     assert recipe.performance.evidence in recipe.evidence
     root = Path(__file__).resolve().parents[2]
     result = json.loads(
-        (root / "benchmarks/gb10/results/GB10-GLM53-RESEARCH-001.json").read_text()
+        (root / "benchmarks/gb10/results/GB10-GLM53-RESEARCH-OPT-002.json").read_text()
     )
     assert result["result_id"] == recipe.performance.evidence
     assert result["status"] == "measured"
@@ -361,9 +367,28 @@ def test_glm53_full_recipe_points_to_measured_failed_research_evidence():
     )
     assert result["stability"]["oom_count"] == 0
     assert result["stability"]["swap_out_pages"] == 0
-    assert result["validation"]["output_correctness_evaluated"] is False
+    assert result["validation"]["output_correctness_evaluated"] is True
+    assert result["validation"]["output_correctness"] is False
+    assert result["quality_checks"]["candidate"][0]["correct"] is True
+    assert result["quality_checks"]["candidate"][1]["finish_reason"] == "length"
     evaluation = evaluate_tier(recipe, result, "research")
     assert not evaluation.passed
+
+
+def test_glm53_portfolio_numbers_match_recipe():
+    import re
+
+    root = Path(__file__).resolve().parents[2]
+    recipe = get_recipe("glm-5.3")
+    expected = [
+        f"{recipe.performance.decode_tokens_per_second:.2f}",
+        f"{recipe.performance.warm_ttft_seconds:.3f}",
+    ]
+    readme_row = (root / "README.md").read_text().split(">GLM-5.3</a>", 1)[1].split("</tr>", 1)[0]
+    assert re.findall(r'<td align="right">([^<]+)</td>', readme_row) == expected
+    models_row = next(line for line in (root / "docs/models.md").read_text().splitlines()
+                      if line.startswith("| [GLM-5.3]("))
+    assert [cell.strip() for cell in models_row.split("|")[-3:-1]] == expected
 
 
 def test_historical_qwen_nvfp4_evidence_does_not_transfer_to_new_checkpoint():

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -76,7 +76,7 @@ def test_models_research_table_includes_measured_glm52_fallback(capsys):
     assert glm52_row.split()[-2:] == ["0.80", "2.570"]
     glm53_row = next(line for line in output.splitlines() if line.startswith("GLM-5.3"))
     assert "NVFP4" in glm53_row and "EXPERIMENTAL" in glm53_row
-    assert glm53_row.split()[-2:] == ["0.81", "2.530"]
+    assert glm53_row.split()[-2:] == ["1.11", "1.958"]
     assert "Kimi K3" in output
 
 

--- a/tests/test_bench_decode_moe_speculative.py
+++ b/tests/test_bench_decode_moe_speculative.py
@@ -45,6 +45,25 @@ def test_decode_benchmark_defaults_to_gpu_first_unified_memory_residency():
     assert "--disable-moe-prefill-overlap" in command
 
 
+def test_aime_suite_can_use_shared_server_launcher(monkeypatch):
+    from pathlib import Path
+    import sys
+
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "benchmarks"))
+    from benchmarks import bench_aime_suite
+
+    monkeypatch.setattr(sys, "argv", [
+        "bench_aime_suite.py", "--model", "/tmp/model", "--json", "/tmp/result.jsonl",
+        "--min-memory-gib", "12",
+    ])
+    args = bench_aime_suite.parse_args()
+    command = serve_cmd(args, "offload", 12345)
+    assert args.normal_eos and args.min_memory_gib == 12
+    assert command[command.index("--speculative-method") + 1] == "auto"
+    assert command[command.index("--speculative-tokens") + 1] == "0"
+    assert command[command.index("--dsv4-kv-storage") + 1] == "bf16"
+
+
 def test_decode_benchmark_keeps_overlap_with_an_explicit_host_cache():
     args = parse_args([
         "--model", "/tmp/model",


### PR DESCRIPTION
## Summary

- Optimize full GLM-5.3 disk offload: protect current routes during layer-LRU borrowing, avoid redundant decode synchronization, stage only routed prefill experts, and bound b12x compute-bank descriptors for larger caches.
- Select 2,850 expert slots and publish **1.11 tok/s / 1.958 s warm TTFT** from the comparable 256-token run (36.4% faster than the historical selected result).
- Keep README metrics scalar and concise; store methodology, raw evidence, and caveats in model/experiment details.
- Keep Experimental status. A separate normal-EOS AIME check completed correctly at 1.091 tok/s versus 0.815 for the control; the second problem hit its token limit. No bit-exact or broad quality claim.
- Preserve existing checkpoint pins and artifact version. Kimi K3 numbers are unchanged. Unrelated visualizer/image work is excluded.

## Validation

- CPU workflow suite: 1,122 passed, 75 skipped.
- CUDA offload/NVFP4 suites: 55 passed, 4 skipped.
- Actual Triton layer-LRU CPU-interpreter tests: 3 passed.
- Portfolio/CLI/recipe consistency tests; public-tree hygiene and diff checks passed.
- Selected hardware run: 29.7 GiB minimum available memory, zero scoped swap-out/OOM.

Evidence: `GB10-GLM53-RESEARCH-OPT-002` and accompanying raw results. Local home prefixes are redacted; numeric measurements are unchanged.
