### PR TITLE
Report Qwen27 short-prompt portfolio benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
       <td>27B dense</td>
       <td>NVFP4 · FP4 prefill + DFlash2-12 (greedy)</td>
       <td>Experimental</td>
-      <td align="right">27.47</td>
-      <td align="right">5.432</td>
+      <td align="right">49.52</td>
+      <td align="right">0.125</td>
       <td><a href="docs/models/qwen3.8-27b.md">Instructions</a></td>
     </tr>
     <tr>
@@ -161,6 +161,10 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
     </tr>
   </tbody>
 </table>
+
+Qwen3.8-27B uses the three-trial median of the original 96-input/128-output
+short-prompt probe. Its separate 8K-input/256-output comparison averages
+27.47 tok/s; see the [benchmark details](docs/models/qwen3.8-27b.md#measured-performance).
 
 Status meanings:
 

--- a/benchmarks/gb10/QWEN38_27B_FAST.md
+++ b/benchmarks/gb10/QWEN38_27B_FAST.md
@@ -27,6 +27,16 @@ target-only configuration, using speculative generation that vLLM does not use
 in this comparison. vLLM still wins target-only decode and prompt processing.
 No vLLM DFlash performance is claimed.
 
+## Short portfolio probe
+
+The portfolio now reports a separate rerun of the original short probe on this
+default recipe: **49.52 tok/s** and **0.125 s warm TTFT**, medians of three trials
+after one warmup, with 96 input and 128 output tokens. The historical Inferact
+result on that workload was 45.88 tok/s. These short-probe numbers do not replace
+the 30-request long-prompt comparison above. See the
+[short-probe record](results/GB10-QWEN38-27B-PORTFOLIO-001.json) for the exact prompt,
+per-trial timings, output hashes, launch arguments, and raw artifact hashes.
+
 ## What changed
 
 The pinned RadixArk checkpoint stores more projections in reduced precision than

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -4,6 +4,10 @@ This directory contains compact, reviewable summaries for SparkLab model
 recipes. Raw logs and large result streams stay outside the source repository.
 
 - `result.schema.json` defines the versioned summary contract.
+- `results/GB10-QWEN38-27B-PORTFOLIO-001.json` reruns the original 96-input/
+  128-output short probe on the default RadixArk + FP4 prefill + DFlash2-12 recipe:
+  49.52 tok/s and 0.125 s warm TTFT, medians of three trials after one warmup.
+  The separate 8K/256 comparison remains in `QWEN38_27B_FAST.md`.
 - `results/GB10-DSV4-PREFIX-006.json` records safe replay-free compressor-prefix
   commits and shared verification metadata: 14.02 tok/s over 128 tokens and
   9.96 tok/s over 256 tokens. It also identifies the older first-rejection

--- a/benchmarks/gb10/results/GB10-QWEN38-27B-PORTFOLIO-001.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-27B-PORTFOLIO-001.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-27B-PORTFOLIO-001",
+  "status": "measured",
+  "date": "2026-09-09",
+  "recipe": {
+    "slug": "qwen3.8-27b",
+    "recipe_version": "0.4.0",
+    "status": "experimental"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "git_revision": "9312e95d96955381e1c1687d755e27087708b9c4",
+    "git_tree": "5f38bf54e047d5985492fe7cb086d8fa68398990",
+    "git_tracked_dirty": false,
+    "merged_main_commit": "c6224c473bd3bc5675ffd186cf33e0ba21cc4e24",
+    "merged_main_tree_matches": true
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "cuda": "13.0",
+    "torch": "2.11.0+cu130",
+    "triton": "3.6.0",
+    "flashinfer": "0.6.15.post1"
+  },
+  "checkpoint": {
+    "target_repository": "RadixArk/Qwen3.8-27B-NVFP4",
+    "target_revision": "319f741cce68d7914884900c138a1fbb70a42f30",
+    "target_format": "ftw-nvfp4",
+    "target_fingerprint": "1ad54cc34ff10c49",
+    "draft_repository": "maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal",
+    "draft_revision": "bd7a934213c47a9e7ef69eef36bb3325f47fd1f1"
+  },
+  "configuration": {
+    "nvfp4_backend": "triton",
+    "cuda_graph_max_bs": 1,
+    "cache_type": "radix",
+    "page_size": 16,
+    "max_running_req": 1,
+    "max_seq_len_override": 65536,
+    "num_tokens": 65536,
+    "attention_backend": "triton",
+    "nvfp4_prefill_backend": "flashinfer",
+    "max_prefill_length": 2048,
+    "speculative_method": "dflash2",
+    "speculative_tokens": 12,
+    "speculative_draft_model": "@draft"
+  },
+  "workload": {
+    "name": "Original AIME-25 problem 0 portfolio probe",
+    "prompt": "Find the sum of all integer bases $b>9$ for which $17_b$ is a divisor of $97_b.$\nPlease reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_sha256": "51e1235f1c85cf333085c9e2889a20fb7e7ef65f320856975bac705eb04e43d4",
+    "prompt_tokens": 96,
+    "output_tokens": 128,
+    "clients": 1,
+    "temperature": 0,
+    "thinking": true,
+    "ignore_eos": true,
+    "warmup_requests": 1,
+    "measured_trials": 3,
+    "aggregation": "median",
+    "metric": "(completion_tokens - 1) / (last content event - first content event)"
+  },
+  "metrics": {
+    "decode_tokens_per_second": 49.519452895302685,
+    "warm_ttft_seconds": 0.12460947199724615,
+    "previous_published_decode_tokens_per_second": 45.878599543535536,
+    "previous_published_warm_ttft_seconds": 0.15192310701240785,
+    "improvement_over_previous_published_percent": 7.93584239273093
+  },
+  "trials": [
+    {
+      "decode_tokens_per_second": 49.519452895302685,
+      "ttft_seconds": 0.12460947199724615,
+      "elapsed_seconds": 2.689518706058152,
+      "usage": {
+        "prompt_tokens": 96,
+        "completion_tokens": 128,
+        "total_tokens": 224
+      },
+      "output_sha256": "690adfa2168a262be71fffd635142f0b5b21e2ed107049dd12e3d4bbcf93223c",
+      "text": "We need solve problem. Need reason step by step. Problem: Find sum of all integer bases b>9 for which 17_b is a divisor of 97_b.\n\nInterpretation: In base b, digits? 17_b means 1*b + 7 = b+7. 97_b means 9*b + 7 = 9b+7. Need b integer >9, and b+7 divides 9b+7. Need sum of all such bases.\n\nLet's solve. Divisibility: b+7 | 9b+7. Compute 9"
+    },
+    {
+      "decode_tokens_per_second": 49.54258047428204,
+      "ttft_seconds": 0.12600689905229956,
+      "elapsed_seconds": 2.689864707062952,
+      "usage": {
+        "prompt_tokens": 96,
+        "completion_tokens": 128,
+        "total_tokens": 224
+      },
+      "output_sha256": "690adfa2168a262be71fffd635142f0b5b21e2ed107049dd12e3d4bbcf93223c",
+      "text": "We need solve problem. Need reason step by step. Problem: Find sum of all integer bases b>9 for which 17_b is a divisor of 97_b.\n\nInterpretation: In base b, digits? 17_b means 1*b + 7 = b+7. 97_b means 9*b + 7 = 9b+7. Need b integer >9, and b+7 divides 9b+7. Need sum of all such bases.\n\nLet's solve. Divisibility: b+7 | 9b+7. Compute 9"
+    },
+    {
+      "decode_tokens_per_second": 49.4659033000671,
+      "ttft_seconds": 0.12278802692890167,
+      "elapsed_seconds": 2.69073077396024,
+      "usage": {
+        "prompt_tokens": 96,
+        "completion_tokens": 128,
+        "total_tokens": 224
+      },
+      "output_sha256": "690adfa2168a262be71fffd635142f0b5b21e2ed107049dd12e3d4bbcf93223c",
+      "text": "We need solve problem. Need reason step by step. Problem: Find sum of all integer bases b>9 for which 17_b is a divisor of 97_b.\n\nInterpretation: In base b, digits? 17_b means 1*b + 7 = b+7. 97_b means 9*b + 7 = 9b+7. Need b integer >9, and b+7 divides 9b+7. Need sum of all such bases.\n\nLet's solve. Divisibility: b+7 | 9b+7. Compute 9"
+    }
+  ],
+  "validation": {
+    "all_trials_exact_prompt_and_output_tokens": true,
+    "all_trial_output_hashes_equal": true,
+    "output_matches_previous_profile": false,
+    "completed_requests_including_warmup": 4,
+    "host_swap_in_pages_during_startup_and_probe": 1,
+    "host_swap_out_pages_during_startup_and_probe": 0,
+    "quality_and_serving_evidence": "GB10-QWEN38-27B-FAST-001"
+  },
+  "source": {
+    "benchmark": "benchmarks/bench_single_stream.py:generate",
+    "command": [
+      "$REPO/.venv/bin/python",
+      "-m",
+      "sparklab",
+      "serve",
+      "--model",
+      "$REPO/results/qwen27-shipping-20260909/acquisition-root/models/qwen3.8-27b/prepared/0.4.0",
+      "--served-model-name",
+      "RadixArk/Qwen3.8-27B-NVFP4",
+      "--attention-backend",
+      "triton",
+      "--nvfp4-backend",
+      "triton",
+      "--nvfp4-prefill-backend",
+      "flashinfer",
+      "--max-prefill-length",
+      "2048",
+      "--cuda-graph-max-bs",
+      "1",
+      "--cache-type",
+      "radix",
+      "--page-size",
+      "16",
+      "--max-running-requests",
+      "1",
+      "--max-seq-len-override",
+      "65536",
+      "--num-tokens",
+      "65536",
+      "--speculative-method",
+      "dflash2",
+      "--speculative-tokens",
+      "12",
+      "--speculative-draft-model",
+      "$REPO/results/qwen27-shipping-20260909/acquisition-root/models/qwen3.8-27b/draft/bd7a934213c4",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "1938"
+    ],
+    "environment_overrides": {
+      "PYTHONPATH": "$SOURCE_WORKTREE/python",
+      "SPARKLAB_DISABLE_KERNEL_CACHE": "1"
+    },
+    "raw_directory": "results/qwen27-portfolio-20260909",
+    "raw_manifest_sha256": "f292e4ac7ca5e571bb7f455b27f5c0effe8917bccc828f7c014f8ce11f0ec947",
+    "previous_short_probe": "GB10-QWEN38-DFLASH-004",
+    "long_prompt_comparison": "GB10-QWEN38-27B-FAST-001",
+    "path_placeholders": {
+      "$REPO": "SparkLab checkout containing the prepared benchmark artifacts",
+      "$SOURCE_WORKTREE": "Clean source checkout at engine.git_revision; tree matches the recorded merged main commit",
+      "$HOME": "User home directory"
+    }
+  },
+  "limitations": [
+    "One fixed short prompt, not a broad workload average or a completed-answer quality test.",
+    "The previous 45.88 tok/s is a historical result on the same prompt and token budget, not a contemporaneous control; checkpoint, runtime and KV capacity differ.",
+    "Outputs are stable across the three new trials but differ from the previous Inferact profile.",
+    "The default recipe is measured with greedy requests; sampled requests use target-only generation.",
+    "The 27.47 tok/s, 5.432 s TTFT long-prompt mean remains valid on its separate 30-request 8K/256 workload.",
+    "Pre-existing host swap and one swap-in page were observed; no swap-out during startup and the probe. CPU activity was not isolated.",
+    "The advanced server command uses the final recipe arguments and source JIT with the incompatible optional kernel-cache package disabled.",
+    "Full Fast certification and endurance remain outstanding."
+  ]
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -32,7 +32,7 @@ coding-agent task, and versioned benchmark evidence. Status means:
 |---|---|---|---|---|---:|---:|
 | **Fast — routine chat, editing, and short agent loops** |  |  |  |  |  |  |
 | [Qwen3.6-35B-A3B](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4) | 35B total / 3B active | NVFP4 · Marlin + MTP4 container | `qwen3.6-35b-a3b` | Preview | 112.08 | 1.436 |
-| [Qwen3.8-27B](https://huggingface.co/oakmindai/Qwen3.8-27B-NVFP4-FTW) | 27B dense | NVFP4 · FTW + optional DFlash2-12 | `qwen3.8-27b` | Experimental | 45.88 | 0.152 |
+| [Qwen3.8-27B](https://huggingface.co/RadixArk/Qwen3.8-27B-NVFP4) | 27B dense | NVFP4 · FP4 prefill + DFlash2-12 (greedy) | `qwen3.8-27b` | Experimental | 49.52 | 0.125 |
 | **Frontier — hard coding, reasoning, and long agent work** |  |  |  |  |  |  |
 | [Qwen3.8-Flash-Next](https://huggingface.co/oakmindai/Qwen3.8-Flash-Next-NVFP4-FTW) | 125B LM + 55B auxiliary / 6B active | NVFP4 · FTW + optional MTP3 | `qwen3.8-flash-next` | Experimental | 31.97 | 0.260 |
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 14.02 | 0.515 |
@@ -53,6 +53,12 @@ evidence attached to each recipe. Certification applies only to that exact check
 and recipe version. Portfolio performance and warm-TTFT columns use the selected
 single-stream profile; concurrent-serving results remain in model-specific evidence.
 
+Qwen3.8-27B recipe 0.4.0 uses the original AIME-25 short-prompt probe: 96 input
+tokens, 128 output tokens, thinking enabled, temperature 0, one warmup and three
+measured trials. The portfolio reports median decode speed and warm TTFT.
+The separate 30-request 8K/256 workload averages 27.47 tok/s and 5.432 s TTFT;
+these workloads are not interchangeable.
+
 Qwen3.6 recipe 0.6.0 defaults to the Marlin/MTP4 container. The portfolio row uses
 the two-repeat 8K-input/256-output C1 mean: 112.08 tok/s and 1.436 s TTFT. A one-hour
 zero-swap run passed, but the profile remains Preview because the fixed quality
@@ -72,7 +78,7 @@ to the current NVIDIA checkpoint. Its selected MTP3 metric is batch-one.
 | Model | Current result | Evidence |
 |---|---|---|
 | Qwen3.6-35B-A3B | Default Marlin/MTP4 container: 112.08 tok/s, 28 serving checks and 1,411 requests over one zero-swap hour. Preview with documented quality differences; previous native artifact remains available. | [GB10-QWEN36-MARLIN-001](../benchmarks/gb10/results/GB10-QWEN36-MARLIN-001.json), [qualification](../benchmarks/qwen36_marlin/QUALIFICATION.md) |
-| Qwen3.8-27B | The opt-in DFlash2-12 profile reached 45.88 tok/s with exact target-output parity on the 128-token probe. Longer math, coding, and prose probes improved; their complete traces can differ with verification grouping. Full Fast certification remains pending. | [target-only](../benchmarks/gb10/results/GB10-QWEN38-27B-001.json), [DFlash2-12](../benchmarks/gb10/results/GB10-QWEN38-DFLASH-004.json) |
+| Qwen3.8-27B | Default RadixArk + FP4 prefill + greedy DFlash2-12: 49.52 tok/s and 0.125 s warm TTFT on the original short probe. Three trials produced identical output, which differs from the previous Inferact profile. The broader screen passed 70/74 quality and 29/29 serving checks; full Fast certification remains pending. | [short portfolio probe](../benchmarks/gb10/results/GB10-QWEN38-27B-PORTFOLIO-001.json), [8K comparison and verification](../benchmarks/gb10/QWEN38_27B_FAST.md) |
 | Qwen3.8-Flash-Next | NVIDIA MTP3 with accepted-prefix state commits measured 31.97 tok/s and 0.260 s warm TTFT, 13.9% above its baseline with zero rejection replay. Output differs from target-only; prior Inferact certification evidence does not transfer. | [NVIDIA baseline](../benchmarks/gb10/results/GB10-QWENNVIDIA-001.json), [accepted-prefix commits](../benchmarks/gb10/results/GB10-QWENNVIDIA-002.json) |
 | DeepSeek V4 Flash | The selected three-trial DSpark5 burst profile reaches 14.02 tok/s with replay-free compressor-prefix commits. This fixes the previous first-rejection carry shortcut; target-only remains the default and full certification is pending. | [GB10-DSV4-PREFIX-006](../benchmarks/gb10/results/GB10-DSV4-PREFIX-006.json) |
 | GLM-5.3 Flash | The opt-in MTP3 profile reached a median 7.77 tok/s with no rejection replay, 3.4% above its fresh baseline and identical output across three trials. NVMe sensitivity and the remaining certification gates keep it Experimental. | [target-only](../benchmarks/gb10/results/GB10-GLM53-MHC-003.json), [MTP sweep](../benchmarks/gb10/results/GB10-GLM53-MTP-004.json), [optimized MTP3](../benchmarks/gb10/results/GB10-GLM53-OPT-005.json), [KDA state commits](../benchmarks/gb10/results/GB10-GLM53-OPT-006.json) |

--- a/docs/models/qwen3.8-27b.md
+++ b/docs/models/qwen3.8-27b.md
@@ -45,6 +45,17 @@ to `sparklab run`.
 
 ## Measured performance
 
+The portfolio uses the original short AIME-25 problem 0 probe: 96 input tokens,
+exactly 128 output tokens, thinking enabled, temperature 0, one client, one warmup
+and three measured trials. The new default measured **49.52 tok/s** and
+**0.125 s warm TTFT** (medians); individual decode trials were 49.47–49.54 tok/s.
+This is 7.9% above the historical 45.88 tok/s result on the same short workload.
+All three new outputs matched each other, but differed from the previous Inferact
+output. This truncated speed probe does not measure completed-answer quality.
+See the [short-probe evidence](../../benchmarks/gb10/results/GB10-QWEN38-27B-PORTFOLIO-001.json).
+
+### Long-prompt comparison
+
 Thirty fixed SPEED-Bench requests, roughly 8K input tokens and exactly 256 output
 tokens, three warmups, thinking enabled, temperature 0, one client:
 

--- a/python/sparklab/recipes/qwen3.8-27b.json
+++ b/python/sparklab/recipes/qwen3.8-27b.json
@@ -42,14 +42,15 @@
   },
   "description": "Experimental Fast-tier text-only RadixArk NVFP4 recipe with FP4 prefill and greedy DFlash2-12 on one NVIDIA GB10.",
   "performance": {
-    "decode_tokens_per_second": 27.467633094202384,
-    "warm_ttft_seconds": 5.432493594633333,
+    "decode_tokens_per_second": 49.519452895302685,
+    "warm_ttft_seconds": 0.12460947199724615,
     "context_tokens": 65536,
-    "evidence": "GB10-QWEN38-27B-FAST-001",
-    "note": "Thirty fixed SPEED-Bench requests, roughly 8K input and exactly 256 output tokens, three warmups, one client, temperature 0, thinking enabled. Mean request time 15.02 s. Sampled requests use target-only generation. Quality: 70/74 checks; serving: 29/29. These are not quality-equivalence or endurance certification results."
+    "evidence": "GB10-QWEN38-27B-PORTFOLIO-001",
+    "note": "Original AIME-25 problem 0 short portfolio probe: 96 input tokens, exactly 128 output tokens, one warmup and three measured trials; median streaming decode and warm TTFT, one client, temperature 0, thinking enabled. The separate 30-request 8K/256 benchmark remains 27.47 tok/s and 5.432 s mean TTFT (GB10-QWEN38-27B-FAST-001). Sampled requests use target-only generation. Full Fast certification remains outstanding."
   },
   "evidence": [
-    "GB10-QWEN38-27B-FAST-001"
+    "GB10-QWEN38-27B-FAST-001",
+    "GB10-QWEN38-27B-PORTFOLIO-001"
   ],
   "limitations": [
     "Text-only serving; the published checkpoint includes a vision tower.",

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -165,10 +165,13 @@ def test_next_model_recipes_are_immutable_and_capacity_plannable():
     assert qwen27.source_bytes == 21945295265
     assert qwen27.prepared_bytes == 21036142615
     assert qwen27.intended_tier == "fast"
-    assert qwen27.performance.decode_tokens_per_second == pytest.approx(27.467633094202384)
-    assert qwen27.performance.warm_ttft_seconds == pytest.approx(5.432493594633333)
+    assert qwen27.performance.decode_tokens_per_second == pytest.approx(49.519452895302685)
+    assert qwen27.performance.warm_ttft_seconds == pytest.approx(0.12460947199724615)
     assert qwen27.performance.context_tokens == 65_536
-    assert qwen27.evidence == ("GB10-QWEN38-27B-FAST-001",)
+    assert qwen27.evidence == (
+        "GB10-QWEN38-27B-FAST-001",
+        "GB10-QWEN38-27B-PORTFOLIO-001",
+    )
     assert qwen27.recipe_version == "0.4.0"
     assert qwen27.draft_model is not None
     assert qwen27.draft_model.revision == "bd7a934213c47a9e7ef69eef36bb3325f47fd1f1"


### PR DESCRIPTION
## Outcome

Restore the original short-prompt benchmark convention for the Qwen3.8-27B portfolio entry using a fresh measurement of the default RadixArk + FP4 prefill + greedy DFlash2-12 recipe: **49.52 tok/s and 0.125 s warm TTFT**. Update the README, model docs, and catalog together, with versioned per-trial evidence.

The probe uses the same 96 input tokens and 128 output tokens as the historical 45.88 tok/s result, with one warmup and three measured trials. The separate 30-request 8K/256 comparison remains documented at 27.47 tok/s. Outputs match across the new trials but differ from the previous Inferact profile; status remains Experimental.

## Validation

- Replayed the original short probe on the default recipe: trials 49.5195, 49.5426, and 49.4659 tok/s; exactly 96 input and 128 output tokens each.
- `PYTHONPATH=python .venv/bin/python -m pytest -q tests/sparklab`: **96 passed** in the isolated PR checkout.
- Verified reported medians, token counts, evidence references, raw artifact hashes, public-tree path hygiene, and `git diff --check`.
- Evidence: `benchmarks/gb10/results/GB10-QWEN38-27B-PORTFOLIO-001.json`. GPU server stopped after measurement.

## Checklist

- [x] The change is focused and contains no unrelated generated files or credentials.
- [x] Behavior changes include tests and relevant documentation (performance metadata and existing catalog expectations only).
- [x] Model, performance, or certification claims link exact versioned evidence.
- [x] Public API, package, artifact-format, or compatibility changes have a design issue (not applicable; measured portfolio metadata only).
- [x] Every commit includes a DCO `Signed-off-by` line.
- [x] I have the right to submit all code, data, and documentation in this pull request.

Prepared with Codex; benchmark output and the final diff were checked locally.
