### PR TITLE
docs: remove Qwen3.6 benchmark note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,6 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
   </tbody>
 </table>
 
-Qwen3.6 uses the default Marlin/MTP4 container; its values are from the fixed
-8K-input/256-output benchmark. See the model instructions for quality limitations
-and the previous native profile.
-
 Status meanings:
 
 - **Experimental:** implementation or measured evidence exists, but required gates remain


### PR DESCRIPTION
## Outcome

Remove the Qwen3.6 container/benchmark explanatory paragraph below the README model table, as requested.

## Validation

Reviewed the diff: README-only removal of one paragraph. `git diff --cached --check` passed; no runtime behavior changes.

## Checklist

- [x] The change is focused and contains no unrelated generated files or credentials.
- [x] Behavior changes include tests and relevant documentation (not applicable: documentation only).
- [x] Model, performance, or certification claims link exact versioned evidence (no new claims).
- [x] Public API, package, artifact-format, or compatibility changes have a design issue (not applicable).
- [x] Every commit includes a DCO `Signed-off-by` line.
- [x] I have the right to submit all code, data, and documentation in this pull request.
