### PR TITLE
Reduce Qwen3.8-Flash-Next prefill latency and publish framework benchmarks

### DIFF
--- a/benchmarks/frameworks/QWEN38_FLASH_NEXT.md
+++ b/benchmarks/frameworks/QWEN38_FLASH_NEXT.md
@@ -1,5 +1,9 @@
 # Qwen3.8-Flash-Next cross-framework benchmark
 
+For current SparkLab, vLLM, and SGLang measurements using newer checkpoints and
+file-backed PLE support, see the [2026-09-09 comparison](QWEN38_FLASH_NEXT_20260909.md).
+The results below are historical and use a different checkpoint and workload.
+
 This report measures batch-one text serving of Qwen3.8-Flash-Next on one NVIDIA
 DGX Spark (GB10, 128 GB coherent memory, ARM64 Linux). It is separate from the
 [Qwen3.6 comparison](README.md) because Qwen3.8-Flash-Next has a substantially

--- a/benchmarks/frameworks/QWEN38_FLASH_NEXT_20260909.md
+++ b/benchmarks/frameworks/QWEN38_FLASH_NEXT_20260909.md
@@ -1,0 +1,133 @@
+# Qwen3.8-Flash-Next on one DGX Spark — 2026-09-09
+
+This run compares single-client text generation on the same NVIDIA GB10 using
+frozen prompts and fixed output budgets. SparkLab and SGLang use the same pinned
+NVIDIA source checkpoint. **vLLM uses a different Mia quantization and the existing
+Spark adaptation**, so its row compares deployable configurations and does not
+isolate framework efficiency or establish quality parity.
+
+## Measured results
+
+Decode throughput, in output tokens/second:
+
+| Configuration | Short / 128 output | 1K / 256 output | ~8K / 256 output |
+|---|---:|---:|---:|
+| SparkLab fast (NVIDIA) | 41.90 | 30.49 | 25.93 |
+| vLLM + Spark adaptation (Mia) | 42.14 | 33.96 | 31.14 |
+| SGLang (NVIDIA) | 35.07 | 28.83 | 26.46 |
+
+Prompt and full-request latency:
+
+| Configuration | 1K TTFT | ~8K TTFT | ~8K full request |
+|---|---:|---:|---:|
+| SparkLab fast (NVIDIA) | 2.213 s | 23.244 s | 33.172 s |
+| vLLM + Spark adaptation (Mia) | 0.730 s | 4.527 s | 12.788 s |
+| SGLang (NVIDIA) | 0.816 s | 10.536 s | 20.303 s |
+
+The short column is the median of three repeats of the original AIME25 portfolio
+prompt, after one warmup. The other columns are means over 30 distinct requests,
+after three separate warmups each. All engines completed all 70 requests including
+warmups. Input token counts match across engines: 96 for short, 1,024 for random1k,
+and 7,908–8,983 for SPEED-Bench. Each response has the exact requested output count.
+
+Decode rate is `(completion_tokens - 1) / (request_s - ttft_s)`: timing continues
+until the stream completes, including generation that emits no visible text.
+The original last-visible-token calculation inflated some SGLang random1k trials;
+all rows use the corrected window, derived from the saved timings. Both versions
+and trailing durations are retained in the result. TTFT ends at the first nonempty
+content/reasoning delta; full-request latency includes prefill and generation. These are client-observed
+streaming metrics. Do not mix the short probe with long-prompt means.
+
+## Configurations
+
+All runs use one client, temperature zero, `ignore_eos`, a 12,288-token context
+limit, BF16 KV, and MTP with three speculative steps. Thinking is enabled for the
+short and SPEED-Bench prompts and disabled for random1k. Servers run sequentially.
+Framework KV pool capacities, page sizes, kernels, and MTP execution differ.
+
+- **SparkLab:** clean source `3f259fb04d7d28a4d78b49f96502083e8586012f`;
+  NVIDIA source `fab0aecb760cec45227f6656abcaafa11abca87a`, FTW fingerprint
+  `94e1ee0daa442357`. Published opt-in fast profile: separate FP8 draft head,
+  immediate redraft, light verification snapshots, full 24,576-expert preload,
+  Triton NVFP4/W4A16 prefill, FP32 recurrent state, page size 16, 131,072 KV tokens.
+  This is not recipe 0.9.0's target-only default.
+- **vLLM:** `0.1.dev20073+g8e685d198`, dedicated image digest
+  `sha256:3b0e188ffceb3d07e09c3cb5215433a0020eacf02d7f882ed3a8bfd15454477e`;
+  Mia source `925d7be6c14c6c9442ef83e8f05b5a3c39304f69`;
+  [existing Spark adaptation](https://github.com/MiaAI-Lab/Qwen3.8-Flash-Next-Single-DGX-Spark)
+  at local commit `5218435fcbfe567c58cc28668be5035ec137d77f`.
+  Adaptations provide NVFP4/file-backed PLE, GB10 compatibility, and QSA handling;
+  mounted-file hashes are retained in the evidence. Mia's PLE and attention
+  precision differ from NVIDIA's export. Prefix caching is disabled, batch-token
+  cap is 8,192, memory utilization is 0.80, and the runtime reports 216,760 KV tokens.
+- **SGLang:** stock cookbook image `0.0.0.dev1+g4ccff141d`, commit
+  `4ccff141dbe992794f9da6c3aa23535b4f72000d`, ARM64 image digest
+  `sha256:a1e17bbf0e9618364dc6395a4de5f9c3e8dfc9f43d603995b7a6aebc83de6e06`.
+  Same NVIDIA source revision as SparkLab; ModelOpt mixed auto-detection,
+  FlashInfer CUTLASS MoE, page size 64, 4,096-token prefill chunks, FP32 recurrent
+  state, NEXTN three steps/four draft tokens, maximum 8 requests/40 Mamba slots,
+  memory fraction 0.85, and 97,792 KV tokens. PLE is a fresh file-backed FP8 table
+  with an 8 GiB resident cap. Compared with the cookbook command, context is reduced to the matched
+  workload limit and radix caching is disabled; precision is explicit and the
+  model is loaded offline from the pinned snapshot.
+
+The original NVIDIA safetensors were recovered from the existing native cache
+plus source-only tensors and headers. All 11 complete weight files match the
+publisher's SHA256 hashes; this did not introduce another quantization.
+
+## SGLang cookbook reference
+
+The [Qwen3.8-Flash-Next cookbook](https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next)
+was retrieved on 2026-09-09. The requested H200/BF16/low-latency/single-node cell
+uses tensor parallelism of four and lists accuracy, but no speed measurements.
+
+Its single-Spark NVIDIA NVFP4 random 1,024-input/256-output, concurrency-one entries
+report:
+
+| Published profile | TTFT | TPOT | Decode rate derived as 1000 / TPOT |
+|---|---:|---:|---:|
+| MTP | 650.03 ms | 33.26 ms | 30.07 tok/s |
+| No MTP | 604.33 ms | 63.54 ms | 15.74 tok/s |
+
+The published 136 and 78 tokens/s/GPU values include input plus output tokens;
+they are not output decode rates. Our random1k workload matches the lengths, but
+uses different frozen inputs and chat/streaming measurement, so it is not an exact
+reproduction of the published benchmark.
+
+## Limits and operational observations
+
+- Fixed token budgets test speed, not completed-answer quality. The prior native
+  fast-profile MGSM tuning subset scored 92/100 versus 94/100 for the original
+  profile; no new quality comparison was performed. Identical NVIDIA source
+  weights do not guarantee identical activation arithmetic or generated text.
+- The three native short repeats generated identical text. vLLM and SGLang each
+  produced three distinct outputs despite temperature zero; decode variation
+  includes different generated continuations and speculation acceptance.
+- Native short repeats reuse 64 of 96 prompt tokens, while vLLM and SGLang have
+  prefix reuse disabled. Short TTFT is therefore omitted from the comparison
+  table. All native 1K/8K prefill batches report zero cached tokens.
+- The host was not isolated. SGLang image acquisition overlapped native short/1K
+  and early 8K requests; background source acquisition resumed during native 8K.
+  Bulk source recovery ended before vLLM measurement. These observations are
+  practical measurements, not a fully isolated causal framework experiment.
+- Pre-existing swap and additional host swap traffic occurred. Memory telemetry,
+  guard status, and container exits are retained; these runs do not certify
+  zero-swap serving or production endurance.
+- SGLang emitted a startup compiler warning about concurrent writes to
+  `Logits(bx, position)`. Its effect on output quality was not evaluated.
+- Concurrency one does not measure multi-client throughput or capacity.
+
+## Evidence
+
+The [versioned result](../gb10/results/GB10-QWEN38-FLASH-NEXT-FRAMEWORKS-001.json)
+contains exact commands, revisions, per-request timing/usage/output hashes,
+validation, and memory summaries. Raw requests, generated text, logs, suite,
+launch scripts, and checkpoint verification live in
+`results/qwen38-flash-next-frameworks-20260909` at the repository root. The frozen
+suite SHA256 is
+`38316b0c391b4dc37c57923315389d69663a98aa90b20a5c8b1e04dc6f15f7fb`.
+
+This supersedes the framework availability conclusions in the
+[earlier comparison](QWEN38_FLASH_NEXT.md), which used older checkpoints/runtimes
+and a different 256-output-token short probe. Historical measurements remain
+unchanged.

--- a/benchmarks/frameworks/QWEN38_FLASH_NEXT_PREFILL_20260910.md
+++ b/benchmarks/frameworks/QWEN38_FLASH_NEXT_PREFILL_20260910.md
@@ -1,0 +1,82 @@
+# Qwen3.8-Flash-Next prefill optimization — 2026-09-10
+
+Batched PLE reads and sparse-attention selection reduce long-prompt processing
+cost in the native Qwen4 runtime. On one DGX Spark, the paired 30-request ~8K/256
+workload reduced mean TTFT by **15.8%** and full-request
+time by **11.3%**. Weights, activation/storage
+precision, sampling, KV capacity, and the selected MTP profile are unchanged.
+
+| Workload, input / output tokens | TTFT, baseline → optimized | Decode tok/s, baseline → optimized | Full request, baseline → optimized |
+|---|---:|---:|---:|
+| Short, 96 / 128 | 0.243 → 0.243 s | 42.20 → 42.14 | 3.252 → 3.256 s |
+| Random, 1024 / 256 | 2.213 → 1.981 s | 30.65 → 30.57 | 10.748 → 10.536 s |
+| SPEED-Bench, ~8K / 256 | 23.010 → 19.374 s | 26.10 → 26.28 | 32.880 → 29.171 s |
+
+Short is the median of three repeats after one warmup. The other rows are means
+over 30 distinct requests after three separate warmups. Decode timing is
+`(completion_tokens - 1) / (request_s - ttft_s)`, through stream completion.
+Both native runs reuse prefix cache for the short repeated prompt. The same
+frozen chat messages, thinking settings, and token budgets are used in both runs.
+
+## Changes
+
+Large PLE cache misses are submitted in batches of 512 rows to the existing
+16-worker I/O pool. This removes most per-row Future/queue overhead while keeping
+parallel NVMe reads. Raw bytes, FP8 scaling, returned row order, cache insertion,
+and the small decode lookup path are preserved. Serial reads were rejected after
+a cold-file test showed a substantial regression. The prototype with 2,048-row
+jobs reduced a cold 8K lookup from 4.1–4.5 seconds to 1.9 seconds; the table above
+measures the final 512-row implementation in the full model.
+
+Sparse QSA prompt selection processes up to 128 queries at once. It retains the
+existing FP32 score reduction and causal visibility, packs selected physical rows
+in chronological order, and uses the original one-dimensional top-k whenever a
+selection boundary is tied. Dense prefixes and partial block tails are retained.
+Small decode and MTP verification batches keep their existing selection path.
+The 8K-shaped component test selected exactly the same 15,081,760 physical rows;
+warmed selection took 44.6 ms versus 198.5 ms for the old query loop.
+
+The changes apply automatically to native Qwen4 prefill. No recipe flag,
+quantization choice, or portfolio number was changed.
+
+## Validation
+
+- **223 focused tests passed:** exact attention-row selection across causal
+  boundaries, cached prefixes, tails and tied scores; scaled FP8/BF16 PLE reads
+  across source shards, async lookups, cache eviction and short-read errors; plus
+  mixed prefill/decode request packing and existing Qwen4 model and metadata tests.
+- All 140 speed requests including warmups completed with the requested token
+  counts. Paired measured outputs were identical for **63/63** requests.
+- The same 52-case arithmetic/recall/JSON smoke suite, run after the speed workloads, scored
+  **42/52 → 42/52**, with
+  **0 new failures** and **52/52 identical answers**. Existing baseline failures are retained in the report.
+
+## Reproduction and limits
+
+Fresh sequential servers used a clean baseline at
+`3f259fb04d7d28a4d78b49f96502083e8586012f` and an isolated candidate checkout of that
+revision plus the recorded source-file hashes. Both used NVIDIA source
+`fab0aecb760cec45227f6656abcaafa11abca87a`, FTW fingerprint `94e1ee0daa442357`, full
+24,576-expert preload, BF16 resident projections/KV, FP32 recurrent state, Triton
+NVFP4, a 12,288-token sequence cap and 131,072 KV tokens. Each server uses the same
+existing model-page-cache release policy at preload. No other benchmarks or
+downloads ran alongside speed measurements. Host swap and memory observations
+are retained in the result. Neither run had an OOM or memory-guard event.
+Minimum available memory was 22.7 GiB before and 27.1 GiB after. The optimized
+run recorded no swap-out pages; the baseline recorded 7,737, with pre-existing
+host swap present in both runs.
+
+The measured fast MTP3 profile remains opt-in: separate FP8 proposal head,
+immediate redraft and light verification snapshots. Its historical MGSM tuning
+subset was 92/100 versus 94/100 for the older profile. This optimization and its
+smoke tests do not establish general quality parity, reverse that historical
+limitation, or certify concurrency, long context, or production endurance.
+MGSM was not rerun. The previous external-engine measurements remain historical;
+vLLM and SGLang were not rerun for this change.
+
+[Versioned evidence](../gb10/results/GB10-QWENNVIDIA-006.json) includes commands,
+source hashes, per-request metrics and output hashes, quality results and memory
+telemetry. Raw logs, scripts and requests are in
+`results/qwen38-flash-next-opt-20260910` at the repository root. The corpus matches
+the [earlier framework comparison](QWEN38_FLASH_NEXT_20260909.md), with suite SHA256
+`38316b0c391b4dc37c57923315389d69663a98aa90b20a5c8b1e04dc6f15f7fb`.

--- a/benchmarks/gb10/results/GB10-QWEN38-FLASH-NEXT-FRAMEWORKS-001.json
+++ b/benchmarks/gb10/results/GB10-QWEN38-FLASH-NEXT-FRAMEWORKS-001.json
@@ -1,0 +1,4669 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWEN38-FLASH-NEXT-FRAMEWORKS-001",
+  "status": "measured_with_limitations",
+  "date": "2026-09-09",
+  "hardware": {
+    "platform": "NVIDIA DGX Spark GB10",
+    "gpus": 1,
+    "physical_memory_bytes": 130663591936,
+    "machine": "aarch64"
+  },
+  "metric": "(completion_tokens - 1) / (request_s - ttft_s); includes stream tail after the last visible token",
+  "workload": {
+    "clients": 1,
+    "temperature": 0,
+    "ignore_eos": true,
+    "context_limit": 12288,
+    "short": "Original AIME25 problem 0, thinking on, 96 input / 128 output, 1 warmup + 3 measured repeats, median",
+    "random1k": "Frozen seeded random word chat, thinking off, 1024 input / 256 output, 3 separate warmups + 30 measured requests, mean",
+    "speedbench8k": "Same frozen SPEED-Bench messages as Qwen27 comparison, thinking on, 7908..8983 input / 256 output, 3 separate warmups + 30 measured requests, mean"
+  },
+  "profiles": {
+    "native-fast": {
+      "configuration": {
+        "argv": [
+          "$HOME/projects/sparklab/.venv/bin/python",
+          "-m",
+          "sparklab",
+          "serve",
+          "--model",
+          "$HOME/models/qwen38-nvidia/prepared/fab0aecb760c",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          "1938",
+          "--moe-backend",
+          "offload",
+          "--nvfp4-backend",
+          "triton",
+          "--moe-storage",
+          "disk",
+          "--moe-host-cache-gb",
+          "0.0",
+          "--max-running-requests",
+          "1",
+          "--max-seq-len-override",
+          "12288",
+          "--attention-backend",
+          "qsa",
+          "--page-size",
+          "16",
+          "--cache-type",
+          "radix",
+          "--memory-ratio",
+          "0.9",
+          "--cuda-graph-max-bs",
+          "1",
+          "--moe-hybrid-max-fetch",
+          "-1",
+          "--moe-cache-policy",
+          "lru",
+          "--speculative-method",
+          "mtp",
+          "--speculative-tokens",
+          "3",
+          "--draft-sample-method",
+          "greedy",
+          "--dspark-confidence-threshold",
+          "0.0",
+          "--dspark-draft-cache-slots",
+          "0",
+          "--dspark-draft-cache-quotas",
+          "",
+          "--dsv4-kv-storage",
+          "bf16",
+          "--dsv4-index-storage",
+          "bf16",
+          "--qwen4-dense-storage",
+          "bf16",
+          "--num-tokens",
+          "131072",
+          "--disable-moe-prefill-overlap",
+          "--moe-preload-all",
+          "--moe-collect-stats",
+          "--moe-cache-size",
+          "24576"
+        ],
+        "environment": {
+          "PYTHONPATH": "/tmp/sparklab-flash-next-bench/python",
+          "SPARKLAB_DISABLE_KERNEL_CACHE": "1",
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_QWEN4_FAST_QSA_METADATA": "0"
+        }
+      },
+      "workloads": {
+        "short": {
+          "aggregation": "median",
+          "warmup_count": 1,
+          "metrics": {
+            "decode_tps": 41.895011841015766,
+            "ttft_s": 0.2423810730688274,
+            "request_s": 3.272878817981109,
+            "output_tps": 39.10930013563943
+          },
+          "last_visible_metrics": {
+            "decode_tps": 41.90081213097168,
+            "ttft_s": 0.2423810730688274,
+            "request_s": 3.272878817981109,
+            "output_tps": 39.10930013563943
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.26095531100872904,
+              "request_s": 3.3109071400249377,
+              "decode_tps": 41.64000191470731,
+              "output_tps": 38.66009966049241,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 41.6484634870755,
+              "after_last_visible_s": 0.0006196480244398117
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.2423810730688274,
+              "request_s": 3.272617676993832,
+              "decode_tps": 41.91091871687493,
+              "output_tps": 39.112420891638806,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 41.917322408595815,
+              "after_last_visible_s": 0.00046292797196656466
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.24149168096482754,
+              "request_s": 3.272878817981109,
+              "decode_tps": 41.895011841015766,
+              "output_tps": 39.10930013563943,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 41.90081213097168,
+              "after_last_visible_s": 0.00041963206604123116
+            }
+          ],
+          "unique_output_hashes": 1
+        },
+        "random1k": {
+          "aggregation": "mean",
+          "warmup_count": 3,
+          "metrics": {
+            "decode_tps": 30.493271795584434,
+            "ttft_s": 2.2133803345883885,
+            "request_s": 10.792312564320552,
+            "output_tps": 24.132910116943652
+          },
+          "last_visible_metrics": {
+            "decode_tps": 30.49545022970591,
+            "ttft_s": 2.2133803345883885,
+            "request_s": 10.792312564320552,
+            "output_tps": 24.132910116943652
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.1269808969227597,
+              "request_s": 8.985268477001227,
+              "decode_tps": 37.181293000997556,
+              "output_tps": 28.491079666151307,
+              "output_sha256": "2c2df7d5cdb1918cff359315001a4b45e2f797b2c1b9069b7132c6cd99a9eca0",
+              "messages_sha256": "fd05fd04bcb2464a7a6497d04f8827e3adbeb3ba5b690d29219eed8807b4678f",
+              "last_visible_decode_tps": 37.18489261158618,
+              "after_last_visible_s": 0.0006639030762016773
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.4867747320095077,
+              "request_s": 9.476812095032074,
+              "decode_tps": 36.48049169936558,
+              "output_tps": 27.01330335906946,
+              "output_sha256": "184c490918b270620d8cad0ed494cad4dab5a00ef592cf4ae3267ded95aaf115",
+              "messages_sha256": "9d3c13b9b3cb989e17e6f087a4b51ae7a9e9b62f7412eba5c17f334a350f66b7",
+              "last_visible_decode_tps": 36.485256241392925,
+              "after_last_visible_s": 0.0009128160309046507
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.0954358120216057,
+              "request_s": 9.546493491041474,
+              "decode_tps": 34.22332922183785,
+              "output_tps": 26.816128900127882,
+              "output_sha256": "126e874af6c05ac4c0684ace73810ef6b2415d87674dab0906950e47b4a66152",
+              "messages_sha256": "46f0d620c4ff493c23434a85f989f05b0b8c79d64a6eceae217ed64da6087dc8",
+              "last_visible_decode_tps": 34.224848166653636,
+              "after_last_visible_s": 0.00033068796619684093
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2138891130452976,
+              "request_s": 9.787094642990269,
+              "decode_tps": 33.67134286686299,
+              "output_tps": 26.156894291744976,
+              "output_sha256": "1e67040cfe6e821adaef80becdf4917747d8ef2d756ea76119691c64863fee31",
+              "messages_sha256": "351c4b87bca15880c9a221c3c7ecc495977504c51c057f808aded026d4dfcbe9",
+              "last_visible_decode_tps": 33.672999748574355,
+              "after_last_visible_s": 0.0003726399736470043
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.241644336958416,
+              "request_s": 9.911346648004837,
+              "decode_tps": 33.24770501623405,
+              "output_tps": 25.828982588509607,
+              "output_sha256": "6e24f2e9c9f98a6b56693ffe8ec9acc146bae58f7db9df5b0c570ba7f5ed7f50",
+              "messages_sha256": "e9d549112d9b6b376a937ce8bd469bc6fdbcfceae8f24b10ed66da75d34976da",
+              "last_visible_decode_tps": 33.251252555367685,
+              "after_last_visible_s": 0.0008182720048353076
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2315807779086754,
+              "request_s": 10.788689932902344,
+              "decode_tps": 29.799783476080794,
+              "output_tps": 23.72855291904117,
+              "output_sha256": "9b79a7de50a49c7868c94d9d2e25a9d8866e9e828084ba882da806f7212ea8e0",
+              "messages_sha256": "5de4e7aa01d3e27586cb1cc310bdc25bcf0a4368ca3b00b4e64fa569f325d4ac",
+              "last_visible_decode_tps": 29.80112626104673,
+              "after_last_visible_s": 0.0003855678951367736
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.227876788005233,
+              "request_s": 11.311575523926876,
+              "decode_tps": 28.072265209721024,
+              "output_tps": 22.63168375249712,
+              "output_sha256": "ab41d8d2363c6192db0c38eef40af54d39409b7adf15f6f27a01011d14903a54",
+              "messages_sha256": "f87053c55701dea335b53fda88cc564c701b28a245a98adf265e7f79f6c280c6",
+              "last_visible_decode_tps": 28.07330119939087,
+              "after_last_visible_s": 0.00033521594014018774
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2415553409373388,
+              "request_s": 10.299078314914368,
+              "decode_tps": 31.647443119127367,
+              "output_tps": 24.856593199148666,
+              "output_sha256": "34f4575e126969971f7a076e368b3284c249bbd35f74a90ce3aa04f06d46fd88",
+              "messages_sha256": "d8069e26b75b5eb4a7153d47aa02e1770237c0858fb83aee5e0c2e4fecc3eddd",
+              "last_visible_decode_tps": 31.650577422606514,
+              "after_last_visible_s": 0.0007979229558259249
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.232955685001798,
+              "request_s": 9.882693549036048,
+              "decode_tps": 33.33447557711741,
+              "output_tps": 25.90386909497665,
+              "output_sha256": "f3e54e6f09e158a7196d88f968bf9e9a7d2aabb7418e6e08fe21d5c3614bb12a",
+              "messages_sha256": "e800a0211fd8d9af8b310dcf013ce7f4ac88c2e8b6122477038335355ecd0b84",
+              "last_visible_decode_tps": 33.33575574434774,
+              "after_last_visible_s": 0.00029376696329652674
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2351757809519768,
+              "request_s": 10.65690761397127,
+              "decode_tps": 30.278807857573327,
+              "output_tps": 24.021977976461244,
+              "output_sha256": "7048a15d1217b83c21db462cd7a49fdf90f8f84fcd94b16ae3af6c787fa6d56f",
+              "messages_sha256": "af91fd95c24d0a5caf0a8c1f146b044709a7925452c9e08339c7d2a3d3e07126",
+              "last_visible_decode_tps": 30.281178993840076,
+              "after_last_visible_s": 0.000659454963169992
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2300511919893324,
+              "request_s": 10.166846371022984,
+              "decode_tps": 32.12883717518935,
+              "output_tps": 25.17988279331513,
+              "output_sha256": "3ade04c90ff24c7e18bf6d363f801b56cdffde1559e17b4005a419fbb714ec3d",
+              "messages_sha256": "91e513cd17e2359a4ac5a2133f044e4ac5243f084a258094630cdc75ee88a217",
+              "last_visible_decode_tps": 32.13141183125379,
+              "after_last_visible_s": 0.0006359670078381896
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.239884080947377,
+              "request_s": 12.476853425963782,
+              "decode_tps": 24.909716089375607,
+              "output_tps": 20.51799370082166,
+              "output_sha256": "2e299f9309ab725c9713f0f37b9b10dee109fd62c851fa9904e102fcf31fa6a2",
+              "messages_sha256": "51f6c369c9a29f7740a6adb17675d09377c0f2f5bf479723bc8ee0f3a0979e86",
+              "last_visible_decode_tps": 24.911283314760837,
+              "after_last_visible_s": 0.0006440309807658195
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.076545459101908,
+              "request_s": 12.051711370004341,
+              "decode_tps": 25.56348458538377,
+              "output_tps": 21.241796466945075,
+              "output_sha256": "fb6df3d6fe8dc764a2ad9cac3f0fab3c9c61592da736b2054c2b5df7ae26c414",
+              "messages_sha256": "00d2c430c3cb9f70f6fdcccdcfd63ba26bc9e97eb77ece7b347e09d676892d68",
+              "last_visible_decode_tps": 25.56548201978938,
+              "after_last_visible_s": 0.0007793609984219074
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2196086049079895,
+              "request_s": 10.722845561918803,
+              "decode_tps": 29.988579794869256,
+              "output_tps": 23.874259730939368,
+              "output_sha256": "bd3b035f5a828f5f070139e4dafa36958cba5d7c6fdd584081fdde065e9c61ae",
+              "messages_sha256": "7eff05f669b0ba36be981ebe122320b91cc0c41ea8392a73598fe03c3443b520",
+              "last_visible_decode_tps": 29.9910563212356,
+              "after_last_visible_s": 0.0007021590135991573
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2437300560995936,
+              "request_s": 11.199257505009882,
+              "decode_tps": 28.474034774024222,
+              "output_tps": 22.85865825350304,
+              "output_sha256": "29a6c2b2f86697ef4544682aa211929f3d9cb1ea6801766e6005233ba429d049",
+              "messages_sha256": "f153493c65b593fe8eefd207868401bb94b351bb371996dbff8d821bb36122c1",
+              "last_visible_decode_tps": 28.47655050907287,
+              "after_last_visible_s": 0.000791167956776917
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.215184638975188,
+              "request_s": 10.122766232001595,
+              "decode_tps": 32.24753320596542,
+              "output_tps": 25.289529969653422,
+              "output_sha256": "b40ab3029b5b1d7aee6c68a3ada8c28b48455326258a4d0734595d2a6df767ec",
+              "messages_sha256": "98d415d7d31c29e3c66e512d7e8fe8ab7fd2e39244e6a020d521306b4e745b70",
+              "last_visible_decode_tps": 32.25015745503425,
+              "after_last_visible_s": 0.0006434530951082706
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.241584411007352,
+              "request_s": 10.582704709027894,
+              "decode_tps": 30.571432959732626,
+              "output_tps": 24.190413229768332,
+              "output_sha256": "35250ff8674ecc5675d7572cf727b607fc71bb06bd663bdeb9e93e2a49f014fd",
+              "messages_sha256": "b30006037dbea53da63a6c437ddb1f4c1c768090f80d6c9eab9d56523d2c9108",
+              "last_visible_decode_tps": 30.57233926405825,
+              "after_last_visible_s": 0.0002472690539434552
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.234573654946871,
+              "request_s": 11.77058843895793,
+              "decode_tps": 26.740730354944077,
+              "output_tps": 21.749125060961195,
+              "output_sha256": "e2f322ad5a813c69e157b42bfa66d282273e6bf5cefe2e0090c49d7bca7781b9",
+              "messages_sha256": "0e5a92b9ae131935a7924a8d24cbcedd36778902a71a8801f2e5289805ad2ba9",
+              "last_visible_decode_tps": 26.741837963269543,
+              "after_last_visible_s": 0.00039496796671301126
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.261011120979674,
+              "request_s": 10.868264263030142,
+              "decode_tps": 29.626176410939447,
+              "output_tps": 23.55481922452128,
+              "output_sha256": "1a0a75b94e37d129cb6057f971891d930d708f8d19e4375116c4075d083c3702",
+              "messages_sha256": "7fb3b0a1c915264a43ba1263fc5140ff27037a6f4ee2e7a1703924aa4941655e",
+              "last_visible_decode_tps": 29.62840946054588,
+              "after_last_visible_s": 0.0006487159989774227
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.101518442039378,
+              "request_s": 9.625858237966895,
+              "decode_tps": 33.8900165218504,
+              "output_tps": 26.595031182806043,
+              "output_sha256": "558d6a25d9d5e80bf9445e7ad70da626224b6850c81eb4125644446a5524e698",
+              "messages_sha256": "8e32fa9923f934b4c306c6fde5ae15ffbaef46f76a3923f49d1e3b2a39a422e1",
+              "last_visible_decode_tps": 33.89297430712385,
+              "after_last_visible_s": 0.000656637013888961
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.202099342015572,
+              "request_s": 10.203029631986283,
+              "decode_tps": 31.871293806877237,
+              "output_tps": 25.090586740770153,
+              "output_sha256": "f06a19db153f82a907a6e53c7805d692c18ee441be486fd2adcb6bc5c45a94d3",
+              "messages_sha256": "3661b9d7092eab8a4bfdd070cbf5225c6b6e2feaae3f4fb820fea65e56903e71",
+              "last_visible_decode_tps": 31.87398772601916,
+              "after_last_visible_s": 0.0006762209814041853
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2171542230062187,
+              "request_s": 19.120112599921413,
+              "decode_tps": 15.086116543259083,
+              "output_tps": 13.389042489271334,
+              "output_sha256": "8f68a84aae05b06f22a9c5e1285209f5b662f308ad8fbdb4bb12c134de054115",
+              "messages_sha256": "aa4ce6ba6413619243e372c8e2137576f4a26fc0a08083ccf80af97f79996ed6",
+              "last_visible_decode_tps": 15.086729928324777,
+              "after_last_visible_s": 0.0006872279336676002
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2182155360933393,
+              "request_s": 10.17130797507707,
+              "decode_tps": 32.06299963899132,
+              "output_tps": 25.16883773721936,
+              "output_sha256": "d8d6021a1fd40efa4f827c74076ce559c2fa9c02721f1b0c447650c5f37774cd",
+              "messages_sha256": "ab85e111bc2209bcf6c4bf1e2494431ee78e4a5e8dd1ab2a64e51d37770524f1",
+              "last_visible_decode_tps": 32.0640969136288,
+              "after_last_visible_s": 0.0002721650525918662
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2336493069306016,
+              "request_s": 11.343259134911932,
+              "decode_tps": 27.992417327988615,
+              "output_tps": 22.568469692461765,
+              "output_sha256": "41f9f3f33cfb90ab9aed5ace4d86d1a73996c1d63cd2cc594a3d5211cf897aad",
+              "messages_sha256": "0ca9a28ad42e11364679587bc1f14925f2dc6dffb683e29b471eb07f501eca75",
+              "last_visible_decode_tps": 27.995757254155993,
+              "after_last_visible_s": 0.0010867869714275002
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.210052714915946,
+              "request_s": 10.804388834978454,
+              "decode_tps": 29.670703639892707,
+              "output_tps": 23.69407505690816,
+              "output_sha256": "1cfe2eee7427647ecabf6cf8aed072ffb890345ae06b6f5bd41c0e7e4040eb5a",
+              "messages_sha256": "c7c5189772f7b8d90cb859882c376ee49597e059591775da303fdd6750667a82",
+              "last_visible_decode_tps": 29.671433085410936,
+              "after_last_visible_s": 0.00021128403022885323
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2046705649700016,
+              "request_s": 10.090577497030608,
+              "decode_tps": 32.336166555971246,
+              "output_tps": 25.370203050849575,
+              "output_sha256": "abccd7d2665017a2ec1cf9d29e9ba3186371850bb5b3b01bc1427f7cb3b8b372",
+              "messages_sha256": "56dbf47b8c9b1c3b6f1f6ddb6d5680f0d5de43e450ed0175e883dd8b980b88f4",
+              "last_visible_decode_tps": 32.338897244326574,
+              "after_last_visible_s": 0.0006658839993178844
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.072107278043404,
+              "request_s": 9.87405826302711,
+              "decode_tps": 32.684132531823714,
+              "output_tps": 25.92652313573827,
+              "output_sha256": "e9126314ddefef9172f92046bf3fd0e1ba17572ab325cb7686834364ebcd491a",
+              "messages_sha256": "cafd5ad01fc944dd68d7db5844123dde9f031d640248bde313b40092f2df11cd",
+              "last_visible_decode_tps": 32.686921767747855,
+              "after_last_visible_s": 0.0006657550111421884
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2077674629399553,
+              "request_s": 10.829700230970047,
+              "decode_tps": 29.575735146710205,
+              "output_tps": 23.638696782013266,
+              "output_sha256": "a955a2b0b1ef26911fc012d55f69fa8de01a04f3d6997cf6a3b0e10b4cae0c1d",
+              "messages_sha256": "382625c6dfde4d48674a27bdf15c746a6eedd6987198d8c680847bc5edb95508",
+              "last_visible_decode_tps": 29.578539901468073,
+              "after_last_visible_s": 0.0008175659459084272
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.221774385077879,
+              "request_s": 10.052888080012053,
+              "decode_tps": 32.56241831413526,
+              "output_tps": 25.465318818081684,
+              "output_sha256": "ab78c2c43b470bc86322b647a861f7a2e19bfa0834dcecb4f72e128e0a87b9d4",
+              "messages_sha256": "e444a05c5f84c1ce785b515593f134bb8eba784671954b707337b8804bf3f439",
+              "last_visible_decode_tps": 32.56493974593975,
+              "after_last_visible_s": 0.0006063459441065788
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "finish_reason": "length",
+              "ttft_s": 2.2163582989014685,
+              "request_s": 11.04639827797655,
+              "decode_tps": 28.878691444691558,
+              "output_tps": 23.17497464403333,
+              "output_sha256": "721a869a6a4f799dec84cbc39462d4b8c4b9911ddc51e4d396b3d0e4cb21a716",
+              "messages_sha256": "06fad65979ff8a446f6ec4594dc530316b847d83368f792a41dc0e0737bcc823",
+              "last_visible_decode_tps": 28.879511933204373,
+              "after_last_visible_s": 0.0002508680336177349
+            }
+          ],
+          "unique_output_hashes": 30
+        },
+        "speedbench8k": {
+          "aggregation": "mean",
+          "warmup_count": 3,
+          "metrics": {
+            "decode_tps": 25.9297914344823,
+            "ttft_s": 23.24384604350974,
+            "request_s": 33.17246030632717,
+            "output_tps": 7.731039827468852
+          },
+          "last_visible_metrics": {
+            "decode_tps": 25.931361466587816,
+            "ttft_s": 23.24384604350974,
+            "request_s": 33.17246030632717,
+            "output_tps": 7.731039827468852
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8383,
+                "completion_tokens": 256,
+                "total_tokens": 8639
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.40018398698885,
+              "request_s": 32.32047690497711,
+              "decode_tps": 28.58650521282529,
+              "output_tps": 7.9206752039162485,
+              "output_sha256": "fa988b392c38318d33f68a9be940130658aed7d2a59d8d9f4de53333013be2ca",
+              "messages_sha256": "7fd8c532b80267873da28f5c5f5fbeb7e0cec4dc80d770525f9cda129189fc2e",
+              "last_visible_decode_tps": 28.58845267620785,
+              "after_last_visible_s": 0.0006076559657230973
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8835,
+                "completion_tokens": 256,
+                "total_tokens": 9091
+              },
+              "finish_reason": "length",
+              "ttft_s": 24.26056378497742,
+              "request_s": 33.78983704803977,
+              "decode_tps": 26.75964818727977,
+              "output_tps": 7.576242514458979,
+              "output_sha256": "1606b13c910a7e0933337a15551c880c2d03b1d9bd8828748b0c2fa57c66ffa2",
+              "messages_sha256": "282594e0313add260dbfd02023efd84f3901194d1caa9b98b7ca43cbbb20788a",
+              "last_visible_decode_tps": 26.760482717449904,
+              "after_last_visible_s": 0.0002971719950437546
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8207,
+                "completion_tokens": 256,
+                "total_tokens": 8463
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.09445384296123,
+              "request_s": 34.08361479896121,
+              "decode_tps": 23.20468332577952,
+              "output_tps": 7.510940418438314,
+              "output_sha256": "ab645328925c4aeeadbd4ff543289c4d724fe3bfaed1721928f3aa8c637582f2",
+              "messages_sha256": "77d166177f5b7493cabb27f8f719a72f2e861e6bbaff8edfff4cef882645cd21",
+              "last_visible_decode_tps": 23.20597706374762,
+              "after_last_visible_s": 0.0006126479711383581
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8519,
+                "completion_tokens": 256,
+                "total_tokens": 8775
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.497697293991223,
+              "request_s": 32.84004213102162,
+              "decode_tps": 27.295074678602376,
+              "output_tps": 7.795361497364684,
+              "output_sha256": "01e36186ffc8bbb8db01f8f294b7927c7b6eab040345d3491690c22a17d618ff",
+              "messages_sha256": "94a90a9e31eddf8e29c23ef67ef98bf74da8a6891864a7f55da038044e9bc34d",
+              "last_visible_decode_tps": 27.29808336468651,
+              "after_last_visible_s": 0.0010296760592609644
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8617,
+                "completion_tokens": 256,
+                "total_tokens": 8873
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.21371929801535,
+              "request_s": 32.72282656293828,
+              "decode_tps": 26.81639746989085,
+              "output_tps": 7.823285054780213,
+              "output_sha256": "9069d7f2a41a0c21ae004450c3d9fb5e640df85f3dfef4c0f5530b5d3fc17b70",
+              "messages_sha256": "479156bb0a995fcb36011dd1ba9769e53af698c18bec4fca793d7cff060f06d5",
+              "last_visible_decode_tps": 26.819128920431616,
+              "after_last_visible_s": 0.000968475011177361
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8229,
+                "completion_tokens": 256,
+                "total_tokens": 8485
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.132277388940565,
+              "request_s": 33.19609829399269,
+              "decode_tps": 25.33828874796329,
+              "output_tps": 7.7117496680724935,
+              "output_sha256": "100dfd8da7bdeb8d7a44cae10d0b1545e56cf41cfa516f9ebee833b198f97d06",
+              "messages_sha256": "fcf30a56fc7f0f09370cb70b6ead8d0e0a3ffec7fab89bfe0dc79245e9b64e6a",
+              "last_visible_decode_tps": 25.33899020286303,
+              "after_last_visible_s": 0.00027859502006322145
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8351,
+                "completion_tokens": 256,
+                "total_tokens": 8607
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.27257026708685,
+              "request_s": 32.25913762010168,
+              "decode_tps": 28.375684505881104,
+              "output_tps": 7.93573600803508,
+              "output_sha256": "fb72b7b2bde1148cfbd5fb8d579eae5805670b0771085ba73e8c12603371fe61",
+              "messages_sha256": "133889404b066c394db6501790a18b9bf2536437cfe137877d4fa33f44cc8b34",
+              "last_visible_decode_tps": 28.376244953625086,
+              "after_last_visible_s": 0.00017749005928635597
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8724,
+                "completion_tokens": 256,
+                "total_tokens": 8980
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.90335563197732,
+              "request_s": 33.67115429404657,
+              "decode_tps": 26.10618920619517,
+              "output_tps": 7.602946954665691,
+              "output_sha256": "f25cd6a9438e304a9ad2d02186d3a03fe48fbeff27895e1aa45ea1b5b440a5e2",
+              "messages_sha256": "0c0700e0f72aa24218555767cf069fe1d0744d201ad4204dce39eef4993fbbb0",
+              "last_visible_decode_tps": 26.106977400594502,
+              "after_last_visible_s": 0.0002948991023004055
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8681,
+                "completion_tokens": 256,
+                "total_tokens": 8937
+              },
+              "finish_reason": "length",
+              "ttft_s": 24.587617316981778,
+              "request_s": 34.146807032986544,
+              "decode_tps": 26.675901156460828,
+              "output_tps": 7.49704063846141,
+              "output_sha256": "afe8c1264a2a4190c99a72953087ee09fcdb623aae2d7ff8f62c6913f253f9e9",
+              "messages_sha256": "4782275289fb3ba557ed853afcf2c8f8cc6faa8c3439687d2d662ea41a6d1b58",
+              "last_visible_decode_tps": 26.676243581792015,
+              "after_last_visible_s": 0.00012270500883460045
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8947,
+                "completion_tokens": 256,
+                "total_tokens": 9203
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.146842074929737,
+              "request_s": 33.8004552309867,
+              "decode_tps": 23.935541516731657,
+              "output_tps": 7.573862489441,
+              "output_sha256": "4590427b35569a13fdb02200468ff29916a2ed2e1059ee2d51ade57efe382463",
+              "messages_sha256": "34579c9c71f809bfc0cd9a1f33eff6c46b879413c4eca50e78efb797d81f8d13",
+              "last_visible_decode_tps": 23.936948015112616,
+              "after_last_visible_s": 0.0006259899819269776
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8742,
+                "completion_tokens": 256,
+                "total_tokens": 8998
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.91343673900701,
+              "request_s": 34.36542562698014,
+              "decode_tps": 24.397270484416875,
+              "output_tps": 7.449347573306805,
+              "output_sha256": "e587f15eb73ae5170413f02314519b58af48d85484c18199240fb49696d365c6",
+              "messages_sha256": "0998562aeda4bccc5e01f8395c3a10fa6bb1d9dcbbc1c1233be2e04ce7ca28cf",
+              "last_visible_decode_tps": 24.397876991166385,
+              "after_last_visible_s": 0.0002598259598016739
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8856,
+                "completion_tokens": 256,
+                "total_tokens": 9112
+              },
+              "finish_reason": "length",
+              "ttft_s": 25.027705574058928,
+              "request_s": 35.99888566194568,
+              "decode_tps": 23.242713906550925,
+              "output_tps": 7.111331234083639,
+              "output_sha256": "973f0f88a03289980491d84c2758baf9a2dbfc5f081d329475e847f485495334",
+              "messages_sha256": "dec5a5907d2be787817df1a28ee684aec5b517dca7a96141237f41cda59126c5",
+              "last_visible_decode_tps": 23.243302538614465,
+              "after_last_visible_s": 0.00027784297708421946
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8983,
+                "completion_tokens": 256,
+                "total_tokens": 9239
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.421957688988186,
+              "request_s": 32.64740934595466,
+              "decode_tps": 24.93777375850892,
+              "output_tps": 7.8413572509612,
+              "output_sha256": "069251a1c7fe8c954bfac0da107445490bf7577281c817da0523388d90444a98",
+              "messages_sha256": "8b6f5647950d97eabfb94f39825bd2db29629b0f9a6e77cebbad6ea72a355e28",
+              "last_visible_decode_tps": 24.93846550510519,
+              "after_last_visible_s": 0.00028363498859107494
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8694,
+                "completion_tokens": 256,
+                "total_tokens": 8950
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.223804648965597,
+              "request_s": 33.939704391988926,
+              "decode_tps": 23.79641524418141,
+              "output_tps": 7.542788146982972,
+              "output_sha256": "17e58fa9c549e0a556085cd4c46ae1ad0268719cdac5ea0c9cffefbd51fbc892",
+              "messages_sha256": "f72986290d0c15f855c3cf8f8a6cac65d7fd57195ceaf6889cb93f2153bcafab",
+              "last_visible_decode_tps": 23.79779545144682,
+              "after_last_visible_s": 0.000621492974460125
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8400,
+                "completion_tokens": 256,
+                "total_tokens": 8656
+              },
+              "finish_reason": "length",
+              "ttft_s": 25.140125834033825,
+              "request_s": 35.91339222795796,
+              "decode_tps": 23.6697015256036,
+              "output_tps": 7.128260075658027,
+              "output_sha256": "9eec4d5cbcf5293d0a1369777db50862fd632257516377684dccd56f15204859",
+              "messages_sha256": "1b46ea66d6c736574840d10f3f4a09e7712df41601c03d8b164abd2e0119a287",
+              "last_visible_decode_tps": 23.6711440322357,
+              "after_last_visible_s": 0.0006565169896930456
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8485,
+                "completion_tokens": 256,
+                "total_tokens": 8741
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.74892473302316,
+              "request_s": 32.22673927398864,
+              "decode_tps": 26.90493667056116,
+              "output_tps": 7.943714001702517,
+              "output_sha256": "57aab0acc30ac6ba8421fb9676f8ef9bf13a7f20d795d3614cc5e83094115081",
+              "messages_sha256": "e84a7d9243f6dd4d7eb4278aee9f04571bf4939febf56491482c908d36c78d3c",
+              "last_visible_decode_tps": 26.907132861506167,
+              "after_last_visible_s": 0.0007735900580883026
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 7908,
+                "completion_tokens": 256,
+                "total_tokens": 8164
+              },
+              "finish_reason": "length",
+              "ttft_s": 20.538364727050066,
+              "request_s": 30.510544428019784,
+              "decode_tps": 25.571139675231002,
+              "output_tps": 8.390541853618934,
+              "output_sha256": "6361ebbabaeb1916093c62e620bd60c037b84c6eece389bc4b38bed258d77611",
+              "messages_sha256": "9be9870e3bd47528e5f0a8bb1b8cd5be6abe6501980681b6f585e2ca722e9ecb",
+              "last_visible_decode_tps": 25.57307643927049,
+              "after_last_visible_s": 0.0007552379975095391
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8221,
+                "completion_tokens": 256,
+                "total_tokens": 8477
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.887486722087488,
+              "request_s": 33.27213809802197,
+              "decode_tps": 24.55547045045153,
+              "output_tps": 7.694125314273663,
+              "output_sha256": "2b3804b4eb4ddd413024bfe9a575d4756fcf68786b595532195e9099444b0688",
+              "messages_sha256": "4ae8ad9b1c31dfdc2264585a8bd0edf0a6fa555a5ad4b752d23fc776ed3e56b0",
+              "last_visible_decode_tps": 24.55717248166809,
+              "after_last_visible_s": 0.0007197490194812417
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8911,
+                "completion_tokens": 256,
+                "total_tokens": 9167
+              },
+              "finish_reason": "length",
+              "ttft_s": 21.84523836709559,
+              "request_s": 31.616594749037176,
+              "decode_tps": 26.09668402549156,
+              "output_tps": 8.09701367373841,
+              "output_sha256": "dfb67a5f7d3d87cdb63a572747d6d01f470d34751c04c98ab09717dcd0cca509",
+              "messages_sha256": "acd9530dcc303861067c63608d56b016430d22b96b93a32601ea7845a46c1920",
+              "last_visible_decode_tps": 26.098721008242332,
+              "after_last_visible_s": 0.0007626459700986743
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8658,
+                "completion_tokens": 256,
+                "total_tokens": 8914
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.182357645011507,
+              "request_s": 33.750433227047324,
+              "decode_tps": 24.129274816454068,
+              "output_tps": 7.585087820290368,
+              "output_sha256": "391b2dd5e08572df2d7dca785383835940449d6d8d609f455238fb3a5bc873fa",
+              "messages_sha256": "8cff09204a3ea3f2e9b18fe64b2d89940b76eabdc83930ca44daa05cf98c3ae0",
+              "last_visible_decode_tps": 24.130870961123588,
+              "after_last_visible_s": 0.0006990289548411965
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8322,
+                "completion_tokens": 256,
+                "total_tokens": 8578
+              },
+              "finish_reason": "length",
+              "ttft_s": 24.21935625805054,
+              "request_s": 35.35230211704038,
+              "decode_tps": 22.90498878103209,
+              "output_tps": 7.241395458560643,
+              "output_sha256": "f0915b49f8fe55169accee2264ec34172a17d59cbe0995a30bbc0af3b6ecd523",
+              "messages_sha256": "e4db7a9f8f2dfd2967796f94016dbec1ebbecb3c20b248f1d5ee5711de1d6f82",
+              "last_visible_decode_tps": 22.906433804882372,
+              "after_last_visible_s": 0.0007023080252110958
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8352,
+                "completion_tokens": 256,
+                "total_tokens": 8608
+              },
+              "finish_reason": "length",
+              "ttft_s": 23.623781822039746,
+              "request_s": 32.08134085405618,
+              "decode_tps": 30.150543322805923,
+              "output_tps": 7.979716345541488,
+              "output_sha256": "ddc2a4c0e1366f2568710adfc96cd86ef7cb7ce52ebe61734e4cf6cc66e19b91",
+              "messages_sha256": "2fa7a4a682b448a2f6f2f67b9be68d4833bc7b24ce93fa2cde1d2e303d8988d6",
+              "last_visible_decode_tps": 30.152838124044624,
+              "after_last_visible_s": 0.0006436679977923632
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8603,
+                "completion_tokens": 256,
+                "total_tokens": 8859
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.351406167028472,
+              "request_s": 32.27344063506462,
+              "decode_tps": 25.70037433567511,
+              "output_tps": 7.9322190309594625,
+              "output_sha256": "8f4090330add2413a58c0885a949cfb2295aa63b8f036ab706a74e37f7d9c4fa",
+              "messages_sha256": "5ab21160fff4bdc672ceb979cc453a1f36e92c7dc039d669fa395f0f017dca79",
+              "last_visible_decode_tps": 25.702101090174498,
+              "after_last_visible_s": 0.000666595995426178
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8814,
+                "completion_tokens": 256,
+                "total_tokens": 9070
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.840409478987567,
+              "request_s": 31.094328554929234,
+              "decode_tps": 30.894414841462176,
+              "output_tps": 8.233012639194538,
+              "output_sha256": "a9a1a6cf39ed8eeaeccc58b1af1109005bd0105bc420c44ebad661a15a94cc51",
+              "messages_sha256": "94372f8fa466fd721fbd64ae4fce462d7d5b61e8215626c7c9d330b15d17987c",
+              "last_visible_decode_tps": 30.896877766759236,
+              "after_last_visible_s": 0.0006579559994861484
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8758,
+                "completion_tokens": 256,
+                "total_tokens": 9014
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.091573145007715,
+              "request_s": 31.944841327960603,
+              "decode_tps": 25.879738099605852,
+              "output_tps": 8.013813478420033,
+              "output_sha256": "8ab67494c9b5cef926ac0ac55b1c5ee041c6485b2be02d35cf98c8be1bd371fe",
+              "messages_sha256": "e93c6b66260b50c8bfa142081d4d5bbef7e00da2616b70a53206ed2b4b959d87",
+              "last_visible_decode_tps": 25.881505012615815,
+              "after_last_visible_s": 0.0006726760184392333
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8685,
+                "completion_tokens": 256,
+                "total_tokens": 8941
+              },
+              "finish_reason": "length",
+              "ttft_s": 24.092255041003227,
+              "request_s": 31.68658765091095,
+              "decode_tps": 33.5776707577071,
+              "output_tps": 8.079128078426592,
+              "output_sha256": "b066e5d3d6d7d7207806f7e285d892398c01df037a352f61893ae732d0e760dd",
+              "messages_sha256": "4d1e0da2e47c86fdecfaa9610f485b706c220804b1966a0f28c9f414249bebf9",
+              "last_visible_decode_tps": 33.58095319823387,
+              "after_last_visible_s": 0.0007423239294430672
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8204,
+                "completion_tokens": 256,
+                "total_tokens": 8460
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.506162269972265,
+              "request_s": 31.348581864964217,
+              "decode_tps": 28.838260530457454,
+              "output_tps": 8.166238622937854,
+              "output_sha256": "527e67eb649f837c5c89d8c8c522b957091a06a0faddcd15147688664fec14c9",
+              "messages_sha256": "39bd55948fc2ee6cc87d59a7f1804ae866422dd0c919a31708bbe91d5d3aeab7",
+              "last_visible_decode_tps": 28.840518881826345,
+              "after_last_visible_s": 0.0006924039917066693
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8817,
+                "completion_tokens": 256,
+                "total_tokens": 9073
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.17684700898826,
+              "request_s": 33.7326786009362,
+              "decode_tps": 22.066780566245285,
+              "output_tps": 7.589080103259133,
+              "output_sha256": "eac315a9b1d6bc63c0fe71bf7c19319198a0325efd90c8e1ee0811497433cf12",
+              "messages_sha256": "9de35e1a23c73b40a6be54e1dd2450091d8178940cbdef973fb05f6010e14f46",
+              "last_visible_decode_tps": 22.068014200582187,
+              "after_last_visible_s": 0.0006459879223257303
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8357,
+                "completion_tokens": 256,
+                "total_tokens": 8613
+              },
+              "finish_reason": "length",
+              "ttft_s": 22.665671435999684,
+              "request_s": 32.62473570695147,
+              "decode_tps": 25.604815177644166,
+              "output_tps": 7.84680686150212,
+              "output_sha256": "a7e68fc8f27b03e9f14579384716922a302bee63720a29f93ca5e89b209e0ec6",
+              "messages_sha256": "ba529d0874e62756a7c07be7bd987cbd5253607bb7c0bebe5ccb688f7c788076",
+              "last_visible_decode_tps": 25.60644423737071,
+              "after_last_visible_s": 0.0006335870129987597
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8331,
+                "completion_tokens": 256,
+                "total_tokens": 8587
+              },
+              "finish_reason": "length",
+              "ttft_s": 24.309235112043098,
+              "request_s": 35.96325492800679,
+              "decode_tps": 21.880862056772948,
+              "output_tps": 7.118376813013026,
+              "output_sha256": "4a1442b4f666e52da7c76dc191a20a1d3ff09bfa9f5e2c388535de7a6ca443f8",
+              "messages_sha256": "9e673d890e321e289f33e819ce9fd33ef15558a7d3eaae97256c87236df9272d",
+              "last_visible_decode_tps": 21.882070514254853,
+              "after_last_visible_s": 0.0006436039693653584
+            }
+          ],
+          "unique_output_hashes": 30
+        }
+      },
+      "passed": true,
+      "telemetry": {
+        "samples": 1545,
+        "duration_s": 1609.2955082799308,
+        "swap_start_bytes": 2399072256,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 2721796096,
+        "swap_growth_bytes": 322723840,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-22789aa0-aba2-4504-97eb-e23bbe599565.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 41033728,
+            "swap_peak_bytes": 87113728,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-22789aa0-aba2-4504-97eb-e23bbe599565.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 41541632,
+            "swap_peak_bytes": 87113728,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": 507904
+          }
+        },
+        "power_w_avg": 40.822556634304206,
+        "power_w_peak": 57.87,
+        "temperature_c_peak": 72.0,
+        "utilization_pct_avg": 77.2537216828479,
+        "request_energy_j_est": 65695.55702808885,
+        "mem_available_gib_min": 23.077831268310547,
+        "nvme_temperature_c_peak": 56.85,
+        "swap_in_pages_delta": 1654,
+        "swap_out_pages_delta": 79339,
+        "page_faults_delta": 38037557,
+        "major_faults_delta": 6842,
+        "oom_kill_delta": 0
+      },
+      "source_commit": "3f259fb04d7d28a4d78b49f96502083e8586012f",
+      "source_checkpoint": {
+        "repository": "nvidia/Qwen3.8-Flash-Next-NVFP4",
+        "revision": "fab0aecb760cec45227f6656abcaafa11abca87a",
+        "ftw_fingerprint": "94e1ee0daa442357"
+      }
+    },
+    "vllm-mia": {
+      "configuration": {
+        "argv": [
+          "docker",
+          "run",
+          "-d",
+          "--name",
+          "qwen38-compare-vllm-mia",
+          "--gpus",
+          "all",
+          "--network",
+          "host",
+          "--ipc",
+          "host",
+          "--cap-add",
+          "SYS_NICE",
+          "--cap-add",
+          "SYS_PTRACE",
+          "--ulimit",
+          "memlock=-1",
+          "--ulimit",
+          "stack=67108864",
+          "--memory",
+          "105g",
+          "--memory-swap",
+          "105g",
+          "-e",
+          "HF_HUB_OFFLINE=1",
+          "-e",
+          "TRANSFORMERS_OFFLINE=1",
+          "-e",
+          "VLLM_PLE_CPU_OFFLOAD=1",
+          "-e",
+          "VLLM_PLE_PACKED_TABLE_DIR=/root/.cache/vllm/ple_cache/Mia-AiLab--Qwen3.8-Flash-Next-NVFP4",
+          "-e",
+          "VLLM_PLE_OFFLOAD_STEP_TIMEOUT=300",
+          "-e",
+          "HF_HOME=/root/.cache/huggingface",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_layer_patched.py:/usr/local/lib/python3.12/dist-packages/vllm/models/qwen3_8_flash_next/nvidia/ple_layer.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/modelopt_patched.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/modelopt.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/qsa_ops_patched.py:/usr/local/lib/python3.12/dist-packages/vllm/models/qwen3_8_flash_next/nvidia/ops/qsa.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/qsa_nvidia_patched.py:/usr/local/lib/python3.12/dist-packages/vllm/models/qwen3_8_flash_next/nvidia/qsa.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/ple_offload_layer.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/ple_offload_layer.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/connector.py:/usr/local/lib/python3.12/dist-packages/vllm/v1/ple_offload/connector.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/worker.py:/usr/local/lib/python3.12/dist-packages/vllm/v1/ple_offload/worker.py:ro",
+          "-v",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/protocol.py:/usr/local/lib/python3.12/dist-packages/vllm/v1/ple_offload/protocol.py:ro",
+          "-v",
+          "$HOME/.cache/huggingface:/root/.cache/huggingface",
+          "-v",
+          "$HOME/.cache/vllm:/root/.cache/vllm",
+          "vllm/vllm-openai@sha256:3b0e188ffceb3d07e09c3cb5215433a0020eacf02d7f882ed3a8bfd15454477e",
+          "/root/.cache/huggingface/hub/models--Mia-AiLab--Qwen3.8-Flash-Next-NVFP4/snapshots/925d7be6c14c6c9442ef83e8f05b5a3c39304f69",
+          "--served-model-name",
+          "qwen3.8-flash-next",
+          "--tensor-parallel-size",
+          "1",
+          "--gpu-memory-utilization",
+          "0.80",
+          "--max-num-seqs",
+          "8",
+          "--max-num-batched-tokens",
+          "8192",
+          "--max-model-len",
+          "12288",
+          "--kv-cache-dtype",
+          "bfloat16",
+          "--load-format",
+          "safetensors",
+          "--safetensors-load-strategy",
+          "lazy",
+          "--enable-chunked-prefill",
+          "--reasoning-parser",
+          "qwen3",
+          "--enable-auto-tool-choice",
+          "--tool-call-parser",
+          "qwen3_coder",
+          "--distributed-executor-backend",
+          "mp",
+          "--speculative-config",
+          "{\"method\":\"mtp\",\"num_speculative_tokens\":3}",
+          "--compilation-config",
+          "{\"mode\":0,\"cudagraph_mode\":\"FULL_DECODE_ONLY\"}",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          "1938",
+          "--no-enable-prefix-caching"
+        ],
+        "checkpoint": "Mia-AiLab/Qwen3.8-Flash-Next-NVFP4",
+        "revision": "925d7be6c14c6c9442ef83e8f05b5a3c39304f69",
+        "adaptation_repository": "https://github.com/MiaAI-Lab/Qwen3.8-Flash-Next-Single-DGX-Spark",
+        "adaptation_local_commit": "5218435fcbfe567c58cc28668be5035ec137d77f",
+        "mounted_patch_sha256": {
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_layer_patched.py": "fae9fd5242748e8cdb314445a25ad628a0ce335cf26f794623f8679497a65186",
+          "$HOME/projects/qwen38-single-spark-optimized/files/modelopt_patched.py": "103e78b948f7cdb1f6421d56ed2da7777f204234b7411086b0c3db97f96224be",
+          "$HOME/projects/qwen38-single-spark-optimized/files/qsa_ops_patched.py": "0669d6334f58a624c89c15f3e46c90f28e59b0b913507101dec1c5765e3c3b12",
+          "$HOME/projects/qwen38-single-spark-optimized/files/qsa_nvidia_patched.py": "ee5de40742ad48a6064ea24b99a285ff69c47d57bbb170f57c4eef71567a1df3",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/ple_offload_layer.py": "8a0906467764b3fc9b88badedafdecb85880360f5380e314c1f3e6194bdd2df4",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/connector.py": "9ca076235bb523128ea774215e2d6a42d1a6bfe45ffa3c91323b08dc99814979",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/worker.py": "711b1a8a593be5fb8552332508268c2c759a96ce88458354f5ff578fde7b412f",
+          "$HOME/projects/qwen38-single-spark-optimized/files/ple_offload/protocol.py": "cf64579ca3cf1daa9ff617a1a8c4690e0db2d1d7412a74e3b8b32629492a05da"
+        },
+        "note": "Existing Spark adaptation, not stock vLLM. Different checkpoint from NVIDIA; BF16 KV selected to match native precision, MTP3, 12K context cap."
+      },
+      "workloads": {
+        "short": {
+          "aggregation": "median",
+          "warmup_count": 1,
+          "metrics": {
+            "decode_tps": 42.13723485850957,
+            "ttft_s": 0.2032929010456428,
+            "request_s": 3.217254316085018,
+            "output_tps": 39.78547774729833
+          },
+          "last_visible_metrics": {
+            "decode_tps": 42.13902963520456,
+            "ttft_s": 0.2032929010456428,
+            "request_s": 3.217254316085018,
+            "output_tps": 39.78547774729833
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "total_tokens": 224,
+                "completion_tokens": 128,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 128
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.20319671498145908,
+              "request_s": 3.2059175439644605,
+              "decode_tps": 42.29497420278459,
+              "output_tps": 39.92616723439315,
+              "output_sha256": "23917e6830bb0b66048e0637e5da4aee05e99a49e711721c10a789ab398572cc",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 42.29614166050844,
+              "after_last_visible_s": 8.288107346787754e-05
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "total_tokens": 224,
+                "completion_tokens": 128,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 128
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.2798144989646971,
+              "request_s": 3.352519372012466,
+              "decode_tps": 41.33166224780665,
+              "output_tps": 38.18024172166485,
+              "output_sha256": "52119b6ad2e18d9e1b9d66ffb6616bcbf00d184b997a2f8083582687189571a8",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 41.33356768958504,
+              "after_last_visible_s": 0.0001416490413248539
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "total_tokens": 224,
+                "completion_tokens": 128,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 128
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.2032929010456428,
+              "request_s": 3.217254316085018,
+              "decode_tps": 42.13723485850957,
+              "output_tps": 39.78547774729833,
+              "output_sha256": "15beb777ac565922ef3d0c1f92f7409e569f2636cc5a9b74c2f0d3de0283fa20",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 42.13902963520456,
+              "after_last_visible_s": 0.00012837001122578684
+            }
+          ],
+          "unique_output_hashes": 3
+        },
+        "random1k": {
+          "aggregation": "mean",
+          "warmup_count": 3,
+          "metrics": {
+            "decode_tps": 33.95663689731476,
+            "ttft_s": 0.7304754995352899,
+            "request_s": 8.314019763403728,
+            "output_tps": 31.04920489977412
+          },
+          "last_visible_metrics": {
+            "decode_tps": 33.95727773056655,
+            "ttft_s": 0.7304754995352899,
+            "request_s": 8.314019763403728,
+            "output_tps": 31.04920489977412
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7564208710100502,
+              "request_s": 7.314997511915863,
+              "decode_tps": 38.88038730988766,
+              "output_tps": 34.9965942685538,
+              "output_sha256": "8ffe9b5bba2db479c6a39cb2d0c4f0a4d2cb99913be1350251e8be682f948b95",
+              "messages_sha256": "fd05fd04bcb2464a7a6497d04f8827e3adbeb3ba5b690d29219eed8807b4678f",
+              "last_visible_decode_tps": 38.88130009219788,
+              "after_last_visible_s": 0.0001539699733248412
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7605485550593585,
+              "request_s": 7.560342782060616,
+              "decode_tps": 37.50113481190684,
+              "output_tps": 33.860898557065916,
+              "output_sha256": "62debab05174296422d1e1b104305c1e5017ffd8a2d2f9c2e9eabd1d159024b7",
+              "messages_sha256": "9d3c13b9b3cb989e17e6f087a4b51ae7a9e9b62f7412eba5c17f334a350f66b7",
+              "last_visible_decode_tps": 37.50197701075388,
+              "after_last_visible_s": 0.00015270605217665434
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7588910079794005,
+              "request_s": 8.419146075029857,
+              "decode_tps": 33.288708765958425,
+              "output_tps": 30.406884227756095,
+              "output_sha256": "9890f59722c81adc480cf6666f1daefd2c7d7319974c49f63cc0fdec69c9fb5a",
+              "messages_sha256": "46f0d620c4ff493c23434a85f989f05b0b8c79d64a6eceae217ed64da6087dc8",
+              "last_visible_decode_tps": 33.289328022195626,
+              "after_last_visible_s": 0.00014249794185250408
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6775562629336491,
+              "request_s": 10.277530067018233,
+              "decode_tps": 26.562572482385622,
+              "output_tps": 24.908708447522155,
+              "output_sha256": "53e8d533a1f1881c3a681b667342821aa5a6e978a0fc52649427d3d89ec0c55c",
+              "messages_sha256": "351c4b87bca15880c9a221c3c7ecc495977504c51c057f808aded026d4dfcbe9",
+              "last_visible_decode_tps": 26.562979829752837,
+              "after_last_visible_s": 0.00014721706975251436
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7622977109858766,
+              "request_s": 8.040029925992712,
+              "decode_tps": 35.038387297925674,
+              "output_tps": 31.84067750449217,
+              "output_sha256": "209ef4b46e465370a9af66759e0adbc4b54e6c875a52a81b61a233a35a4f36ad",
+              "messages_sha256": "e9d549112d9b6b376a937ce8bd469bc6fdbcfceae8f24b10ed66da75d34976da",
+              "last_visible_decode_tps": 35.03913622340381,
+              "after_last_visible_s": 0.0001555540366089403
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7587317100260407,
+              "request_s": 8.210469798068516,
+              "decode_tps": 34.22020433181742,
+              "output_tps": 31.179701807102816,
+              "output_sha256": "86b2e6d00ee6410d39e1e2be52906f72d30f0eaf00c905ecae46871f9b93e7bc",
+              "messages_sha256": "5de4e7aa01d3e27586cb1cc310bdc25bcf0a4368ca3b00b4e64fa569f325d4ac",
+              "last_visible_decode_tps": 34.220923538550224,
+              "after_last_visible_s": 0.00015661003999323242
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7506450299406424,
+              "request_s": 7.975075336988084,
+              "decode_tps": 35.29690081600582,
+              "output_tps": 32.10001024224588,
+              "output_sha256": "9f21c14319c3e5920b0fb24e63f8f432faab51311e295f6c042b4fc5a6dd813c",
+              "messages_sha256": "f87053c55701dea335b53fda88cc564c701b28a245a98adf265e7f79f6c280c6",
+              "last_visible_decode_tps": 35.297566241288365,
+              "after_last_visible_s": 0.00013619405217468739
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6690150980139151,
+              "request_s": 7.421400667051785,
+              "decode_tps": 37.76443116182038,
+              "output_tps": 34.4948361481874,
+              "output_sha256": "75398f925221456a8b35895d7996661a5be3bde199a02fe7caeb668974f9ab3e",
+              "messages_sha256": "d8069e26b75b5eb4a7153d47aa02e1770237c0858fb83aee5e0c2e4fecc3eddd",
+              "last_visible_decode_tps": 37.765346527524656,
+              "after_last_visible_s": 0.00016366597265005112
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.754490889958106,
+              "request_s": 9.341888368944637,
+              "decode_tps": 29.694677651056466,
+              "output_tps": 27.403453123142015,
+              "output_sha256": "f53d373b87b0ba227237a2cfe148f41e97fa1c81056c91254120e146977eb4cc",
+              "messages_sha256": "e800a0211fd8d9af8b310dcf013ce7f4ac88c2e8b6122477038335355ecd0b84",
+              "last_visible_decode_tps": 29.695084368642565,
+              "after_last_visible_s": 0.00011761696077883244
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7545504129957408,
+              "request_s": 9.091701379977167,
+              "decode_tps": 30.58598806833482,
+              "output_tps": 28.157546019251562,
+              "output_sha256": "8567e21d509ec23ad4e06a3bcf187b9508c62b9417dc36d0c8683aa9104656f8",
+              "messages_sha256": "af91fd95c24d0a5caf0a8c1f146b044709a7925452c9e08339c7d2a3d3e07126",
+              "last_visible_decode_tps": 30.586499517947065,
+              "after_last_visible_s": 0.00013940897770226002
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6695008139358833,
+              "request_s": 8.135128180030733,
+              "decode_tps": 34.15654003280188,
+              "output_tps": 31.468465442056853,
+              "output_sha256": "563924c38a6b9f6451ea3aa90d86e9d216f3fd7d5a12554a6d361c2370ed0e43",
+              "messages_sha256": "91e513cd17e2359a4ac5a2133f044e4ac5243f084a258094630cdc75ee88a217",
+              "last_visible_decode_tps": 34.15707779814681,
+              "after_last_visible_s": 0.00011753803119152195
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6799102869117633,
+              "request_s": 8.032912616967224,
+              "decode_tps": 34.67971157273884,
+              "output_tps": 31.86888893317144,
+              "output_sha256": "dda8bd444483bb1b9d3f46738e78b12f8e33084c3f7ad9b8cb532cf4edfa5e91",
+              "messages_sha256": "51f6c369c9a29f7740a6adb17675d09377c0f2f5bf479723bc8ee0f3a0979e86",
+              "last_visible_decode_tps": 34.68026306537179,
+              "after_last_visible_s": 0.00011692894622683525
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7556196869118139,
+              "request_s": 8.512378704966977,
+              "decode_tps": 32.87455487613377,
+              "output_tps": 30.073849962833993,
+              "output_sha256": "a698b2b0ed78970412c83f36130307d431dd9f424ce03f635d65f6405e65fb2f",
+              "messages_sha256": "00d2c430c3cb9f70f6fdcccdcfd63ba26bc9e97eb77ece7b347e09d676892d68",
+              "last_visible_decode_tps": 32.875020408850105,
+              "after_last_visible_s": 0.00010984099935740232
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7572488279547542,
+              "request_s": 9.45554898190312,
+              "decode_tps": 29.31607273683806,
+              "output_tps": 27.07404937460065,
+              "output_sha256": "f75ae1a36df52bce7012744485334cb3df21612c8b6a84ca2bd3150d95fdc38c",
+              "messages_sha256": "7eff05f669b0ba36be981ebe122320b91cc0c41ea8392a73598fe03c3443b520",
+              "last_visible_decode_tps": 29.316477673032885,
+              "after_last_visible_s": 0.00012014596723020077
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6722226410638541,
+              "request_s": 7.0960330290254205,
+              "decode_tps": 39.696065823779364,
+              "output_tps": 36.07649498710964,
+              "output_sha256": "b039fba24e69b421b3353a6c4feb1bcbb0df86d5ec3572776588805194e02508",
+              "messages_sha256": "f153493c65b593fe8eefd207868401bb94b351bb371996dbff8d821bb36122c1",
+              "last_visible_decode_tps": 39.69684298179903,
+              "after_last_visible_s": 0.00012576102744787931
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6605809669708833,
+              "request_s": 7.477338396012783,
+              "decode_tps": 37.40781488183898,
+              "output_tps": 34.23678138420343,
+              "output_sha256": "424012cb5f5fec879c26b954cd7221933bd96a92216a231c17d65f8abd36a158",
+              "messages_sha256": "98d415d7d31c29e3c66e512d7e8fe8ab7fd2e39244e6a020d521306b4e745b70",
+              "last_visible_decode_tps": 37.4086702799463,
+              "after_last_visible_s": 0.00015587406232864254
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7428927089786157,
+              "request_s": 7.937002173974179,
+              "decode_tps": 35.44566582434637,
+              "output_tps": 32.25399141749471,
+              "output_sha256": "ee865ec4ca5c18e308b14bedb549c7195cb0a9664665f146ab6e87fd089bec99",
+              "messages_sha256": "b30006037dbea53da63a6c437ddb1f4c1c768090f80d6c9eab9d56523d2c9108",
+              "last_visible_decode_tps": 35.446206945034795,
+              "after_last_visible_s": 0.00010982505045831203
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7541962370742112,
+              "request_s": 8.686471412074752,
+              "decode_tps": 32.147144970923506,
+              "output_tps": 29.47111523836291,
+              "output_sha256": "e3dff69023ffab1c69c8a9037dcae865dbb26ea915a2a2fee9c1f529700af554",
+              "messages_sha256": "0e5a92b9ae131935a7924a8d24cbcedd36778902a71a8801f2e5289805ad2ba9",
+              "last_visible_decode_tps": 32.14761827288871,
+              "after_last_visible_s": 0.00011678505688905716
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6722251169849187,
+              "request_s": 7.498670515022241,
+              "decode_tps": 37.354726381216686,
+              "output_tps": 34.13938503994141,
+              "output_sha256": "296b5276fa9bc8feabf63b9652c0c5ab49b3aeec9d9ac9bc5c758a7d17c56a36",
+              "messages_sha256": "7fb3b0a1c915264a43ba1263fc5140ff27037a6f4ee2e7a1703924aa4941655e",
+              "last_visible_decode_tps": 37.355383926776256,
+              "after_last_visible_s": 0.00012016203254461288
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7915240980219096,
+              "request_s": 7.722130425972864,
+              "decode_tps": 36.793317631040686,
+              "output_tps": 33.15147321767077,
+              "output_sha256": "4cf28109c1ddc7e66e3eb8329b9c3d2149bcd4e839786c0493ae1b40354e4786",
+              "messages_sha256": "8e32fa9923f934b4c306c6fde5ae15ffbaef46f76a3923f49d1e3b2a39a422e1",
+              "last_visible_decode_tps": 36.793969400265944,
+              "after_last_visible_s": 0.00012276892084628344
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7489134999923408,
+              "request_s": 8.605457136989571,
+              "decode_tps": 32.45702076918152,
+              "output_tps": 29.748564884439823,
+              "output_sha256": "5f742bca2271b6d1a2206fb5e750627c01c0c15957f8e770b59bf22a6e0f9480",
+              "messages_sha256": "3661b9d7092eab8a4bfdd070cbf5225c6b6e2feaae3f4fb820fea65e56903e71",
+              "last_visible_decode_tps": 32.457525647756505,
+              "after_last_visible_s": 0.00012220896314829588
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7502825621049851,
+              "request_s": 8.753602846059948,
+              "decode_tps": 31.861776231950053,
+              "output_tps": 29.245101074608066,
+              "output_sha256": "db0b1e073fc84a20fd0ca8406b6339859c94bf9862582ff6de0629112c2db6d6",
+              "messages_sha256": "aa4ce6ba6413619243e372c8e2137576f4a26fc0a08083ccf80af97f79996ed6",
+              "last_visible_decode_tps": 31.86238328480412,
+              "after_last_visible_s": 0.0001524819526821375
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7524210760602728,
+              "request_s": 7.671861313981935,
+              "decode_tps": 36.852692014374895,
+              "output_tps": 33.368694964993836,
+              "output_sha256": "d558b489b78a672aeeeb924ed63a5434daae2e43606c6094943f6b40d21ee0cf",
+              "messages_sha256": "ab85e111bc2209bcf6c4bf1e2494431ee78e4a5e8dd1ab2a64e51d37770524f1",
+              "last_visible_decode_tps": 36.8533872199348,
+              "after_last_visible_s": 0.00013052893336862326
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7614871900295839,
+              "request_s": 9.679656532010995,
+              "decode_tps": 28.593312172220415,
+              "output_tps": 26.4472193980642,
+              "output_sha256": "1c521ea3c0c64cfa9585c368b9778ad992839c646084fc7f9629408bde07fd15",
+              "messages_sha256": "0ca9a28ad42e11364679587bc1f14925f2dc6dffb683e29b471eb07f501eca75",
+              "last_visible_decode_tps": 28.59384302717646,
+              "after_last_visible_s": 0.00016556901391595602
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7470353960525244,
+              "request_s": 7.933889262960292,
+              "decode_tps": 35.48145053764908,
+              "output_tps": 32.266646472512186,
+              "output_sha256": "c78c13d8d60606cac11c785a36f08d71e1459f600dc25be0280d507d4e94fcc7",
+              "messages_sha256": "c7c5189772f7b8d90cb859882c376ee49597e059591775da303fdd6750667a82",
+              "last_visible_decode_tps": 35.482213467312214,
+              "after_last_visible_s": 0.00015452993102371693
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.731962174992077,
+              "request_s": 7.727847063099034,
+              "decode_tps": 36.449999403721094,
+              "output_tps": 33.12694957725243,
+              "output_sha256": "b345f8d9daa821b2ceb865a377480cabe92a7e0d1435706abaacd1f86f3f0fea",
+              "messages_sha256": "56dbf47b8c9b1c3b6f1f6ddb6d5680f0d5de43e450ed0175e883dd8b980b88f4",
+              "last_visible_decode_tps": 36.45090026042882,
+              "after_last_visible_s": 0.00017289805691689253
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7626362690934911,
+              "request_s": 9.250919397105463,
+              "decode_tps": 30.041410748715585,
+              "output_tps": 27.67292514515912,
+              "output_sha256": "4a5aed8d95977a81df06cce473b3a182a1cd37c1cbd7beb3c71a2bbc7584d358",
+              "messages_sha256": "cafd5ad01fc944dd68d7db5844123dde9f031d640248bde313b40092f2df11cd",
+              "last_visible_decode_tps": 30.04198954748799,
+              "after_last_visible_s": 0.00016353803221136332
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6781449229456484,
+              "request_s": 9.352734228945337,
+              "decode_tps": 29.396204362508772,
+              "output_tps": 27.371674820793864,
+              "output_sha256": "36a1d73d2471e17abf37f56bfbfdf6bb8198c44bd0260699283bfdeacd219fb1",
+              "messages_sha256": "382625c6dfde4d48674a27bdf15c746a6eedd6987198d8c680847bc5edb95508",
+              "last_visible_decode_tps": 29.396773043350123,
+              "after_last_visible_s": 0.00016781000886112452
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.6641178440768272,
+              "request_s": 8.186078216996975,
+              "decode_tps": 33.90073695655549,
+              "output_tps": 31.272606150825712,
+              "output_sha256": "05f0a2be28ee2d8b2d4130487fa4ba53fec06223bb1a13cb02cf680d966c54c0",
+              "messages_sha256": "e444a05c5f84c1ce785b515593f134bb8eba784671954b707337b8804bf3f439",
+              "last_visible_decode_tps": 33.901464714870365,
+              "after_last_visible_s": 0.00016147294081747532
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 0
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7581951169995591,
+              "request_s": 8.052350554964505,
+              "decode_tps": 34.959496293808684,
+              "output_tps": 31.791959161808805,
+              "output_sha256": "5afbe3aafd11e558f6dc4a9e6727e9e94cb22a181308902333f79cd2c7a22201",
+              "messages_sha256": "06fad65979ff8a446f6ec4594dc530316b847d83368f792a41dc0e0737bcc823",
+              "last_visible_decode_tps": 34.96017957950564,
+              "after_last_visible_s": 0.00014256197027862072
+            }
+          ],
+          "unique_output_hashes": 30
+        },
+        "speedbench8k": {
+          "aggregation": "mean",
+          "warmup_count": 3,
+          "metrics": {
+            "decode_tps": 31.13944294577029,
+            "ttft_s": 4.52729104271081,
+            "request_s": 12.788248417635138,
+            "output_tps": 20.10092927046691
+          },
+          "last_visible_metrics": {
+            "decode_tps": 31.139954270433787,
+            "ttft_s": 4.52729104271081,
+            "request_s": 12.788248417635138,
+            "output_tps": 20.10092927046691
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8383,
+                "total_tokens": 8639,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 5.217083240975626,
+              "request_s": 12.774113936931826,
+              "decode_tps": 33.74341196423241,
+              "output_tps": 20.04052893718653,
+              "output_sha256": "9deb1d310cf14bd345811d37a7a79ca2e3572aa93120701608b6f2a54ae9cedb",
+              "messages_sha256": "7fd8c532b80267873da28f5c5f5fbeb7e0cec4dc80d770525f9cda129189fc2e",
+              "last_visible_decode_tps": 33.74389164135204,
+              "after_last_visible_s": 0.00010742491576731794
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8835,
+                "total_tokens": 9091,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.836718094069511,
+              "request_s": 13.659623043029569,
+              "decode_tps": 28.902045468602317,
+              "output_tps": 18.741366375453193,
+              "output_sha256": "45c11b05e8bb422839c72f0361b6b596e346d0489813b8e40bcda54dfc0ca37e",
+              "messages_sha256": "282594e0313add260dbfd02023efd84f3901194d1caa9b98b7ca43cbbb20788a",
+              "last_visible_decode_tps": 28.902409538656666,
+              "after_last_visible_s": 0.0001111379824578762
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8207,
+                "total_tokens": 8463,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.562673881999217,
+              "request_s": 14.067049206001684,
+              "decode_tps": 26.82974854286529,
+              "output_tps": 18.198557227679135,
+              "output_sha256": "86d8e83d9d633ce97735ab4ec6e48f3f7ad1e0380669c3b8959b65f778fefe7d",
+              "messages_sha256": "77d166177f5b7493cabb27f8f719a72f2e861e6bbaff8edfff4cef882645cd21",
+              "last_visible_decode_tps": 26.83017487573021,
+              "after_last_visible_s": 0.0001510250149294734
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8519,
+                "total_tokens": 8775,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.7922967879567295,
+              "request_s": 13.05413795192726,
+              "decode_tps": 30.864790903030435,
+              "output_tps": 19.610640008764822,
+              "output_sha256": "c2633e219ec182b920760907abca83b11dda610413d7cf8074f0486986d744d3",
+              "messages_sha256": "94a90a9e31eddf8e29c23ef67ef98bf74da8a6891864a7f55da038044e9bc34d",
+              "last_visible_decode_tps": 30.865331684000058,
+              "after_last_visible_s": 0.00014475290663540363
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8617,
+                "total_tokens": 8873,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.4404335470171645,
+              "request_s": 12.320733389933594,
+              "decode_tps": 32.359174788154604,
+              "output_tps": 20.77798389900715,
+              "output_sha256": "1e27d3ffc8f052bfc9cd7ac3ac6717e0f221c84347323c956a8de74a10021d02",
+              "messages_sha256": "479156bb0a995fcb36011dd1ba9769e53af698c18bec4fca793d7cff060f06d5",
+              "last_visible_decode_tps": 32.35965875610949,
+              "after_last_visible_s": 0.00011785700917332775
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8229,
+                "total_tokens": 8485,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.742790941032581,
+              "request_s": 13.968554252991453,
+              "decode_tps": 27.639989383800568,
+              "output_tps": 18.326878742313365,
+              "output_sha256": "b9fd3533c5b34898251751c3cf9cb4407908529a4d35be43a9566d939631b2be",
+              "messages_sha256": "fcf30a56fc7f0f09370cb70b6ead8d0e0a3ffec7fab89bfe0dc79245e9b64e6a",
+              "last_visible_decode_tps": 27.640353747869522,
+              "after_last_visible_s": 0.00012161699123680592
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8351,
+                "total_tokens": 8607,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.383398115984164,
+              "request_s": 12.921332650003023,
+              "decode_tps": 29.866708275165223,
+              "output_tps": 19.812197931452534,
+              "output_sha256": "d891c71c89fb500fb61b9d09b1c3fdb80952b722bb8942b666d86aa4fd50e404",
+              "messages_sha256": "133889404b066c394db6501790a18b9bf2536437cfe137877d4fa33f44cc8b34",
+              "last_visible_decode_tps": 29.867237427276393,
+              "after_last_visible_s": 0.0001512649469077587
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8724,
+                "total_tokens": 8980,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.785988850984722,
+              "request_s": 12.438649913063273,
+              "decode_tps": 33.321742323544,
+              "output_tps": 20.581011748802787,
+              "output_sha256": "65d961b8202b1dd39e6c801a803838c10d6c2b58a00111342141631f441af351",
+              "messages_sha256": "0c0700e0f72aa24218555767cf069fe1d0744d201ad4204dce39eef4993fbbb0",
+              "last_visible_decode_tps": 33.322354862907275,
+              "after_last_visible_s": 0.00014067301526665688
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8681,
+                "total_tokens": 8937,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.629914763034321,
+              "request_s": 12.836632987018675,
+              "decode_tps": 31.072103737491034,
+              "output_tps": 19.942924305687136,
+              "output_sha256": "1c9c4b72c940e0502fd3fb9427777f5d4822dd0833bc75a2fb56773a00793f0c",
+              "messages_sha256": "4782275289fb3ba557ed853afcf2c8f8cc6faa8c3439687d2d662ea41a6d1b58",
+              "last_visible_decode_tps": 31.072660591967793,
+              "after_last_visible_s": 0.00014707294758409262
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8947,
+                "total_tokens": 9203,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.438874518033117,
+              "request_s": 13.658443322987296,
+              "decode_tps": 27.658560329087685,
+              "output_tps": 18.742985122554153,
+              "output_sha256": "4e8c5ea3b10269c46c2a672a418a341dc22d0f2e23be3826acd37463d471fa30",
+              "messages_sha256": "34579c9c71f809bfc0cd9a1f33eff6c46b879413c4eca50e78efb797d81f8d13",
+              "last_visible_decode_tps": 27.658991856617323,
+              "after_last_visible_s": 0.00014384102541953325
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8742,
+                "total_tokens": 8998,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.489151734043844,
+              "request_s": 12.889967989991419,
+              "decode_tps": 30.354193239194604,
+              "output_tps": 19.860406185552556,
+              "output_sha256": "d2ff20ce2f3363ceec557921b00b081225c3a452508b924ba6f26f3f67f0b334",
+              "messages_sha256": "0998562aeda4bccc5e01f8395c3a10fa6bb1d9dcbbc1c1233be2e04ce7ca28cf",
+              "last_visible_decode_tps": 30.354639094761204,
+              "after_last_visible_s": 0.00012339302338659763
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8856,
+                "total_tokens": 9112,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.825724661001004,
+              "request_s": 12.82861867302563,
+              "decode_tps": 31.863473340625735,
+              "output_tps": 19.955383079417885,
+              "output_sha256": "12d229bb77eabb8bad3e01482bc87c9237a4cb42cc39fc4d0c682c3defaff7d7",
+              "messages_sha256": "dec5a5907d2be787817df1a28ee684aec5b517dca7a96141237f41cda59126c5",
+              "last_visible_decode_tps": 31.86413785789037,
+              "after_last_visible_s": 0.0001668980112299323
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8983,
+                "total_tokens": 9239,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.33970304694958,
+              "request_s": 12.597001462010667,
+              "decode_tps": 30.88177115349095,
+              "output_tps": 20.32229660145952,
+              "output_sha256": "56238e63725dd27d8ce98611247580ae20b4c33c61438d1609f7b672974530fe",
+              "messages_sha256": "8b6f5647950d97eabfb94f39825bd2db29629b0f9a6e77cebbad6ea72a355e28",
+              "last_visible_decode_tps": 30.882249517650948,
+              "after_last_visible_s": 0.00012790504842996597
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8694,
+                "total_tokens": 8950,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.57506020902656,
+              "request_s": 12.078648685012013,
+              "decode_tps": 33.98374002200469,
+              "output_tps": 21.194423869423552,
+              "output_sha256": "bc6276182131f4d390adae09697ee900b861fe9344cc3bd34c3236dc8d05e1f3",
+              "messages_sha256": "f72986290d0c15f855c3cf8f8a6cac65d7fd57195ceaf6889cb93f2153bcafab",
+              "last_visible_decode_tps": 33.984215976772596,
+              "after_last_visible_s": 0.00010508904233663685
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8400,
+                "total_tokens": 8656,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 5.153401145013049,
+              "request_s": 13.950752087985165,
+              "decode_tps": 28.98599835939366,
+              "output_tps": 18.350265160290203,
+              "output_sha256": "70673aa24eebb5ae084e00e0d0e9c22f08af3a4f686a9bdf06be7920393f1043",
+              "messages_sha256": "1b46ea66d6c736574840d10f3f4a09e7712df41601c03d8b164abd2e0119a287",
+              "last_visible_decode_tps": 28.98639559584699,
+              "after_last_visible_s": 0.00012056098785251379
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8485,
+                "total_tokens": 8741,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.337074387003668,
+              "request_s": 13.186153839924373,
+              "decode_tps": 28.81655672283916,
+              "output_tps": 19.414304057707568,
+              "output_sha256": "bb950223d429a7a74ccc5487e4fdb711c600e004f6239f465514dc36005b0254",
+              "messages_sha256": "e84a7d9243f6dd4d7eb4278aee9f04571bf4939febf56491482c908d36c78d3c",
+              "last_visible_decode_tps": 28.817081101649272,
+              "after_last_visible_s": 0.00016102497465908527
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 7908,
+                "total_tokens": 8164,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 3.789239665027708,
+              "request_s": 12.755450702970847,
+              "decode_tps": 28.440106854600348,
+              "output_tps": 20.069851388346123,
+              "output_sha256": "6f42bda9dc2bd583404e3999e530d607cabf817aef16e3fef63a8b53862b1cb2",
+              "messages_sha256": "9be9870e3bd47528e5f0a8bb1b8cd5be6abe6501980681b6f585e2ca722e9ecb",
+              "last_visible_decode_tps": 28.44055859725518,
+              "after_last_visible_s": 0.00014241703320294619
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8221,
+                "total_tokens": 8477,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.638211566954851,
+              "request_s": 13.381150931934826,
+              "decode_tps": 29.166392371587044,
+              "output_tps": 19.1313887200123,
+              "output_sha256": "516140604aca5a4fe7b26bbd36f78aceb32765ab2b6f0369690c42677e9df06f",
+              "messages_sha256": "4ae8ad9b1c31dfdc2264585a8bd0edf0a6fa555a5ad4b752d23fc776ed3e56b0",
+              "last_visible_decode_tps": 29.16688781848184,
+              "after_last_visible_s": 0.0001485130051150918
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8911,
+                "total_tokens": 9167,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.427394153084606,
+              "request_s": 12.202703962102532,
+              "decode_tps": 32.79612083164159,
+              "output_tps": 20.978956860303203,
+              "output_sha256": "41a996bb1ff1d1093db27fdebb2e18a1eecc063c6ccedd48d9f48ec7258a13b6",
+              "messages_sha256": "acd9530dcc303861067c63608d56b016430d22b96b93a32601ea7845a46c1920",
+              "last_visible_decode_tps": 32.796719867933255,
+              "after_last_visible_s": 0.00014201703015803702
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8658,
+                "total_tokens": 8914,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.461161150014959,
+              "request_s": 12.428940591053106,
+              "decode_tps": 32.00389793505319,
+              "output_tps": 20.597089359673983,
+              "output_sha256": "e9b58f32cfd866b043032be88839d017d61c8a624ea6e7ce031a2406cc9292cc",
+              "messages_sha256": "8cff09204a3ea3f2e9b18fe64b2d89940b76eabdc83930ca44daa05cf98c3ae0",
+              "last_visible_decode_tps": 32.004365806926806,
+              "after_last_visible_s": 0.00011648098006755703
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8322,
+                "total_tokens": 8578,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.402809908031486,
+              "request_s": 12.08912782697007,
+              "decode_tps": 33.17583304376426,
+              "output_tps": 21.17605204147816,
+              "output_sha256": "d4b38aa9a912852f9f9aab32283debbb81e86c1606580af2ce6177cb548f274f",
+              "messages_sha256": "e4db7a9f8f2dfd2967796f94016dbec1ebbecb3c20b248f1d5ee5711de1d6f82",
+              "last_visible_decode_tps": 33.17645645995623,
+              "after_last_visible_s": 0.00014443299733013504
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8352,
+                "total_tokens": 8608,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.487974107963964,
+              "request_s": 13.763347108033486,
+              "decode_tps": 27.492155840858228,
+              "output_tps": 18.60012669814715,
+              "output_sha256": "d89a4921e97ac42e28a8a3e503ee4da143a3bdf2983bd5563359c51287c0fc0d",
+              "messages_sha256": "2fa7a4a682b448a2f6f2f67b9be68d4833bc7b24ce93fa2cde1d2e303d8988d6",
+              "last_visible_decode_tps": 27.49255330958026,
+              "after_last_visible_s": 0.0001340970629826188
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8603,
+                "total_tokens": 8859,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.1797720020404086,
+              "request_s": 12.328108562040143,
+              "decode_tps": 31.294730908857833,
+              "output_tps": 20.7655536704355,
+              "output_sha256": "db6be9f7bca67e86c166222924d4567b43a76f47b8550c2f8dd9ae038ef4487e",
+              "messages_sha256": "5ab21160fff4bdc672ceb979cc453a1f36e92c7dc039d669fa395f0f017dca79",
+              "last_visible_decode_tps": 31.295232352945312,
+              "after_last_visible_s": 0.00013056094758212566
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8814,
+                "total_tokens": 9070,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.424564586021006,
+              "request_s": 11.36499658995308,
+              "decode_tps": 36.741228767248316,
+              "output_tps": 22.525303723039382,
+              "output_sha256": "32325083fa6d71c3c78d1c488f6b9737f5c80a6f5893dcdbd09f2121d972091f",
+              "messages_sha256": "94372f8fa466fd721fbd64ae4fce462d7d5b61e8215626c7c9d330b15d17987c",
+              "last_visible_decode_tps": 36.741914098835146,
+              "after_last_visible_s": 0.00012945698108524084
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8758,
+                "total_tokens": 9014,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.406959914951585,
+              "request_s": 12.665672980016097,
+              "decode_tps": 30.87648135866167,
+              "output_tps": 20.212111934669153,
+              "output_sha256": "35e357de88f210e95478e3d3bd446555ee50095bd72a4a1341a2ce036b5fd5c9",
+              "messages_sha256": "e93c6b66260b50c8bfa142081d4d5bbef7e00da2616b70a53206ed2b4b959d87",
+              "last_visible_decode_tps": 30.877021293666612,
+              "after_last_visible_s": 0.00014441704843193293
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8685,
+                "total_tokens": 8941,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.627365068998188,
+              "request_s": 13.088184950989671,
+              "decode_tps": 30.1389231252585,
+              "output_tps": 19.559625796749028,
+              "output_sha256": "f4b067b4053f1c04c9b840a83e95d3b0ca5bfbb74047c65e8eb5674ba0177128",
+              "messages_sha256": "4d1e0da2e47c86fdecfaa9610f485b706c220804b1966a0f28c9f414249bebf9",
+              "last_visible_decode_tps": 30.13939089240246,
+              "after_last_visible_s": 0.00013131299056112766
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8204,
+                "total_tokens": 8460,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.22323486499954,
+              "request_s": 10.186989527079277,
+              "decode_tps": 42.75829816095654,
+              "output_tps": 25.130093568811006,
+              "output_sha256": "79975e45920146c9fe2913e0647accd27690c6a351c8199002c9df0ea479a29c",
+              "messages_sha256": "39bd55948fc2ee6cc87d59a7f1804ae866422dd0c919a31708bbe91d5d3aeab7",
+              "last_visible_decode_tps": 42.75927258125801,
+              "after_last_visible_s": 0.00013590510934591293
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8817,
+                "total_tokens": 9073,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.231807380099781,
+              "request_s": 13.069064981071278,
+              "decode_tps": 28.855105453977863,
+              "output_tps": 19.58824142130905,
+              "output_sha256": "9b812bbd40a6ba65431deffad7ce4d7d28827cf7a273ab5cec000d1793e3a07a",
+              "messages_sha256": "9de35e1a23c73b40a6be54e1dd2450091d8178940cbdef973fb05f6010e14f46",
+              "last_visible_decode_tps": 28.855519852072437,
+              "after_last_visible_s": 0.00012691307347267866
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8357,
+                "total_tokens": 8613,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.471086413017474,
+              "request_s": 12.317432555020787,
+              "decode_tps": 32.499203499948315,
+              "output_tps": 20.783551998882285,
+              "output_sha256": "cc71ea9e6a53b3228b0e3249df6262e7fe886a9f570a786429c8b61c9b0e8fd0",
+              "messages_sha256": "ba529d0874e62756a7c07be7bd987cbd5253607bb7c0bebe5ccb688f7c788076",
+              "last_visible_decode_tps": 32.499691267755956,
+              "after_last_visible_s": 0.00011776096653282053
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8331,
+                "total_tokens": 8587,
+                "completion_tokens": 256,
+                "completion_tokens_details": {
+                  "reasoning_tokens": 256
+                }
+              },
+              "finish_reason": "length",
+              "ttft_s": 4.496862575993873,
+              "request_s": 12.775867867982015,
+              "decode_tps": 30.800801667172703,
+              "output_tps": 20.03777767939893,
+              "output_sha256": "b006bfc15e537b7da6599f4ff8f9f015fde85d27163e986a5911364ad5c37ebc",
+              "messages_sha256": "9e673d890e321e289f33e819ce9fd33ef15558a7d3eaae97256c87236df9272d",
+              "last_visible_decode_tps": 30.80125978688592,
+              "after_last_visible_s": 0.0001231370260939002
+            }
+          ],
+          "unique_output_hashes": 30
+        }
+      },
+      "passed": true,
+      "version": "0.1.dev20073+g8e685d198",
+      "telemetry": {
+        "samples": 1436,
+        "time_first": 1788991543.5770304,
+        "time_last": 1788992979.7328925,
+        "duration_s": 1436.1558620929718,
+        "host_min_available_gib": 10.866836547851562,
+        "host_swap_start_bytes": 2721755136,
+        "host_swap_end_bytes": 3178766336,
+        "host_swap_growth_bytes": 457011200,
+        "host_swap_in_pages": 168641,
+        "host_swap_out_pages": 242857,
+        "after_server_ready": {
+          "host_min_available_gib": 10.866836547851562,
+          "host_swap_growth_bytes": -38002688,
+          "host_swap_in_pages": 26010,
+          "host_swap_out_pages": 7
+        },
+        "memory_guard": [],
+        "passed": true,
+        "container_state": {
+          "Status": "exited",
+          "Running": false,
+          "Paused": false,
+          "Restarting": false,
+          "OOMKilled": false,
+          "Dead": false,
+          "Pid": 0,
+          "ExitCode": 0,
+          "Error": "",
+          "StartedAt": "2026-09-09T22:05:42.124185059Z",
+          "FinishedAt": "2026-09-09T22:29:39.591246365Z"
+        }
+      }
+    },
+    "sglang-nvidia": {
+      "configuration": {
+        "argv": [
+          "docker",
+          "run",
+          "-d",
+          "--name",
+          "qwen38-compare-sglang-nvidia-2",
+          "--gpus",
+          "all",
+          "--network",
+          "host",
+          "--ipc",
+          "host",
+          "--ulimit",
+          "memlock=-1",
+          "--memory",
+          "105g",
+          "--memory-swap",
+          "105g",
+          "-e",
+          "HF_HUB_OFFLINE=1",
+          "-e",
+          "TRANSFORMERS_OFFLINE=1",
+          "-e",
+          "SGLANG_QWEN4_PLE_FILE_RSS_BUDGET_GB=8",
+          "-v",
+          "$HOME/models/qwen38-nvidia/source/fab0aecb760c:/model:ro",
+          "-v",
+          "$HOME/projects/sparklab/results/qwen38-flash-next-frameworks-20260909/sglang-ple-fresh-2:/ple",
+          "lmsysorg/sglang@sha256:a1e17bbf0e9618364dc6395a4de5f9c3e8dfc9f43d603995b7a6aebc83de6e06",
+          "python3",
+          "-m",
+          "sglang.launch_server",
+          "--model-path",
+          "/model",
+          "--served-model-name",
+          "qwen3.8-flash-next",
+          "--tp",
+          "1",
+          "--moe-runner-backend",
+          "flashinfer_cutlass",
+          "--fp4-gemm-backend",
+          "flashinfer_cutlass",
+          "--page-size",
+          "64",
+          "--chunked-prefill-size",
+          "4096",
+          "--context-length",
+          "12288",
+          "--speculative-algorithm",
+          "NEXTN",
+          "--speculative-num-steps",
+          "3",
+          "--speculative-eagle-topk",
+          "1",
+          "--speculative-num-draft-tokens",
+          "4",
+          "--max-running-requests",
+          "8",
+          "--max-mamba-cache-size",
+          "40",
+          "--mamba-ssm-dtype",
+          "float32",
+          "--kv-cache-dtype",
+          "bf16",
+          "--reasoning-parser",
+          "qwen3",
+          "--mem-fraction-static",
+          "0.85",
+          "--ple-offload-embedding",
+          "--ple-offload-backend",
+          "file",
+          "--ple-offload-dir",
+          "/ple",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          "1938",
+          "--disable-radix-cache"
+        ],
+        "checkpoint": "nvidia/Qwen3.8-Flash-Next-NVFP4",
+        "revision": "fab0aecb760cec45227f6656abcaafa11abca87a",
+        "source_commit": "4ccff141dbe992794f9da6c3aa23535b4f72000d",
+        "version": "0.0.0.dev1+g4ccff141d",
+        "cookbook_overrides": [
+          "12288-token context for matched requests",
+          "BF16 KV and FP32 recurrent state explicit",
+          "loopback listener",
+          "fresh benchmark PLE directory",
+          "offline local pinned snapshot",
+          "Disable prefix reuse for matched prefill measurements"
+        ],
+        "stock_image": true
+      },
+      "workloads": {
+        "short": {
+          "aggregation": "median",
+          "warmup_count": 1,
+          "metrics": {
+            "decode_tps": 35.06674776590496,
+            "ttft_s": 0.30026146199088544,
+            "request_s": 3.9344113749684766,
+            "output_tps": 32.533456164335526
+          },
+          "last_visible_metrics": {
+            "decode_tps": 35.068540910291006,
+            "ttft_s": 0.30026146199088544,
+            "request_s": 3.9344113749684766,
+            "output_tps": 32.533456164335526
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "total_tokens": 224,
+                "completion_tokens": 128,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 131
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.2939118460053578,
+              "request_s": 4.198149723932147,
+              "decode_tps": 32.52875566778707,
+              "output_tps": 30.489622433025165,
+              "output_sha256": "df138e512400120980ca786d402a99a6893958fc1d2a3dba430cfa502250ebcb",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 32.530170119163486,
+              "after_last_visible_s": 0.0001697610132400662
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "total_tokens": 224,
+                "completion_tokens": 128,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 129
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.3127467470476404,
+              "request_s": 3.9344113749684766,
+              "decode_tps": 35.06674776590496,
+              "output_tps": 32.533456164335526,
+              "output_sha256": "689731d381db2ce647c8484b78947d5648ef553b38aa1a2b815e1aed757b54d4",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 35.068540910291006,
+              "after_last_visible_s": 0.00018518499564335045
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 96,
+                "total_tokens": 224,
+                "completion_tokens": 128,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 130
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.30026146199088544,
+              "request_s": 3.7979533299803734,
+              "decode_tps": 36.309659281965565,
+              "output_tps": 33.70236253025823,
+              "output_sha256": "a35c1ad890ba04ff4eb9629c991c31f7dfa31cd872a12e911cc6207efe44c235",
+              "messages_sha256": "0f684df28c2a1d1d0e6b117773cbed161663a8d7d8e58173c25982bdcf7559a3",
+              "last_visible_decode_tps": 36.31127083341356,
+              "after_last_visible_s": 0.0001552330795675516
+            }
+          ],
+          "unique_output_hashes": 3
+        },
+        "random1k": {
+          "aggregation": "mean",
+          "warmup_count": 3,
+          "metrics": {
+            "decode_tps": 28.83115028207287,
+            "ttft_s": 0.815830024133902,
+            "request_s": 9.803951798841203,
+            "output_tps": 26.469355777926555
+          },
+          "last_visible_metrics": {
+            "decode_tps": 30.216428746835394,
+            "ttft_s": 0.815830024133902,
+            "request_s": 9.803951798841203,
+            "output_tps": 26.469355777926555
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7932614319724962,
+              "request_s": 9.792722570011392,
+              "decode_tps": 28.3350298521949,
+              "output_tps": 26.1418617927519,
+              "output_sha256": "cb8b9e3725738ed4f580a51959056f6f136469edf7ea610f4ac356eb252bbfb4",
+              "messages_sha256": "fd05fd04bcb2464a7a6497d04f8827e3adbeb3ba5b690d29219eed8807b4678f",
+              "last_visible_decode_tps": 28.335587079744233,
+              "after_last_visible_s": 0.00017697701696306467
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7853265049634501,
+              "request_s": 8.498338139965199,
+              "decode_tps": 33.06101586088716,
+              "output_tps": 30.123536600186203,
+              "output_sha256": "12bd10c431369a25119f8cd65744de9f6164aaa32aced2599d9a9a2873af65d9",
+              "messages_sha256": "9d3c13b9b3cb989e17e6f087a4b51ae7a9e9b62f7412eba5c17f334a350f66b7",
+              "last_visible_decode_tps": 33.061557468646534,
+              "after_last_visible_s": 0.00012635299936025746
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8183998140739277,
+              "request_s": 10.465217175078578,
+              "decode_tps": 26.43358845278724,
+              "output_tps": 24.46198637995086,
+              "output_sha256": "7e7380f53def2d917c21c87a847118c93a19bd7072ef18f2658af570dd8caa49",
+              "messages_sha256": "46f0d620c4ff493c23434a85f989f05b0b8c79d64a6eceae217ed64da6087dc8",
+              "last_visible_decode_tps": 26.433933585592687,
+              "after_last_visible_s": 0.00012595299631357193
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7881393260322511,
+              "request_s": 9.349839376052842,
+              "decode_tps": 29.783804444233798,
+              "output_tps": 27.380149508843626,
+              "output_sha256": "d9bf25c32ecffb237cc3695296cf1cf217af6be7e4d557b81c1a54e9b9ab9e91",
+              "messages_sha256": "351c4b87bca15880c9a221c3c7ecc495977504c51c057f808aded026d4dfcbe9",
+              "last_visible_decode_tps": 29.78437881022558,
+              "after_last_visible_s": 0.00016510498244315386
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.798345648101531,
+              "request_s": 10.052591126062907,
+              "decode_tps": 27.554920669359003,
+              "output_tps": 25.4660710646313,
+              "output_sha256": "af701013ec6e058bbdaf02057e3251af4c042fb2b9b98df81bdac8b644bfe131",
+              "messages_sha256": "e9d549112d9b6b376a937ce8bd469bc6fdbcfceae8f24b10ed66da75d34976da",
+              "last_visible_decode_tps": 27.55541800263847,
+              "after_last_visible_s": 0.0001670250203460455
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8082427530316636,
+              "request_s": 9.172148091020063,
+              "decode_tps": 30.488149936585724,
+              "output_tps": 27.91058293646995,
+              "output_sha256": "4e315d289a90710e7b4db157c42b798f3676844cf6d5238a0e49d696f25743c4",
+              "messages_sha256": "5de4e7aa01d3e27586cb1cc310bdc25bcf0a4368ca3b00b4e64fa569f325d4ac",
+              "last_visible_decode_tps": 30.488775878768656,
+              "after_last_visible_s": 0.00017171306535601616
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8046136080520228,
+              "request_s": 9.733452280983329,
+              "decode_tps": 28.559145185706935,
+              "output_tps": 26.301048447133027,
+              "output_sha256": "4d8dba6427563fe08543c3186f1704642119c65d4ac5f6751ac16982c41dc93f",
+              "messages_sha256": "f87053c55701dea335b53fda88cc564c701b28a245a98adf265e7f79f6c280c6",
+              "last_visible_decode_tps": 28.559651895741496,
+              "after_last_visible_s": 0.00015841692220419645
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7866604519076645,
+              "request_s": 8.16948769998271,
+              "decode_tps": 34.539613542560836,
+              "output_tps": 31.336114258491605,
+              "output_sha256": "be82e30f68c9c1d5add3eceef99d184cf57394116641288bb91bfd2943b598a3",
+              "messages_sha256": "d8069e26b75b5eb4a7153d47aa02e1770237c0858fb83aee5e0c2e4fecc3eddd",
+              "last_visible_decode_tps": 34.54026920581078,
+              "after_last_visible_s": 0.0001401450717830599
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7756800210336223,
+              "request_s": 9.170465518021956,
+              "decode_tps": 30.375999492956954,
+              "output_tps": 27.915703897136346,
+              "output_sha256": "390ed6ae3f0e98070d590ff78c59066d3b3d73a47e5b9459f8f227cd84f78719",
+              "messages_sha256": "e800a0211fd8d9af8b310dcf013ce7f4ac88c2e8b6122477038335355ecd0b84",
+              "last_visible_decode_tps": 30.37659374233706,
+              "after_last_visible_s": 0.00016422499902546406
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8438729560002685,
+              "request_s": 9.818815878010355,
+              "decode_tps": 28.412436960979417,
+              "output_tps": 26.07239031473465,
+              "output_sha256": "fb08e96fd4bc430742135360aa67331173956f0b1f35243f29a9b1c06cac0b39",
+              "messages_sha256": "af91fd95c24d0a5caf0a8c1f146b044709a7925452c9e08339c7d2a3d3e07126",
+              "last_visible_decode_tps": 28.412970694567512,
+              "after_last_visible_s": 0.00016859301831573248
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8176317240577191,
+              "request_s": 10.031573610031046,
+              "decode_tps": 27.675451305829757,
+              "output_tps": 25.519425959653375,
+              "output_sha256": "dd6ffe3c55f6236ebdb64fa0dee7e83cfa3d34a4b29112fd5404792d3bb46ddb",
+              "messages_sha256": "91e513cd17e2359a4ac5a2133f044e4ac5243f084a258094630cdc75ee88a217",
+              "last_visible_decode_tps": 27.675953047438185,
+              "after_last_visible_s": 0.00016704096924513578
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7949041429674253,
+              "request_s": 14.762535008019768,
+              "decode_tps": 18.2564962135434,
+              "output_tps": 17.341195117297108,
+              "output_sha256": "93991fcb82bba164008245b5cc68b52de5bf2fcead2f048211028c4a64ac89e1",
+              "messages_sha256": "51f6c369c9a29f7740a6adb17675d09377c0f2f5bf479723bc8ee0f3a0979e86",
+              "last_visible_decode_tps": 51.32845447626361,
+              "after_last_visible_s": 8.99962622509338
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7813834729604423,
+              "request_s": 11.679559150943533,
+              "decode_tps": 23.39841158141364,
+              "output_tps": 21.91863551453644,
+              "output_sha256": "dc226f771be97e9f770a3149792055b8ea5e85e384a2617ec7505f148aff8b4e",
+              "messages_sha256": "00d2c430c3cb9f70f6fdcccdcfd63ba26bc9e97eb77ece7b347e09d676892d68",
+              "last_visible_decode_tps": 31.869325825992508,
+              "after_last_visible_s": 2.8967513180105016
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7825864659389481,
+              "request_s": 9.915077915997244,
+              "decode_tps": 27.92228182139412,
+              "output_tps": 25.819262558387255,
+              "output_sha256": "94498577b9cb3de53fc481a74b919b3d4a9e4aab4ddec17d810cc46c76b4f58b",
+              "messages_sha256": "7eff05f669b0ba36be981ebe122320b91cc0c41ea8392a73598fe03c3443b520",
+              "last_visible_decode_tps": 27.922836973529108,
+              "after_last_visible_s": 0.00018156901933252811
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8092780120205134,
+              "request_s": 10.267651761998422,
+              "decode_tps": 26.960237218432564,
+              "output_tps": 24.932672624083423,
+              "output_sha256": "4088d858cf6a99ed4aed4414f4d033983a1063e9e36521b3223df94b80acb378",
+              "messages_sha256": "f153493c65b593fe8eefd207868401bb94b351bb371996dbff8d821bb36122c1",
+              "last_visible_decode_tps": 26.960730693164372,
+              "after_last_visible_s": 0.0001731209922581911
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7762358009349555,
+              "request_s": 9.476179879973643,
+              "decode_tps": 29.310533226803983,
+              "output_tps": 27.01510558500627,
+              "output_sha256": "bf327b7774a65fa80fc1e05b0484e1997aab12be6b4bc5355a414c30f5f68536",
+              "messages_sha256": "98d415d7d31c29e3c66e512d7e8fe8ab7fd2e39244e6a020d521306b4e745b70",
+              "last_visible_decode_tps": 29.311096491911165,
+              "after_last_visible_s": 0.0001671849749982357
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8176592480158433,
+              "request_s": 9.101407360984012,
+              "decode_tps": 30.783166813196395,
+              "output_tps": 28.127518069065108,
+              "output_sha256": "ceed49eadfc94c8c68969de01a7d3e092d3e6dd2ea8dffafe53214043e516ef4",
+              "messages_sha256": "b30006037dbea53da63a6c437ddb1f4c1c768090f80d6c9eab9d56523d2c9108",
+              "last_visible_decode_tps": 30.783789527222755,
+              "after_last_visible_s": 0.00016756891272962093
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8167366470443085,
+              "request_s": 11.881721807061695,
+              "decode_tps": 23.045670311554158,
+              "output_tps": 21.54569886056841,
+              "output_sha256": "645934ad905b43e97acbb1855db4e14f6deb39bf71636d3afe63a65a92c439f5",
+              "messages_sha256": "0e5a92b9ae131935a7924a8d24cbcedd36778902a71a8801f2e5289805ad2ba9",
+              "last_visible_decode_tps": 23.04593960892959,
+              "after_last_visible_s": 0.00012929702643305063
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8278951819520444,
+              "request_s": 8.805693791015074,
+              "decode_tps": 31.963704838363807,
+              "output_tps": 29.072098811931284,
+              "output_sha256": "f54ca23310c68eed4203cae09c38e102736540502e5cfd87b396b20a53eab9a3",
+              "messages_sha256": "7fb3b0a1c915264a43ba1263fc5140ff27037a6f4ee2e7a1703924aa4941655e",
+              "last_visible_decode_tps": 31.964461623771882,
+              "after_last_visible_s": 0.0001888810656964779
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.9391121319495142,
+              "request_s": 8.894608431030065,
+              "decode_tps": 32.05331137285192,
+              "output_tps": 28.78148059974274,
+              "output_sha256": "760bc2f1d6a68f7306a21338b2c1a3900515bc3dd8bd72081417f8a09d4c539b",
+              "messages_sha256": "8e32fa9923f934b4c306c6fde5ae15ffbaef46f76a3923f49d1e3b2a39a422e1",
+              "last_visible_decode_tps": 32.05393264054583,
+              "after_last_visible_s": 0.00015419302508234978
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.7904615700244904,
+              "request_s": 8.819417294929735,
+              "decode_tps": 31.760045607053016,
+              "output_tps": 29.026861008966417,
+              "output_sha256": "0779ecbc4cbd066b5d94db1833300eb0af951802de09147f810d61c9ebaba74a",
+              "messages_sha256": "3661b9d7092eab8a4bfdd070cbf5225c6b6e2feaae3f4fb820fea65e56903e71",
+              "last_visible_decode_tps": 31.760675179244867,
+              "after_last_visible_s": 0.00015915301628410816
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.823769101058133,
+              "request_s": 8.629116963013075,
+              "decode_tps": 32.66990844097142,
+              "output_tps": 29.666998500227894,
+              "output_sha256": "c918862809e7775d27a5314362fa2619caa9ab34979f9c4d5caed3ea05f276aa",
+              "messages_sha256": "aa4ce6ba6413619243e372c8e2137576f4a26fc0a08083ccf80af97f79996ed6",
+              "last_visible_decode_tps": 32.670590876130156,
+              "after_last_visible_s": 0.00016304093878627413
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8413982950150967,
+              "request_s": 9.585130303981714,
+              "decode_tps": 29.163748355793594,
+              "output_tps": 26.708035455048144,
+              "output_sha256": "942afdbc7ffa8a570adce1a2b1a2eb0d989c3d13cd052c18013358bf78f659ca",
+              "messages_sha256": "ab85e111bc2209bcf6c4bf1e2494431ee78e4a5e8dd1ab2a64e51d37770524f1",
+              "last_visible_decode_tps": 29.164310796734345,
+              "after_last_visible_s": 0.00016862503252923489
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8135064649395645,
+              "request_s": 10.252945145010017,
+              "decode_tps": 27.01431818593018,
+              "output_tps": 24.968435545038695,
+              "output_sha256": "bb0e083cadca28980b895b31bc8d6a3b188dbc740f510b6cbea8649b8cdaab63",
+              "messages_sha256": "0ca9a28ad42e11364679587bc1f14925f2dc6dffb683e29b471eb07f501eca75",
+              "last_visible_decode_tps": 27.014878162823297,
+              "after_last_visible_s": 0.0001956650521606207
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8352510069962591,
+              "request_s": 9.874962366069667,
+              "decode_tps": 28.208865291262807,
+              "output_tps": 25.92414943064644,
+              "output_sha256": "3db8aa06be81b623ad0d2ce9616fb290e39346cda1bd332a7f274690eb6cfb61",
+              "messages_sha256": "c7c5189772f7b8d90cb859882c376ee49597e059591775da303fdd6750667a82",
+              "last_visible_decode_tps": 28.20936963429854,
+              "after_last_visible_s": 0.00016161706298589706
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8301357930758968,
+              "request_s": 10.395793311065063,
+              "decode_tps": 26.657864294268037,
+              "output_tps": 24.625345304578055,
+              "output_sha256": "102437269dae024d801a9a3e4b7761c378d113129d51a23eabe815d609f87727",
+              "messages_sha256": "56dbf47b8c9b1c3b6f1f6ddb6d5680f0d5de43e450ed0175e883dd8b980b88f4",
+              "last_visible_decode_tps": 26.658307789648788,
+              "after_last_visible_s": 0.00015913706738501787
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8401466578943655,
+              "request_s": 10.248873744974844,
+              "decode_tps": 27.102497249617464,
+              "output_tps": 24.978354341180182,
+              "output_sha256": "7393bf510b9a998b3f5cef54227652c3b852c7df21f47e4b32919503201d8a12",
+              "messages_sha256": "cafd5ad01fc944dd68d7db5844123dde9f031d640248bde313b40092f2df11cd",
+              "last_visible_decode_tps": 27.10296465032328,
+              "after_last_visible_s": 0.00016225699800997972
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8282030239934102,
+              "request_s": 8.263459698995575,
+              "decode_tps": 34.29605878399965,
+              "output_tps": 30.97976021243461,
+              "output_sha256": "858da8b0c397f68210223bba5090ce5569d42ad42b0d9690c5eb30d7115b5240",
+              "messages_sha256": "382625c6dfde4d48674a27bdf15c746a6eedd6987198d8c680847bc5edb95508",
+              "last_visible_decode_tps": 34.29677239525476,
+              "after_last_visible_s": 0.00015470501966863281
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8516941369744018,
+              "request_s": 8.99879034992773,
+              "decode_tps": 31.299495345908316,
+              "output_tps": 28.448268049944726,
+              "output_sha256": "666ffc546863adfc9001d7f8782d7fa37e2d214af9c932725ddcc2de936e7d14",
+              "messages_sha256": "e444a05c5f84c1ce785b515593f134bb8eba784671954b707337b8804bf3f439",
+              "last_visible_decode_tps": 31.300112815262136,
+              "after_last_visible_s": 0.00016072089783847332
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 1024,
+                "total_tokens": 1280,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 0
+              },
+              "finish_reason": "length",
+              "ttft_s": 0.8543693310348317,
+              "request_s": 10.010978215024807,
+              "decode_tps": 27.84873780574586,
+              "output_tps": 25.571926589130594,
+              "output_sha256": "819c15844bcb6c130e35c1fbe06a9717763802fb4368a45f52b523a9dc57e7ef",
+              "messages_sha256": "06fad65979ff8a446f6ec4594dc530316b847d83368f792a41dc0e0737bcc823",
+              "last_visible_decode_tps": 27.849222832499628,
+              "after_last_visible_s": 0.0001594730420038104
+            }
+          ],
+          "unique_output_hashes": 30
+        },
+        "speedbench8k": {
+          "aggregation": "mean",
+          "warmup_count": 3,
+          "metrics": {
+            "decode_tps": 26.46168341421856,
+            "ttft_s": 10.535570378834382,
+            "request_s": 20.303082975601622,
+            "output_tps": 12.937397689646227
+          },
+          "last_visible_metrics": {
+            "decode_tps": 26.46210548401032,
+            "ttft_s": 10.535570378834382,
+            "request_s": 20.303082975601622,
+            "output_tps": 12.937397689646227
+          },
+          "trials": [
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8383,
+                "total_tokens": 8639,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 6.382230349001475,
+              "request_s": 15.12855247198604,
+              "decode_tps": 29.155111876097315,
+              "output_tps": 16.921645377113396,
+              "output_sha256": "0a27dde57702ac0f7ad5c5727b43e692f831607f9bc83484f9472f725786e790",
+              "messages_sha256": "7fd8c532b80267873da28f5c5f5fbeb7e0cec4dc80d770525f9cda129189fc2e",
+              "last_visible_decode_tps": 29.15561061992416,
+              "after_last_visible_s": 0.00014961697161197662
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8835,
+                "total_tokens": 9091,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 7.222546190954745,
+              "request_s": 17.37702492903918,
+              "decode_tps": 25.11207188249072,
+              "output_tps": 14.732096031708627,
+              "output_sha256": "225acc2b74c8ed4b1ce183945ce26dd8094a4df048e16ba41c4e9ab05477bdaf",
+              "messages_sha256": "282594e0313add260dbfd02023efd84f3901194d1caa9b98b7ca43cbbb20788a",
+              "last_visible_decode_tps": 25.112469073309867,
+              "after_last_visible_s": 0.00016060809139162302
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8207,
+                "total_tokens": 8463,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 8.238348754006438,
+              "request_s": 18.779004812939093,
+              "decode_tps": 24.19204256113649,
+              "output_tps": 13.632245294682022,
+              "output_sha256": "4e45c84da1afdb53639f4a74961293f0c1cd8c11a4b1e90c94ce891dea337cf2",
+              "messages_sha256": "77d166177f5b7493cabb27f8f719a72f2e861e6bbaff8edfff4cef882645cd21",
+              "last_visible_decode_tps": 24.192411844080382,
+              "after_last_visible_s": 0.00016089691780507565
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8519,
+                "total_tokens": 8775,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 257
+              },
+              "finish_reason": "length",
+              "ttft_s": 9.998004486085847,
+              "request_s": 20.06891702802386,
+              "decode_tps": 25.320446279134167,
+              "output_tps": 12.75604456595871,
+              "output_sha256": "fd20c60eb898d5e290dc52e03044c557dc51a85b2ff98c93731ca7e0f2b3bb24",
+              "messages_sha256": "94a90a9e31eddf8e29c23ef67ef98bf74da8a6891864a7f55da038044e9bc34d",
+              "last_visible_decode_tps": 25.32087173667132,
+              "after_last_visible_s": 0.00016921793576329947
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8617,
+                "total_tokens": 8873,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 7.139753213967197,
+              "request_s": 16.74614062497858,
+              "decode_tps": 26.54483825081889,
+              "output_tps": 15.287104398141135,
+              "output_sha256": "5a65286398cad1e67b6adcf35a886d40177ca792b791931f72f07619623c9fc3",
+              "messages_sha256": "479156bb0a995fcb36011dd1ba9769e53af698c18bec4fca793d7cff060f06d5",
+              "last_visible_decode_tps": 26.5453096971488,
+              "after_last_visible_s": 0.00017061003018170595
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8229,
+                "total_tokens": 8485,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 257
+              },
+              "finish_reason": "length",
+              "ttft_s": 11.216025026980788,
+              "request_s": 21.698267979896627,
+              "decode_tps": 24.326854581162593,
+              "output_tps": 11.798176713329521,
+              "output_sha256": "1f60bb94d3452316cb62421b027b8da2a6b071f9ed6a577913130a26883e6cd3",
+              "messages_sha256": "fcf30a56fc7f0f09370cb70b6ead8d0e0a3ffec7fab89bfe0dc79245e9b64e6a",
+              "last_visible_decode_tps": 24.327250905144663,
+              "after_last_visible_s": 0.00017076998483389616
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8351,
+                "total_tokens": 8607,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 9.328199616982602,
+              "request_s": 19.043364882003516,
+              "decode_tps": 26.247623488003633,
+              "output_tps": 13.443002409827624,
+              "output_sha256": "c754f47049a097961a31a45237a7420f8295c3d030d109dd7f7d774b4187e1a4",
+              "messages_sha256": "133889404b066c394db6501790a18b9bf2536437cfe137877d4fa33f44cc8b34",
+              "last_visible_decode_tps": 26.248054045981466,
+              "after_last_visible_s": 0.0001593619817867875
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8724,
+                "total_tokens": 8980,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 12.18739918700885,
+              "request_s": 22.853662787005305,
+              "decode_tps": 23.90715339156673,
+              "output_tps": 11.201705494034101,
+              "output_sha256": "554d83fb04b3ad4b8ff26970643ae50f269f712b188664a46dab65b8f1fd9b6a",
+              "messages_sha256": "0c0700e0f72aa24218555767cf069fe1d0744d201ad4204dce39eef4993fbbb0",
+              "last_visible_decode_tps": 23.907555058293582,
+              "after_last_visible_s": 0.00017920206300914288
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8681,
+                "total_tokens": 8937,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 11.261884045088664,
+              "request_s": 20.213682153029367,
+              "decode_tps": 28.485897126500422,
+              "output_tps": 12.66468909830137,
+              "output_sha256": "d2801ed04b0f4f6aec269c1496ddfc34effc39c66210cd492aeaa2fda2156781",
+              "messages_sha256": "4782275289fb3ba557ed853afcf2c8f8cc6faa8c3439687d2d662ea41a6d1b58",
+              "last_visible_decode_tps": 28.486292230022837,
+              "after_last_visible_s": 0.00012416101526468992
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8947,
+                "total_tokens": 9203,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 8.024351580999792,
+              "request_s": 16.508596485946327,
+              "decode_tps": 30.055709477614013,
+              "output_tps": 15.507072343668423,
+              "output_sha256": "2c00ed80152f5a85be15784e1e1e0c13114b3cf59993a26680fd6e2ef113c494",
+              "messages_sha256": "34579c9c71f809bfc0cd9a1f33eff6c46b879413c4eca50e78efb797d81f8d13",
+              "last_visible_decode_tps": 30.0561565836696,
+              "after_last_visible_s": 0.00012620899360626936
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8742,
+                "total_tokens": 8998,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 257
+              },
+              "finish_reason": "length",
+              "ttft_s": 10.987281279987656,
+              "request_s": 21.086400371044874,
+              "decode_tps": 25.249727001021583,
+              "output_tps": 12.140526381711432,
+              "output_sha256": "252f118363201241a176b5f3a590449cf9c9f7fbf666f28d13dae81118fa94da",
+              "messages_sha256": "0998562aeda4bccc5e01f8395c3a10fa6bb1d9dcbbc1c1233be2e04ce7ca28cf",
+              "last_visible_decode_tps": 25.25010155783854,
+              "after_last_visible_s": 0.00014980905689299107
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8856,
+                "total_tokens": 9112,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 12.670921509969048,
+              "request_s": 22.252841032925062,
+              "decode_tps": 26.61262176008474,
+              "output_tps": 11.504149048709115,
+              "output_sha256": "8cdbfce565a172a0a4f4049ca788686bf555980e95bcc126d1e9f595d9e28e77",
+              "messages_sha256": "dec5a5907d2be787817df1a28ee684aec5b517dca7a96141237f41cda59126c5",
+              "last_visible_decode_tps": 26.61300953767411,
+              "after_last_visible_s": 0.00013961794320493937
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8983,
+                "total_tokens": 9239,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 6.183738837949932,
+              "request_s": 15.62746656499803,
+              "decode_tps": 27.002049124059972,
+              "output_tps": 16.38141402736268,
+              "output_sha256": "581fcedf75bf898f65a8786c8bf5bd5fadf07159d82911cc61be80fb090f42d9",
+              "messages_sha256": "8b6f5647950d97eabfb94f39825bd2db29629b0f9a6e77cebbad6ea72a355e28",
+              "last_visible_decode_tps": 27.002501217630478,
+              "after_last_visible_s": 0.00015811307821422815
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8694,
+                "total_tokens": 8950,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 11.869645104976371,
+              "request_s": 21.146664651925676,
+              "decode_tps": 27.4872763509327,
+              "output_tps": 12.105928013413118,
+              "output_sha256": "2dfac946e4aba66821437b9d0b70bf3d49668ba44dcd8680e2bab3f9c415ed1e",
+              "messages_sha256": "f72986290d0c15f855c3cf8f8a6cac65d7fd57195ceaf6889cb93f2153bcafab",
+              "last_visible_decode_tps": 27.487737635434474,
+              "after_last_visible_s": 0.00015568197704851627
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8400,
+                "total_tokens": 8656,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 14.37171350303106,
+              "request_s": 22.553088968037628,
+              "decode_tps": 31.16835318103755,
+              "output_tps": 11.350994995089353,
+              "output_sha256": "f8ab32666a8b1a6102bc4912e412f1055a4b3f6e419ea23f7a8f02bc5853756f",
+              "messages_sha256": "1b46ea66d6c736574840d10f3f4a09e7712df41601c03d8b164abd2e0119a287",
+              "last_visible_decode_tps": 31.168946468701815,
+              "after_last_visible_s": 0.00015572900883853436
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8485,
+                "total_tokens": 8741,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 8.765406023012474,
+              "request_s": 16.38145089300815,
+              "decode_tps": 33.48194559680224,
+              "output_tps": 15.62743139615702,
+              "output_sha256": "b95e38826a829c7fbc18feb980bfb54df932195dbb4256b25288bbadb083a5c3",
+              "messages_sha256": "e84a7d9243f6dd4d7eb4278aee9f04571bf4939febf56491482c908d36c78d3c",
+              "last_visible_decode_tps": 33.482758327440614,
+              "after_last_visible_s": 0.00018486508633941412
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 7908,
+                "total_tokens": 8164,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 258
+              },
+              "finish_reason": "length",
+              "ttft_s": 9.103288347017951,
+              "request_s": 21.090796050033532,
+              "decode_tps": 21.272144829225187,
+              "output_tps": 12.13799609046018,
+              "output_sha256": "d0ed9606309f4870f37ae45a09fa5b89e74d93018ab51b7f61c79d245969a310",
+              "messages_sha256": "9be9870e3bd47528e5f0a8bb1b8cd5be6abe6501980681b6f585e2ca722e9ecb",
+              "last_visible_decode_tps": 21.272399570840143,
+              "after_last_visible_s": 0.00014355301391333342
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8221,
+                "total_tokens": 8477,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 15.20093382790219,
+              "request_s": 27.47757687198464,
+              "decode_tps": 20.77115047528521,
+              "output_tps": 9.31668761014405,
+              "output_sha256": "6621e2bda691e977553ca60dcca106796e7ad775d9bb1270e2aff87c9e048aa2",
+              "messages_sha256": "4ae8ad9b1c31dfdc2264585a8bd0edf0a6fa555a5ad4b752d23fc776ed3e56b0",
+              "last_visible_decode_tps": 20.771359573839497,
+              "after_last_visible_s": 0.0001235849922540666
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8911,
+                "total_tokens": 9167,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 258
+              },
+              "finish_reason": "length",
+              "ttft_s": 7.848055106005631,
+              "request_s": 16.887849910068326,
+              "decode_tps": 28.208604899460447,
+              "output_tps": 15.158827284897647,
+              "output_sha256": "27441e96214183b44033d56537367e82f2b2d332204daeaa52b17478c61c7323",
+              "messages_sha256": "acd9530dcc303861067c63608d56b016430d22b96b93a32601ea7845a46c1920",
+              "last_visible_decode_tps": 28.20901202035594,
+              "after_last_visible_s": 0.00013046502135694027
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8658,
+                "total_tokens": 8914,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 14.034874276956543,
+              "request_s": 24.20582541602198,
+              "decode_tps": 25.071401534963112,
+              "output_tps": 10.575966553512036,
+              "output_sha256": "73c47d480515b80fcc1d714458c0db5a918acb576ddbad57538ddb83954361fa",
+              "messages_sha256": "8cff09204a3ea3f2e9b18fe64b2d89940b76eabdc83930ca44daa05cf98c3ae0",
+              "last_visible_decode_tps": 25.071726251389283,
+              "after_last_visible_s": 0.00013172905892133713
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8322,
+                "total_tokens": 8578,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 258
+              },
+              "finish_reason": "length",
+              "ttft_s": 11.003862592042424,
+              "request_s": 20.913500905036926,
+              "decode_tps": 25.732523422738716,
+              "output_tps": 12.240896498507503,
+              "output_sha256": "3a98717316e9c7ba3aea408329b1d02e8e10ba3c6bde42fb5c0525ec9c6091b8",
+              "messages_sha256": "e4db7a9f8f2dfd2967796f94016dbec1ebbecb3c20b248f1d5ee5711de1d6f82",
+              "last_visible_decode_tps": 25.732814260814475,
+              "after_last_visible_s": 0.00011200096923857927
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8352,
+                "total_tokens": 8608,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 13.208652656991035,
+              "request_s": 21.919212769018486,
+              "decode_tps": 29.274810887063236,
+              "output_tps": 11.679251563351805,
+              "output_sha256": "6beaff4ac0a99305992789f3900cb6c1777786c39737966cdfdb4972a80d348c",
+              "messages_sha256": "2fa7a4a682b448a2f6f2f67b9be68d4833bc7b24ce93fa2cde1d2e303d8988d6",
+              "last_visible_decode_tps": 29.27534099889366,
+              "after_last_visible_s": 0.0001577290240675211
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8603,
+                "total_tokens": 8859,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 257
+              },
+              "finish_reason": "length",
+              "ttft_s": 12.285454249940813,
+              "request_s": 22.680034884018824,
+              "decode_tps": 24.532014227105783,
+              "output_tps": 11.287460592945864,
+              "output_sha256": "5d862e09bdc566425e8a8f22606b1de9b259448dc248b9217a1b0ba598da4b5b",
+              "messages_sha256": "5ab21160fff4bdc672ceb979cc453a1f36e92c7dc039d669fa395f0f017dca79",
+              "last_visible_decode_tps": 24.532378139968746,
+              "after_last_visible_s": 0.00015419302508234978
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8814,
+                "total_tokens": 9070,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 258
+              },
+              "finish_reason": "length",
+              "ttft_s": 7.176382695091888,
+              "request_s": 15.735128913074732,
+              "decode_tps": 29.794083561470448,
+              "output_tps": 16.26932968990695,
+              "output_sha256": "c01b80598123b00ba724c7621b9c218b5980e6423ee84c9170044b4b1e952b56",
+              "messages_sha256": "94372f8fa466fd721fbd64ae4fce462d7d5b61e8215626c7c9d330b15d17987c",
+              "last_visible_decode_tps": 29.794537399370668,
+              "after_last_visible_s": 0.00013036897871643305
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8758,
+                "total_tokens": 9014,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 257
+              },
+              "finish_reason": "length",
+              "ttft_s": 8.080623134039342,
+              "request_s": 19.28676660405472,
+              "decode_tps": 22.755375270922716,
+              "output_tps": 13.273349818324668,
+              "output_sha256": "643ff746d2dbbe3aa19cebc2590ec1d1679ca9b1208d7b36889587091898cba1",
+              "messages_sha256": "e93c6b66260b50c8bfa142081d4d5bbef7e00da2616b70a53206ed2b4b959d87",
+              "last_visible_decode_tps": 22.755656411198032,
+              "after_last_visible_s": 0.0001384490169584751
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8685,
+                "total_tokens": 8941,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 258
+              },
+              "finish_reason": "length",
+              "ttft_s": 10.443025017040782,
+              "request_s": 18.24418570206035,
+              "decode_tps": 32.68744361203481,
+              "output_tps": 14.031867696407488,
+              "output_sha256": "d1ea960ebb9ce604c1c28947dfdb016af0c802cdba6b596dc7cafe9ed6c52ca4",
+              "messages_sha256": "4d1e0da2e47c86fdecfaa9610f485b706c220804b1966a0f28c9f414249bebf9",
+              "last_visible_decode_tps": 32.6881570173472,
+              "after_last_visible_s": 0.00017025705892592669
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8204,
+                "total_tokens": 8460,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 259
+              },
+              "finish_reason": "length",
+              "ttft_s": 15.200074121006764,
+              "request_s": 24.08491774101276,
+              "decode_tps": 28.700561417402632,
+              "output_tps": 10.629058515075307,
+              "output_sha256": "2776be239bd5b7c7ce68dd106d422c1c7bee802ff5d63b9e1218fa4716b27979",
+              "messages_sha256": "39bd55948fc2ee6cc87d59a7f1804ae866422dd0c919a31708bbe91d5d3aeab7",
+              "last_visible_decode_tps": 28.701068971668427,
+              "after_last_visible_s": 0.00015712098684161901
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8817,
+                "total_tokens": 9073,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 258
+              },
+              "finish_reason": "length",
+              "ttft_s": 8.084457755903713,
+              "request_s": 18.77520564792212,
+              "decode_tps": 23.85240046586265,
+              "output_tps": 13.635003781081455,
+              "output_sha256": "1fed2980c9acc19320906d6a2ef8ac7f0710880e930574e4599d7b9187a8dfbc",
+              "messages_sha256": "9de35e1a23c73b40a6be54e1dd2450091d8178940cbdef973fb05f6010e14f46",
+              "last_visible_decode_tps": 23.85270001388293,
+              "after_last_visible_s": 0.00013425701763480902
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8357,
+                "total_tokens": 8613,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 10.583155650063418,
+              "request_s": 21.324426886974834,
+              "decode_tps": 23.74020675725191,
+              "output_tps": 12.005011968521755,
+              "output_sha256": "6905d1ed46830c5757b41decdf1003eb9aadda80d4b7dfa5ef8223e4691c371d",
+              "messages_sha256": "ba529d0874e62756a7c07be7bd987cbd5253607bb7c0bebe5ccb688f7c788076",
+              "last_visible_decode_tps": 23.74060276066597,
+              "after_last_visible_s": 0.00017916900105774403
+            },
+            {
+              "http_status": 200,
+              "usage": {
+                "prompt_tokens": 8331,
+                "total_tokens": 8587,
+                "completion_tokens": 256,
+                "prompt_tokens_details": null,
+                "reasoning_tokens": 256
+              },
+              "finish_reason": "length",
+              "ttft_s": 17.96682322502602,
+              "request_s": 29.00193432997912,
+              "decode_tps": 23.10805913730614,
+              "output_tps": 8.826997437042479,
+              "output_sha256": "8c681f2ed7368921c38473a08f017bb7e13ef6cfd437e93fb466c34b259f2341",
+              "messages_sha256": "9e673d890e321e289f33e819ce9fd33ef15558a7d3eaae97256c87236df9272d",
+              "last_visible_decode_tps": 23.108374591107868,
+              "after_last_visible_s": 0.00015064096078276634
+            }
+          ],
+          "unique_output_hashes": 30
+        }
+      },
+      "passed": true,
+      "operational_notes": [
+        "The startup compiler emitted a data-race warning for Logits(bx, position); no quality-parity claim is made from these speed requests."
+      ],
+      "telemetry": {
+        "samples": 1757,
+        "time_first": 1788993087.2319438,
+        "time_last": 1788994844.8511515,
+        "duration_s": 1757.6192076206207,
+        "host_min_available_gib": 16.841102600097656,
+        "host_swap_start_bytes": 3158519808,
+        "host_swap_end_bytes": 3177025536,
+        "host_swap_growth_bytes": 18505728,
+        "host_swap_in_pages": 168018,
+        "host_swap_out_pages": 103035,
+        "after_server_ready": {
+          "host_min_available_gib": 16.841102600097656,
+          "host_swap_growth_bytes": -86855680,
+          "host_swap_in_pages": 54541,
+          "host_swap_out_pages": 604
+        },
+        "memory_guard": [],
+        "passed": true,
+        "container_state": {
+          "Status": "exited",
+          "Running": false,
+          "Paused": false,
+          "Restarting": false,
+          "OOMKilled": false,
+          "Dead": false,
+          "Pid": 0,
+          "ExitCode": 0,
+          "Error": "",
+          "StartedAt": "2026-09-09T22:31:25.960519686Z",
+          "FinishedAt": "2026-09-09T23:00:44.656671635Z"
+        }
+      }
+    }
+  },
+  "validation": {
+    "raw_metric": "last-visible-token decode window",
+    "reported_metric": "stream-completion decode window",
+    "suite_sha256": "38316b0c391b4dc37c57923315389d69663a98aa90b20a5c8b1e04dc6f15f7fb",
+    "all_profiles_complete": true,
+    "profiles": {
+      "native-fast": {
+        "short": {
+          "passed": true,
+          "measured_requests": 3,
+          "warmup_requests": 1,
+          "prompt_tokens": [
+            96,
+            96,
+            96
+          ],
+          "output_counts": [
+            128
+          ],
+          "metrics": {
+            "decode_tps": 41.90081213097168,
+            "ttft_s": 0.2423810730688274,
+            "request_s": 3.272878817981109,
+            "output_tps": 39.10930013563943
+          },
+          "decode_tps_stdev": 0.15068595766501214,
+          "ttft_stdev_s": 0.010989587707223934,
+          "stream_completion_metrics": {
+            "decode_tps": 41.895011841015766,
+            "ttft_s": 0.2423810730688274,
+            "request_s": 3.272878817981109,
+            "output_tps": 39.10930013563943
+          },
+          "stream_completion_decode_tps_stdev": 0.15203015321100538,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.0006196480244398117
+        },
+        "random1k": {
+          "passed": true,
+          "measured_requests": 30,
+          "warmup_requests": 3,
+          "prompt_tokens": [
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024
+          ],
+          "output_counts": [
+            256
+          ],
+          "metrics": {
+            "decode_tps": 30.49545022970591,
+            "ttft_s": 2.2133803345883885,
+            "request_s": 10.792312564320552,
+            "output_tps": 24.132910116943652
+          },
+          "decode_tps_stdev": 4.0879933582619294,
+          "ttft_stdev_s": 0.07347017024878232,
+          "stream_completion_metrics": {
+            "decode_tps": 30.493271795584434,
+            "ttft_s": 2.2133803345883885,
+            "request_s": 10.792312564320552,
+            "output_tps": 24.132910116943652
+          },
+          "stream_completion_decode_tps_stdev": 4.087453210052313,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.0010867869714275002
+        },
+        "speedbench8k": {
+          "passed": true,
+          "measured_requests": 30,
+          "warmup_requests": 3,
+          "prompt_tokens": [
+            8383,
+            8835,
+            8207,
+            8519,
+            8617,
+            8229,
+            8351,
+            8724,
+            8681,
+            8947,
+            8742,
+            8856,
+            8983,
+            8694,
+            8400,
+            8485,
+            7908,
+            8221,
+            8911,
+            8658,
+            8322,
+            8352,
+            8603,
+            8814,
+            8758,
+            8685,
+            8204,
+            8817,
+            8357,
+            8331
+          ],
+          "output_counts": [
+            256
+          ],
+          "metrics": {
+            "decode_tps": 25.931361466587816,
+            "ttft_s": 23.24384604350974,
+            "request_s": 33.17246030632717,
+            "output_tps": 7.731039827468852
+          },
+          "decode_tps_stdev": 2.660536664360749,
+          "ttft_stdev_s": 0.9864186949163333,
+          "stream_completion_metrics": {
+            "decode_tps": 25.9297914344823,
+            "ttft_s": 23.24384604350974,
+            "request_s": 33.17246030632717,
+            "output_tps": 7.731039827468852
+          },
+          "stream_completion_decode_tps_stdev": 2.6601071363544513,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.0010296760592609644
+        }
+      },
+      "vllm-mia": {
+        "short": {
+          "passed": true,
+          "measured_requests": 3,
+          "warmup_requests": 1,
+          "prompt_tokens": [
+            96,
+            96,
+            96
+          ],
+          "output_counts": [
+            128
+          ],
+          "metrics": {
+            "decode_tps": 42.13902963520456,
+            "ttft_s": 0.2032929010456428,
+            "request_s": 3.217254316085018,
+            "output_tps": 39.78547774729833
+          },
+          "decode_tps_stdev": 0.5163980673594604,
+          "ttft_stdev_s": 0.04420755784242194,
+          "stream_completion_metrics": {
+            "decode_tps": 42.13723485850957,
+            "ttft_s": 0.2032929010456428,
+            "request_s": 3.217254316085018,
+            "output_tps": 39.78547774729833
+          },
+          "stream_completion_decode_tps_stdev": 0.5166879868370686,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.0001416490413248539
+        },
+        "random1k": {
+          "passed": true,
+          "measured_requests": 30,
+          "warmup_requests": 3,
+          "prompt_tokens": [
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024
+          ],
+          "output_counts": [
+            256
+          ],
+          "metrics": {
+            "decode_tps": 33.95727773056655,
+            "ttft_s": 0.7304754995352899,
+            "request_s": 8.314019763403728,
+            "output_tps": 31.04920489977412
+          },
+          "decode_tps_stdev": 3.3305384540954166,
+          "ttft_stdev_s": 0.040459832461066915,
+          "stream_completion_metrics": {
+            "decode_tps": 33.95663689731476,
+            "ttft_s": 0.7304754995352899,
+            "request_s": 8.314019763403728,
+            "output_tps": 31.04920489977412
+          },
+          "stream_completion_decode_tps_stdev": 3.330415509959143,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.00017289805691689253
+        },
+        "speedbench8k": {
+          "passed": true,
+          "measured_requests": 30,
+          "warmup_requests": 3,
+          "prompt_tokens": [
+            8383,
+            8835,
+            8207,
+            8519,
+            8617,
+            8229,
+            8351,
+            8724,
+            8681,
+            8947,
+            8742,
+            8856,
+            8983,
+            8694,
+            8400,
+            8485,
+            7908,
+            8221,
+            8911,
+            8658,
+            8322,
+            8352,
+            8603,
+            8814,
+            8758,
+            8685,
+            8204,
+            8817,
+            8357,
+            8331
+          ],
+          "output_counts": [
+            256
+          ],
+          "metrics": {
+            "decode_tps": 31.139954270433787,
+            "ttft_s": 4.52729104271081,
+            "request_s": 12.788248417635138,
+            "output_tps": 20.10092927046691
+          },
+          "decode_tps_stdev": 3.155709998807968,
+          "ttft_stdev_s": 0.28084021627226957,
+          "stream_completion_metrics": {
+            "decode_tps": 31.13944294577029,
+            "ttft_s": 4.52729104271081,
+            "request_s": 12.788248417635138,
+            "output_tps": 20.10092927046691
+          },
+          "stream_completion_decode_tps_stdev": 3.1556074398787923,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.0001668980112299323
+        }
+      },
+      "sglang-nvidia": {
+        "short": {
+          "passed": true,
+          "measured_requests": 3,
+          "warmup_requests": 1,
+          "prompt_tokens": [
+            96,
+            96,
+            96
+          ],
+          "output_counts": [
+            128
+          ],
+          "metrics": {
+            "decode_tps": 35.068540910291006,
+            "ttft_s": 0.30026146199088544,
+            "request_s": 3.9344113749684766,
+            "output_tps": 32.533456164335526
+          },
+          "decode_tps_stdev": 1.9271925412533792,
+          "ttft_stdev_s": 0.009582566317577926,
+          "stream_completion_metrics": {
+            "decode_tps": 35.06674776590496,
+            "ttft_s": 0.30026146199088544,
+            "request_s": 3.9344113749684766,
+            "output_tps": 32.533456164335526
+          },
+          "stream_completion_decode_tps_stdev": 1.9270644802640864,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.00018518499564335045
+        },
+        "random1k": {
+          "passed": true,
+          "measured_requests": 30,
+          "warmup_requests": 3,
+          "prompt_tokens": [
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024,
+            1024
+          ],
+          "output_counts": [
+            256
+          ],
+          "metrics": {
+            "decode_tps": 30.216428746835394,
+            "ttft_s": 0.815830024133902,
+            "request_s": 9.803951798841203,
+            "output_tps": 26.469355777926555
+          },
+          "decode_tps_stdev": 4.760930270553997,
+          "ttft_stdev_s": 0.032751253519852065,
+          "stream_completion_metrics": {
+            "decode_tps": 28.83115028207287,
+            "ttft_s": 0.815830024133902,
+            "request_s": 9.803951798841203,
+            "output_tps": 26.469355777926555
+          },
+          "stream_completion_decode_tps_stdev": 3.4283073259672223,
+          "after_last_visible_over_100ms_count": 2,
+          "after_last_visible_max_s": 8.99962622509338
+        },
+        "speedbench8k": {
+          "passed": true,
+          "measured_requests": 30,
+          "warmup_requests": 3,
+          "prompt_tokens": [
+            8383,
+            8835,
+            8207,
+            8519,
+            8617,
+            8229,
+            8351,
+            8724,
+            8681,
+            8947,
+            8742,
+            8856,
+            8983,
+            8694,
+            8400,
+            8485,
+            7908,
+            8221,
+            8911,
+            8658,
+            8322,
+            8352,
+            8603,
+            8814,
+            8758,
+            8685,
+            8204,
+            8817,
+            8357,
+            8331
+          ],
+          "output_counts": [
+            256
+          ],
+          "metrics": {
+            "decode_tps": 26.46210548401032,
+            "ttft_s": 10.535570378834382,
+            "request_s": 20.303082975601622,
+            "output_tps": 12.937397689646227
+          },
+          "decode_tps_stdev": 3.1541746887211475,
+          "ttft_stdev_s": 2.960435126214052,
+          "stream_completion_metrics": {
+            "decode_tps": 26.46168341421856,
+            "ttft_s": 10.535570378834382,
+            "request_s": 20.303082975601622,
+            "output_tps": 12.937397689646227
+          },
+          "stream_completion_decode_tps_stdev": 3.1540627256932217,
+          "after_last_visible_over_100ms_count": 0,
+          "after_last_visible_max_s": 0.00018486508633941412
+        }
+      }
+    },
+    "paired_comparison": {
+      "vllm-mia": {
+        "short": {
+          "same_prompt_token_counts": true,
+          "same_output_text_count": 0,
+          "trials": 3
+        },
+        "random1k": {
+          "same_prompt_token_counts": true,
+          "same_output_text_count": 0,
+          "trials": 30
+        },
+        "speedbench8k": {
+          "same_prompt_token_counts": true,
+          "same_output_text_count": 0,
+          "trials": 30
+        }
+      },
+      "sglang-nvidia": {
+        "short": {
+          "same_prompt_token_counts": true,
+          "same_output_text_count": 0,
+          "trials": 3
+        },
+        "random1k": {
+          "same_prompt_token_counts": true,
+          "same_output_text_count": 0,
+          "trials": 30
+        },
+        "speedbench8k": {
+          "same_prompt_token_counts": true,
+          "same_output_text_count": 0,
+          "trials": 30
+        }
+      }
+    }
+  },
+  "published_reference": {
+    "url": "https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next",
+    "retrieved": "2026-09-09",
+    "requested_h200_cell": {
+      "quantization": "bf16",
+      "strategy": "low-latency",
+      "nodes": 1,
+      "tensor_parallel_size": 4,
+      "speed_entries": [],
+      "gsm8k_percent": 97.73,
+      "aime26_percent": 97.92
+    },
+    "spark_random1024_256_c1": {
+      "mtp": {
+        "ttft_ms": 650.03,
+        "tpot_ms": 33.26,
+        "decode_tps_derived": 30.06614552014432
+      },
+      "no_mtp": {
+        "ttft_ms": 604.33,
+        "tpot_ms": 63.54,
+        "decode_tps_derived": 15.738117721120554
+      }
+    },
+    "warning": "Reference uses different random inputs/protocol. Combined input+output throughput must not be compared with output decode rate."
+  },
+  "source": {
+    "raw_directory": "results/qwen38-flash-next-frameworks-20260909",
+    "suite_sha256": "38316b0c391b4dc37c57923315389d69663a98aa90b20a5c8b1e04dc6f15f7fb",
+    "source_checkpoint_validation": {
+      "passed": true,
+      "indexed_tensors": 299545,
+      "indexed_files": 11,
+      "publisher_sha256_verified_files": 11,
+      "total_verified_bytes": 132680249378,
+      "all_indexed_files_present_and_verified": true
+    },
+    "raw_manifest_sha256": "20aa1004b292c99e2cf536f82ca0a57a1da3be31eafc5832824b49c0071a1444",
+    "raw_manifest_entries": 89
+  },
+  "limitations": [
+    "vLLM uses the existing Mia Spark adaptation and a different quantized checkpoint; this is not stock vLLM on the NVIDIA weights.",
+    "SparkLab uses the published opt-in fast MTP3 profile, not the target-only default. Historical MGSM tuning subset was 92/100 versus 94/100 for the original profile; no new quality or parity evaluation was run.",
+    "Same NVIDIA source for SparkLab/SGLang does not guarantee identical activation quantization, recurrent-state execution, outputs, or quality.",
+    "SparkLab short measured repeats reuse 64 of 96 prompt tokens; vLLM/SGLang prefix reuse is disabled. Short TTFT is not a matched uncached comparison. All native 1K/8K prefill batches report zero cached tokens.",
+    "Host was not isolated: SGLang image pull overlapped native short/1K/early8K, background source download resumed during native8K. Source recovery ended before vLLM measurement.",
+    "Pre-existing host swap and additional swap traffic were observed; these measurements do not certify zero-swap deployment.",
+    "Context limit and BF16 KV precision are common, but framework KV pool capacity, page sizes, kernels, scheduling, and MTP execution differ.",
+    "Single client only; these results do not measure concurrent serving capacity.",
+    "Fixed output budgets measure speed, not completed-answer accuracy.",
+    "Primary decode timing ends at stream completion. The original last-visible-token metric inflated some SGLang random1k requests with invisible trailing generation; both metrics and tail durations are retained."
+  ],
+  "path_notation": "Published paths replace the benchmark host home directory with $HOME; expand that placeholder to reproduce commands. Raw local evidence retains the original paths."
+}

--- a/benchmarks/gb10/results/GB10-QWENNVIDIA-006.json
+++ b/benchmarks/gb10/results/GB10-QWENNVIDIA-006.json
@@ -1,0 +1,3584 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWENNVIDIA-006",
+  "status": "measured",
+  "date": "2026-09-10",
+  "model": "qwen3.8-flash-next",
+  "hardware": {
+    "platform": "NVIDIA DGX Spark GB10",
+    "gpus": 1,
+    "physical_memory_bytes": 130663591936,
+    "machine": "aarch64"
+  },
+  "checkpoint": {
+    "repository": "nvidia/Qwen3.8-Flash-Next-NVFP4",
+    "revision": "fab0aecb760cec45227f6656abcaafa11abca87a",
+    "ftw_fingerprint": "94e1ee0daa442357"
+  },
+  "changes": [
+    "Batch large PLE cache misses into 512-row I/O jobs on the existing 16-worker pool; preserve row bytes, scaling, cache insertion order, and small decode lookups.",
+    "Batch sparse-QSA prefill selection into 128-query chunks using the existing FP32 score reduction, causal visibility, chronological row expansion, and original 1D top-k fallback at tied selection boundaries."
+  ],
+  "metric": "Decode=(completion_tokens-1)/(request_s-ttft_s), through stream completion; TTFT ends at first nonempty content/reasoning delta.",
+  "workload": {
+    "clients": 1,
+    "temperature": 0,
+    "ignore_eos": true,
+    "short": {
+      "input_tokens": 96,
+      "output_tokens": 128,
+      "thinking": true,
+      "warmup": 1,
+      "trials": 3,
+      "aggregation": "median"
+    },
+    "random1k": {
+      "input_tokens": 1024,
+      "output_tokens": 256,
+      "thinking": false,
+      "warmup": 3,
+      "trials": 30,
+      "aggregation": "mean"
+    },
+    "speedbench8k": {
+      "input_tokens_min": 7908,
+      "input_tokens_max": 8983,
+      "output_tokens": 256,
+      "thinking": true,
+      "warmup": 3,
+      "trials": 30,
+      "aggregation": "mean"
+    }
+  },
+  "profiles": {
+    "baseline": {
+      "source": {
+        "git_revision": "3f259fb04d7d28a4d78b49f96502083e8586012f",
+        "files": {
+          "python/sparklab/attention/qsa.py": "60d9211ef374df2fbf641e89bb3df2d8113de33f4710ef120dc0fc3a680e67ea",
+          "python/sparklab/kernels/triton/qwen4.py": "c93b6a682d0510f6b1906d81d7cebb6527c0a817bcfccf81a43295864ab22238",
+          "python/sparklab/models/qwen4_exp/ple.py": "b5fe5bb830f4630615580aeb8b12a9f0d85de98c3d79fc4d02fc99207e236685"
+        },
+        "tracked_dirty": false
+      },
+      "configuration": {
+        "argv": [
+          "$HOME/projects/sparklab/.venv/bin/python",
+          "-m",
+          "sparklab",
+          "serve",
+          "--model",
+          "$HOME/models/qwen38-nvidia/prepared/fab0aecb760c",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          "1938",
+          "--moe-backend",
+          "offload",
+          "--nvfp4-backend",
+          "triton",
+          "--moe-storage",
+          "disk",
+          "--moe-host-cache-gb",
+          "0.0",
+          "--max-running-requests",
+          "1",
+          "--max-seq-len-override",
+          "12288",
+          "--attention-backend",
+          "qsa",
+          "--page-size",
+          "16",
+          "--cache-type",
+          "radix",
+          "--memory-ratio",
+          "0.9",
+          "--cuda-graph-max-bs",
+          "1",
+          "--moe-hybrid-max-fetch",
+          "-1",
+          "--moe-cache-policy",
+          "lru",
+          "--speculative-method",
+          "mtp",
+          "--speculative-tokens",
+          "3",
+          "--draft-sample-method",
+          "greedy",
+          "--dspark-confidence-threshold",
+          "0.0",
+          "--dspark-draft-cache-slots",
+          "0",
+          "--dspark-draft-cache-quotas",
+          "",
+          "--dsv4-kv-storage",
+          "bf16",
+          "--dsv4-index-storage",
+          "bf16",
+          "--qwen4-dense-storage",
+          "bf16",
+          "--num-tokens",
+          "131072",
+          "--disable-moe-prefill-overlap",
+          "--moe-preload-all",
+          "--moe-collect-stats",
+          "--moe-cache-size",
+          "24576"
+        ],
+        "environment": {
+          "PYTHONPATH": "/tmp/sparklab-flash-next-bench/python",
+          "SPARKLAB_DISABLE_KERNEL_CACHE": "1",
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_QWEN4_FAST_QSA_METADATA": "0"
+        }
+      },
+      "workloads": {
+        "short": {
+          "aggregation": "median",
+          "warmup_requests": 1,
+          "metrics": {
+            "decode_tps": 42.200092057084156,
+            "ttft_s": 0.24298588803503662,
+            "request_s": 3.252457996015437,
+            "output_tps": 39.3548510562817
+          },
+          "trials": [
+            {
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "ttft_s": 0.2736486420035362,
+              "request_s": 3.298229507985525,
+              "decode_tps": 41.98928897170253,
+              "output_tps": 38.80870014960819,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "ttft_s": 0.24221256002783775,
+              "request_s": 3.2481336500495672,
+              "decode_tps": 42.24994475789181,
+              "output_tps": 39.40724544941268,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "ttft_s": 0.24298588803503662,
+              "request_s": 3.252457996015437,
+              "decode_tps": 42.200092057084156,
+              "output_tps": 39.3548510562817,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+            }
+          ]
+        },
+        "random1k": {
+          "aggregation": "mean",
+          "warmup_requests": 3,
+          "metrics": {
+            "decode_tps": 30.64544423580723,
+            "ttft_s": 2.2134974546691715,
+            "request_s": 10.747685725272943,
+            "output_tps": 24.225569604302404
+          },
+          "trials": [
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.207841005991213,
+              "request_s": 9.019458174007013,
+              "decode_tps": 37.436043998092245,
+              "output_tps": 28.383079677420202,
+              "output_sha256": "2c2df7d5cdb1918cff359315001a4b45e2f797b2c1b9069b7132c6cd99a9eca0"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2617025419604033,
+              "request_s": 9.20390631898772,
+              "decode_tps": 36.73185175632977,
+              "output_tps": 27.8142770175605,
+              "output_sha256": "184c490918b270620d8cad0ed494cad4dab5a00ef592cf4ae3267ded95aaf115"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2460944349877536,
+              "request_s": 9.658924479968846,
+              "decode_tps": 34.39981740477775,
+              "output_tps": 26.503986083637514,
+              "output_sha256": "126e874af6c05ac4c0684ace73810ef6b2415d87674dab0906950e47b4a66152"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2503996959421784,
+              "request_s": 9.786407122970559,
+              "decode_tps": 33.837546269583804,
+              "output_tps": 26.158731880172787,
+              "output_sha256": "1e67040cfe6e821adaef80becdf4917747d8ef2d756ea76119691c64863fee31"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.156844525015913,
+              "request_s": 9.804913706961088,
+              "decode_tps": 33.34174860786817,
+              "output_tps": 26.109357782338304,
+              "output_sha256": "6e24f2e9c9f98a6b56693ffe8ec9acc146bae58f7db9df5b0c570ba7f5ed7f50"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.1906337580876425,
+              "request_s": 10.718357371049933,
+              "decode_tps": 29.902470058058107,
+              "output_tps": 23.8842568070599,
+              "output_sha256": "9b79a7de50a49c7868c94d9d2e25a9d8866e9e828084ba882da806f7212ea8e0"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2406733320094645,
+              "request_s": 11.302803628961556,
+              "decode_tps": 28.139078963118127,
+              "output_tps": 22.649247779908567,
+              "output_sha256": "ab41d8d2363c6192db0c38eef40af54d39409b7adf15f6f27a01011d14903a54"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2132899309508502,
+              "request_s": 10.24938650499098,
+              "decode_tps": 31.731823734392893,
+              "output_tps": 24.977104715032432,
+              "output_sha256": "34f4575e126969971f7a076e368b3284c249bbd35f74a90ce3aa04f06d46fd88"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.229635111056268,
+              "request_s": 9.845333158038557,
+              "decode_tps": 33.48347038273707,
+              "output_tps": 26.002167310202207,
+              "output_sha256": "f3e54e6f09e158a7196d88f968bf9e9a7d2aabb7418e6e08fe21d5c3614bb12a"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2225661349948496,
+              "request_s": 10.655826021917164,
+              "decode_tps": 30.237417489698785,
+              "output_tps": 24.02441626519173,
+              "output_sha256": "7048a15d1217b83c21db462cd7a49fdf90f8f84fcd94b16ae3af6c787fa6d56f"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2483149910112843,
+              "request_s": 10.12755231198389,
+              "decode_tps": 32.363538450765056,
+              "output_tps": 25.277578640307418,
+              "output_sha256": "3ade04c90ff24c7e18bf6d363f801b56cdffde1559e17b4005a419fbb714ec3d"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2126907519996166,
+              "request_s": 12.340809380984865,
+              "decode_tps": 25.177430215936248,
+              "output_tps": 20.74418233819035,
+              "output_sha256": "2e299f9309ab725c9713f0f37b9b10dee109fd62c851fa9904e102fcf31fa6a2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2348107430152595,
+              "request_s": 12.134871133021079,
+              "decode_tps": 25.75741863730693,
+              "output_tps": 21.096227326500387,
+              "output_sha256": "fb6df3d6fe8dc764a2ad9cac3f0fab3c9c61592da736b2054c2b5df7ae26c414"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.4125234719831496,
+              "request_s": 10.940037662046961,
+              "decode_tps": 29.903204417662987,
+              "output_tps": 23.400285072885254,
+              "output_sha256": "bd3b035f5a828f5f070139e4dafa36958cba5d7c6fdd584081fdde065e9c61ae"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.0869189799996093,
+              "request_s": 11.084195296978578,
+              "decode_tps": 28.34191048670847,
+              "output_tps": 23.095948162315636,
+              "output_sha256": "29a6c2b2f86697ef4544682aa211929f3d9cb1ea6801766e6005233ba429d049"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2024855780182406,
+              "request_s": 10.103101541055366,
+              "decode_tps": 32.27596445555795,
+              "output_tps": 25.33875354609752,
+              "output_sha256": "b40ab3029b5b1d7aee6c68a3ada8c28b48455326258a4d0734595d2a6df767ec"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2284476900240406,
+              "request_s": 10.51130773301702,
+              "decode_tps": 30.786467316409798,
+              "output_tps": 24.354724122088022,
+              "output_sha256": "35250ff8674ecc5675d7572cf727b607fc71bb06bd663bdeb9e93e2a49f014fd"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.181461461004801,
+              "request_s": 11.632451107958332,
+              "decode_tps": 26.98130137960713,
+              "output_tps": 22.00739961200936,
+              "output_sha256": "e2f322ad5a813c69e157b42bfa66d282273e6bf5cefe2e0090c49d7bca7781b9"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.242537455051206,
+              "request_s": 10.709175240015611,
+              "decode_tps": 30.11821297621179,
+              "output_tps": 23.904735356597527,
+              "output_sha256": "1a0a75b94e37d129cb6057f971891d930d708f8d19e4375116c4075d083c3702"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.195201201015152,
+              "request_s": 9.664955198997632,
+              "decode_tps": 34.13767040639805,
+              "output_tps": 26.48744818046856,
+              "output_sha256": "558d6a25d9d5e80bf9445e7ad70da626224b6850c81eb4125644446a5524e698"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2247861709911376,
+              "request_s": 10.157131941989064,
+              "decode_tps": 32.14685886895218,
+              "output_tps": 25.203965200226364,
+              "output_sha256": "f06a19db153f82a907a6e53c7805d692c18ee441be486fd2adcb6bc5c45a94d3"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2230426099849865,
+              "request_s": 18.963277943083085,
+              "decode_tps": 15.232760766261427,
+              "output_tps": 13.499775764947683,
+              "output_sha256": "8f68a84aae05b06f22a9c5e1285209f5b662f308ad8fbdb4bb12c134de054115"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2208761820802465,
+              "request_s": 10.122220474062487,
+              "decode_tps": 32.27298932648171,
+              "output_tps": 25.2908935006882,
+              "output_sha256": "d8d6021a1fd40efa4f827c74076ce559c2fa9c02721f1b0c447650c5f37774cd"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2119157299166545,
+              "request_s": 11.265551968943328,
+              "decode_tps": 28.165478849348403,
+              "output_tps": 22.724141764712126,
+              "output_sha256": "41f9f3f33cfb90ab9aed5ace4d86d1a73996c1d63cd2cc594a3d5211cf897aad"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.1229763890150934,
+              "request_s": 10.676066694082692,
+              "decode_tps": 29.813785533038942,
+              "output_tps": 23.97886856044936,
+              "output_sha256": "1cfe2eee7427647ecabf6cf8aed072ffb890345ae06b6f5bd41c0e7e4040eb5a"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.22224411892239,
+              "request_s": 10.03414788399823,
+              "decode_tps": 32.64249121193883,
+              "output_tps": 25.512878917028043,
+              "output_sha256": "abccd7d2665017a2ec1cf9d29e9ba3186371850bb5b3b01bc1427f7cb3b8b372"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.2219368560472503,
+              "request_s": 10.001203010091558,
+              "decode_tps": 32.77944152449776,
+              "output_tps": 25.596920664612767,
+              "output_sha256": "e9126314ddefef9172f92046bf3fd0e1ba17572ab325cb7686834364ebcd491a"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.214963127975352,
+              "request_s": 10.840444620000198,
+              "decode_tps": 29.563567000378356,
+              "output_tps": 23.615267544256437,
+              "output_sha256": "a955a2b0b1ef26911fc012d55f69fa8de01a04f3d6997cf6a3b0e10b4cae0c1d"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.204995727050118,
+              "request_s": 10.015329838031903,
+              "decode_tps": 32.64905142040661,
+              "output_tps": 25.56081568356077,
+              "output_sha256": "ab78c2c43b470bc86322b647a861f7a2e19bfa0834dcecb4f72e128e0a87b9d4"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.0721139339730144,
+              "request_s": 10.86142428999301,
+              "decode_tps": 29.012515165691557,
+              "output_tps": 23.569652852606197,
+              "output_sha256": "721a869a6a4f799dec84cbc39462d4b8c4b9911ddc51e4d396b3d0e4cb21a716"
+            }
+          ]
+        },
+        "speedbench8k": {
+          "aggregation": "mean",
+          "warmup_requests": 3,
+          "metrics": {
+            "decode_tps": 26.100617793212006,
+            "ttft_s": 23.00962539703663,
+            "request_s": 32.880019718540524,
+            "output_tps": 7.800946008031336
+          },
+          "trials": [
+            {
+              "usage": {
+                "prompt_tokens": 8383,
+                "completion_tokens": 256,
+                "total_tokens": 8639
+              },
+              "ttft_s": 23.138433787971735,
+              "request_s": 32.07993623998482,
+              "decode_tps": 28.518697094646495,
+              "output_tps": 7.980065735944903,
+              "output_sha256": "fa988b392c38318d33f68a9be940130658aed7d2a59d8d9f4de53333013be2ca"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8835,
+                "completion_tokens": 256,
+                "total_tokens": 9091
+              },
+              "ttft_s": 23.51943627395667,
+              "request_s": 33.12131107703317,
+              "decode_tps": 26.557313569460046,
+              "output_tps": 7.729162635035736,
+              "output_sha256": "1606b13c910a7e0933337a15551c880c2d03b1d9bd8828748b0c2fa57c66ffa2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8207,
+                "completion_tokens": 256,
+                "total_tokens": 8463
+              },
+              "ttft_s": 23.16091573308222,
+              "request_s": 34.67430964601226,
+              "decode_tps": 22.148117395134367,
+              "output_tps": 7.382987653207435,
+              "output_sha256": "ab645328925c4aeeadbd4ff543289c4d724fe3bfaed1721928f3aa8c637582f2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8519,
+                "completion_tokens": 256,
+                "total_tokens": 8775
+              },
+              "ttft_s": 23.38602787302807,
+              "request_s": 32.66247751598712,
+              "decode_tps": 27.488965047478956,
+              "output_tps": 7.8377398001941865,
+              "output_sha256": "01e36186ffc8bbb8db01f8f294b7927c7b6eab040345d3491690c22a17d618ff"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8617,
+                "completion_tokens": 256,
+                "total_tokens": 8873
+              },
+              "ttft_s": 23.493955710087903,
+              "request_s": 32.92699582409114,
+              "decode_tps": 27.032642384447787,
+              "output_tps": 7.77477548719148,
+              "output_sha256": "9069d7f2a41a0c21ae004450c3d9fb5e640df85f3dfef4c0f5530b5d3fc17b70"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8229,
+                "completion_tokens": 256,
+                "total_tokens": 8485
+              },
+              "ttft_s": 23.31813865096774,
+              "request_s": 33.118761440040544,
+              "decode_tps": 26.018754673867463,
+              "output_tps": 7.729757662087456,
+              "output_sha256": "100dfd8da7bdeb8d7a44cae10d0b1545e56cf41cfa516f9ebee833b198f97d06"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8351,
+                "completion_tokens": 256,
+                "total_tokens": 8607
+              },
+              "ttft_s": 22.466652346076444,
+              "request_s": 31.339733708067797,
+              "decode_tps": 28.73860720947692,
+              "output_tps": 8.168544199662355,
+              "output_sha256": "fb72b7b2bde1148cfbd5fb8d579eae5805670b0771085ba73e8c12603371fe61"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8724,
+                "completion_tokens": 256,
+                "total_tokens": 8980
+              },
+              "ttft_s": 23.459401146043092,
+              "request_s": 33.05450605705846,
+              "decode_tps": 26.576051264145637,
+              "output_tps": 7.744783708402557,
+              "output_sha256": "f25cd6a9438e304a9ad2d02186d3a03fe48fbeff27895e1aa45ea1b5b440a5e2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8681,
+                "completion_tokens": 256,
+                "total_tokens": 8937
+              },
+              "ttft_s": 24.823436334030703,
+              "request_s": 34.24380087503232,
+              "decode_tps": 27.069016160693838,
+              "output_tps": 7.475805648275847,
+              "output_sha256": "afe8c1264a2a4190c99a72953087ee09fcdb623aae2d7ff8f62c6913f253f9e9"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8947,
+                "completion_tokens": 256,
+                "total_tokens": 9203
+              },
+              "ttft_s": 23.081899750977755,
+              "request_s": 33.58558633294888,
+              "decode_tps": 24.27719049021231,
+              "output_tps": 7.622317426950894,
+              "output_sha256": "4590427b35569a13fdb02200468ff29916a2ed2e1059ee2d51ade57efe382463"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8742,
+                "completion_tokens": 256,
+                "total_tokens": 8998
+              },
+              "ttft_s": 23.08732151100412,
+              "request_s": 33.40227378997952,
+              "decode_tps": 24.72139406013128,
+              "output_tps": 7.664148902246244,
+              "output_sha256": "e587f15eb73ae5170413f02314519b58af48d85484c18199240fb49696d365c6"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8856,
+                "completion_tokens": 256,
+                "total_tokens": 9112
+              },
+              "ttft_s": 24.647318409988657,
+              "request_s": 35.40432172000874,
+              "decode_tps": 23.70548680248793,
+              "output_tps": 7.230755669450425,
+              "output_sha256": "973f0f88a03289980491d84c2758baf9a2dbfc5f081d329475e847f485495334"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8983,
+                "completion_tokens": 256,
+                "total_tokens": 9239
+              },
+              "ttft_s": 22.237475652014837,
+              "request_s": 32.33631728391629,
+              "decode_tps": 25.250420720974073,
+              "output_tps": 7.9167951548809015,
+              "output_sha256": "069251a1c7fe8c954bfac0da107445490bf7577281c817da0523388d90444a98"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8694,
+                "completion_tokens": 256,
+                "total_tokens": 8950
+              },
+              "ttft_s": 23.304145295987837,
+              "request_s": 34.237608816009015,
+              "decode_tps": 23.322893018579904,
+              "output_tps": 7.4771576886613085,
+              "output_sha256": "17e58fa9c549e0a556085cd4c46ae1ad0268719cdac5ea0c9cffefbd51fbc892"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8400,
+                "completion_tokens": 256,
+                "total_tokens": 8656
+              },
+              "ttft_s": 23.908391346107237,
+              "request_s": 34.549210424069315,
+              "decode_tps": 23.96432061589355,
+              "output_tps": 7.409720710191776,
+              "output_sha256": "9eec4d5cbcf5293d0a1369777db50862fd632257516377684dccd56f15204859"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8485,
+                "completion_tokens": 256,
+                "total_tokens": 8741
+              },
+              "ttft_s": 21.83508685301058,
+              "request_s": 31.02265450404957,
+              "decode_tps": 27.754897671002503,
+              "output_tps": 8.252034008456073,
+              "output_sha256": "57aab0acc30ac6ba8421fb9676f8ef9bf13a7f20d795d3614cc5e83094115081"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 7908,
+                "completion_tokens": 256,
+                "total_tokens": 8164
+              },
+              "ttft_s": 20.35604400606826,
+              "request_s": 30.58891896798741,
+              "decode_tps": 24.919682977556423,
+              "output_tps": 8.369043713768203,
+              "output_sha256": "6361ebbabaeb1916093c62e620bd60c037b84c6eece389bc4b38bed258d77611"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8221,
+                "completion_tokens": 256,
+                "total_tokens": 8477
+              },
+              "ttft_s": 22.756054930971004,
+              "request_s": 33.00137008202728,
+              "decode_tps": 24.889424701953647,
+              "output_tps": 7.757253694731267,
+              "output_sha256": "2b3804b4eb4ddd413024bfe9a575d4756fcf68786b595532195e9099444b0688"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8911,
+                "completion_tokens": 256,
+                "total_tokens": 9167
+              },
+              "ttft_s": 21.496992011903785,
+              "request_s": 31.12347204692196,
+              "decode_tps": 26.489433216750918,
+              "output_tps": 8.225303385626534,
+              "output_sha256": "dfb67a5f7d3d87cdb63a572747d6d01f470d34751c04c98ab09717dcd0cca509"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8658,
+                "completion_tokens": 256,
+                "total_tokens": 8914
+              },
+              "ttft_s": 23.892174321925268,
+              "request_s": 34.332096513942815,
+              "decode_tps": 24.425469396215917,
+              "output_tps": 7.456579294423056,
+              "output_sha256": "391b2dd5e08572df2d7dca785383835940449d6d8d609f455238fb3a5bc873fa"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8322,
+                "completion_tokens": 256,
+                "total_tokens": 8578
+              },
+              "ttft_s": 23.634762258036062,
+              "request_s": 34.73274740506895,
+              "decode_tps": 22.977143744707192,
+              "output_tps": 7.37056579528284,
+              "output_sha256": "f0915b49f8fe55169accee2264ec34172a17d59cbe0995a30bbc0af3b6ecd523"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8352,
+                "completion_tokens": 256,
+                "total_tokens": 8608
+              },
+              "ttft_s": 23.12126523000188,
+              "request_s": 31.474634687998332,
+              "decode_tps": 30.526603819240332,
+              "output_tps": 8.133533638680037,
+              "output_sha256": "ddc2a4c0e1366f2568710adfc96cd86ef7cb7ce52ebe61734e4cf6cc66e19b91"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8603,
+                "completion_tokens": 256,
+                "total_tokens": 8859
+              },
+              "ttft_s": 21.643269227002747,
+              "request_s": 31.454632522072643,
+              "decode_tps": 25.9902719256288,
+              "output_tps": 8.138705795413673,
+              "output_sha256": "8f4090330add2413a58c0885a949cfb2295aa63b8f036ab706a74e37f7d9c4fa"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8814,
+                "completion_tokens": 256,
+                "total_tokens": 9070
+              },
+              "ttft_s": 22.616684545064345,
+              "request_s": 30.75883661105763,
+              "decode_tps": 31.31850129218776,
+              "output_tps": 8.322811530133405,
+              "output_sha256": "a9a1a6cf39ed8eeaeccc58b1af1109005bd0105bc420c44ebad661a15a94cc51"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8758,
+                "completion_tokens": 256,
+                "total_tokens": 9014
+              },
+              "ttft_s": 22.297177830943838,
+              "request_s": 32.374786861939356,
+              "decode_tps": 25.303621048971156,
+              "output_tps": 7.907387964952451,
+              "output_sha256": "8ab67494c9b5cef926ac0ac55b1c5ee041c6485b2be02d35cf98c8be1bd371fe"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8685,
+                "completion_tokens": 256,
+                "total_tokens": 8941
+              },
+              "ttft_s": 23.42469215602614,
+              "request_s": 30.962780760019086,
+              "decode_tps": 33.82820412391091,
+              "output_tps": 8.267991237097213,
+              "output_sha256": "b066e5d3d6d7d7207806f7e285d892398c01df037a352f61893ae732d0e760dd"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8204,
+                "completion_tokens": 256,
+                "total_tokens": 8460
+              },
+              "ttft_s": 22.212909570895135,
+              "request_s": 31.006324255955406,
+              "decode_tps": 28.99897356521089,
+              "output_tps": 8.256380146409322,
+              "output_sha256": "527e67eb649f837c5c89d8c8c522b957091a06a0faddcd15147688664fec14c9"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8817,
+                "completion_tokens": 256,
+                "total_tokens": 9073
+              },
+              "ttft_s": 22.47546730900649,
+              "request_s": 33.94410515099298,
+              "decode_tps": 22.234549866632744,
+              "output_tps": 7.541810245438481,
+              "output_sha256": "eac315a9b1d6bc63c0fe71bf7c19319198a0325efd90c8e1ee0811497433cf12"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8357,
+                "completion_tokens": 256,
+                "total_tokens": 8613
+              },
+              "ttft_s": 23.34017589793075,
+              "request_s": 33.201507397927344,
+              "decode_tps": 25.858577008600516,
+              "output_tps": 7.7104932897107314,
+              "output_sha256": "a7e68fc8f27b03e9f14579384716922a302bee63720a29f93ca5e89b209e0ec6"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8331,
+                "completion_tokens": 256,
+                "total_tokens": 8587
+              },
+              "ttft_s": 24.153055940987542,
+              "request_s": 35.684573038015515,
+              "decode_tps": 22.11330893015988,
+              "output_tps": 7.173968418433307,
+              "output_sha256": "4a1442b4f666e52da7c76dc191a20a1d3ff09bfa9f5e2c388535de7a6ca443f8"
+            }
+          ]
+        }
+      },
+      "quality": {
+        "status": "complete",
+        "expected_total": 52,
+        "passed": 42,
+        "total": 52,
+        "cases": [
+          {
+            "name": "multiply-0",
+            "prompt": "Compute 23 * 11. Reply only with FINAL=<integer>.",
+            "expected": "253",
+            "answer": "FINAL=253",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 6,
+              "total_tokens": 34
+            }
+          },
+          {
+            "name": "multiply-1",
+            "prompt": "计算 30 乘以 14。 Reply only with FINAL=<integer>.",
+            "expected": "420",
+            "answer": "FINAL=420",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 6,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-2",
+            "prompt": "Compute 37 * 17. Reply only with FINAL=<integer>.",
+            "expected": "629",
+            "answer": "FINAL=629",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 6,
+              "total_tokens": 34
+            }
+          },
+          {
+            "name": "multiply-3",
+            "prompt": "计算 44 乘以 20。 Reply only with FINAL=<integer>.",
+            "expected": "880",
+            "answer": "FINAL=880",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 6,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-4",
+            "prompt": "Compute 51 * 23. Reply only with FINAL=<integer>.",
+            "expected": "1173",
+            "answer": "FINAL=1173",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-5",
+            "prompt": "计算 58 乘以 26。 Reply only with FINAL=<integer>.",
+            "expected": "1508",
+            "answer": "FINAL=1508",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-6",
+            "prompt": "Compute 65 * 29. Reply only with FINAL=<integer>.",
+            "expected": "1885",
+            "answer": "FINAL=1885",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-7",
+            "prompt": "计算 72 乘以 32。 Reply only with FINAL=<integer>.",
+            "expected": "2304",
+            "answer": "FINAL=2304",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-8",
+            "prompt": "Compute 79 * 35. Reply only with FINAL=<integer>.",
+            "expected": "2765",
+            "answer": "FINAL=2765",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-9",
+            "prompt": "计算 86 乘以 38。 Reply only with FINAL=<integer>.",
+            "expected": "3268",
+            "answer": "FINAL=3268",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-10",
+            "prompt": "Compute 93 * 41. Reply only with FINAL=<integer>.",
+            "expected": "3813",
+            "answer": "FINAL=3813",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-11",
+            "prompt": "计算 100 乘以 44。 Reply only with FINAL=<integer>.",
+            "expected": "4400",
+            "answer": "FINAL=4400",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-12",
+            "prompt": "Compute 107 * 47. Reply only with FINAL=<integer>.",
+            "expected": "5029",
+            "answer": "FINAL=5029",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-13",
+            "prompt": "计算 114 乘以 50。 Reply only with FINAL=<integer>.",
+            "expected": "5700",
+            "answer": "FINAL=5700",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-14",
+            "prompt": "Compute 121 * 53. Reply only with FINAL=<integer>.",
+            "expected": "6413",
+            "answer": "FINAL=6413",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-15",
+            "prompt": "计算 128 乘以 56。 Reply only with FINAL=<integer>.",
+            "expected": "7168",
+            "answer": "FINAL=7168",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-16",
+            "prompt": "Compute 135 * 59. Reply only with FINAL=<integer>.",
+            "expected": "7965",
+            "answer": "FINAL=7965",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-17",
+            "prompt": "计算 142 乘以 62。 Reply only with FINAL=<integer>.",
+            "expected": "8804",
+            "answer": "FINAL=8804",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-18",
+            "prompt": "Compute 149 * 65. Reply only with FINAL=<integer>.",
+            "expected": "9685",
+            "answer": "FINAL=9685",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-19",
+            "prompt": "计算 156 乘以 68。 Reply only with FINAL=<integer>.",
+            "expected": "10608",
+            "answer": "FINAL=10608",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 8,
+              "total_tokens": 38
+            }
+          },
+          {
+            "name": "multiply-20",
+            "prompt": "Compute 163 * 71. Reply only with FINAL=<integer>.",
+            "expected": "11573",
+            "answer": "FINAL=11573",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 8,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-21",
+            "prompt": "计算 170 乘以 74。 Reply only with FINAL=<integer>.",
+            "expected": "12580",
+            "answer": "FINAL=12580",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 8,
+              "total_tokens": 38
+            }
+          },
+          {
+            "name": "multiply-22",
+            "prompt": "Compute 177 * 77. Reply only with FINAL=<integer>.",
+            "expected": "13629",
+            "answer": "FINAL=13629",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 8,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-23",
+            "prompt": "计算 184 乘以 80。 Reply only with FINAL=<integer>.",
+            "expected": "14720",
+            "answer": "FINAL=14720",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 8,
+              "total_tokens": 38
+            }
+          },
+          {
+            "name": "remainder-0",
+            "prompt": "What is the remainder when (107 * 7 + 3) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "4",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 42,
+              "completion_tokens": 4,
+              "total_tokens": 46
+            }
+          },
+          {
+            "name": "remainder-1",
+            "prompt": "What is the remainder when (126 * 8 + 5) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "10",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 42,
+              "completion_tokens": 4,
+              "total_tokens": 46
+            }
+          },
+          {
+            "name": "remainder-2",
+            "prompt": "What is the remainder when (145 * 9 + 7) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "3",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 42,
+              "completion_tokens": 4,
+              "total_tokens": 46
+            }
+          },
+          {
+            "name": "remainder-3",
+            "prompt": "What is the remainder when (164 * 10 + 9) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "0",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 43,
+              "completion_tokens": 4,
+              "total_tokens": 47
+            }
+          },
+          {
+            "name": "remainder-4",
+            "prompt": "What is the remainder when (183 * 11 + 11) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "1",
+            "answer": "FINAL=1",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 4,
+              "total_tokens": 48
+            }
+          },
+          {
+            "name": "remainder-5",
+            "prompt": "What is the remainder when (202 * 12 + 13) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "6",
+            "answer": "To find the remainder when $(202 \\times 12 + 13)$ is divided by $17$, we can perform the calculation using modular arithmetic.\n\n1.  **Find $202 \\pmod{17}$:**\n    $$202 \\div 17 = 11 \\text{ with a remainder of } 15$$\n    $$17 \\times 11 = 187$$\n    $$202 - 187 = 15$$\n    So, $202 \\equiv 15 \\pmod{17}$.\n    Note that $15 \\equiv -2 \\pmod{17}$, which might make calculations easier. Let's use $-2$.\n\n2.  **Find $12 \\pmod{17}$:**\n    $$12 \\equiv 12 \\pmod{17}$$\n    Note that $12 \\equiv -5 \\pmod{17}$.\n\n3.  **Calculate the product $202 \\times 12 \\pmod{17}$:**\n    Using the simplified residues:\n    $$20",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "remainder-6",
+            "prompt": "What is the remainder when (221 * 13 + 15) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "15",
+            "answer": "To find the remainder when $(221 \\times 13 + 15)$ is divided by $17$, we can use modular arithmetic properties.\n\n1.  **Analyze the term $221$ modulo $17$:**\n    We check if $221$ is divisible by $17$.\n    $$ 221 \\div 17 = 13 $$\n    Since $17 \\times 13 = 221$, we have:\n    $$ 221 \\equiv 0 \\pmod{17} $$\n\n2.  **Substitute this back into the expression:**\n    The expression is $221 \\times 13 + 15$.\n    $$ 221 \\times 13 + 15 \\equiv 0 \\times 13 + 15 \\pmod{17} $$\n    $$ 0 + 15 \\equiv 15 \\pmod{17} $$\n\n3.  **Conclusion:**\n    The remainder is $15$.\n\nFINAL=15",
+            "passed": false,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 239,
+              "total_tokens": 283
+            }
+          },
+          {
+            "name": "remainder-7",
+            "prompt": "What is the remainder when (240 * 14 + 17) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "11",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 4,
+              "total_tokens": 48
+            }
+          },
+          {
+            "name": "remainder-8",
+            "prompt": "What is the remainder when (259 * 15 + 19) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "11",
+            "answer": "To find the remainder when $(259 \\times 15 + 19)$ is divided by $17$, we can use modular arithmetic properties. We want to compute:\n$$ (259 \\times 15 + 19) \\pmod{17} $$\n\n**Step 1: Reduce each term modulo 17.**\n\n1.  **Reduce 259 modulo 17:**\n    Divide 259 by 17:\n    $$ 259 \\div 17 = 15 \\text{ with a remainder of } 4 $$\n    $$ 17 \\times 15 = 255 $$\n    $$ 259 - 255 = 4 $$\n    So, $259 \\equiv 4 \\pmod{17}$.\n\n2.  **Reduce 15 modulo 17:**\n    Since $15 < 17$,\n    $$ 15 \\equiv 15 \\pmod{17} $$\n    Alternatively, $15 \\equiv -2 \\pmod{17}$, which might make multiplication easier. Let's use $",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "remainder-9",
+            "prompt": "What is the remainder when (278 * 16 + 21) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "15",
+            "answer": "To find the remainder when $(278 \\times 16 + 21)$ is divided by $17$, we can use modular arithmetic properties. We want to compute:\n$$ (278 \\times 16 + 21) \\pmod{17} $$\n\n**Step 1: Reduce each term modulo 17.**\n\n1.  **Reduce 278 modulo 17:**\n    Divide 278 by 17:\n    $$ 278 \\div 17 = 16 \\text{ with a remainder of } 6 $$\n    $$ 17 \\times 16 = 272 $$\n    $$ 278 - 272 = 6 $$\n    So, $278 \\equiv 6 \\pmod{17}$.\n\n2.  **Reduce 16 modulo 17:**\n    $$ 16 \\equiv -1 \\pmod{17} $$\n    (Using $-1$ is often easier for multiplication).\n\n3.  **Reduce 21 modulo 17:**\n    $$ 21 \\div 17 = ",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "remainder-10",
+            "prompt": "What is the remainder when (297 * 17 + 23) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "6",
+            "answer": "FINAL=6",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 4,
+              "total_tokens": 48
+            }
+          },
+          {
+            "name": "remainder-11",
+            "prompt": "What is the remainder when (316 * 18 + 25) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "1",
+            "answer": "To find the remainder when $(316 \\times 18 + 25)$ is divided by $17$, we can use modular arithmetic properties. We want to compute:\n$$ (316 \\times 18 + 25) \\pmod{17} $$\n\n**Step 1: Reduce each term modulo 17.**\n\n1.  **Reduce 316 modulo 17:**\n    Divide 316 by 17:\n    $$ 316 \\div 17 = 18 \\text{ with a remainder of } 10 $$\n    $$ 17 \\times 18 = 306 $$\n    $$ 316 - 306 = 10 $$\n    So, $316 \\equiv 10 \\pmod{17}$.\n\n2.  **Reduce 18 modulo 17:**\n    $$ 18 = 17 \\times 1 + 1 $$\n    So, $18 \\equiv 1 \\pmod{17}$.\n\n3.  **Reduce 25 modulo 17:**\n    $$ 2",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "recall-0",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7319.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7319",
+            "answer": "violet-7319",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-1",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7456.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7456",
+            "answer": "violet-7456",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-2",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7593.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7593",
+            "answer": "violet-7593",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-3",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7730.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7730",
+            "answer": "violet-7730",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-4",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7867.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7867",
+            "answer": "violet-7867",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-5",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-8004.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-8004",
+            "answer": "violet-8004",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-6",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-8141.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-8141",
+            "answer": "violet-8141",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-7",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-8278.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-8278",
+            "answer": "violet-8278",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "json-0",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 13 + 0, and \"label\" equal to \"sample-0\". No markdown.",
+            "expected": {
+              "sum": 13,
+              "label": "sample-0"
+            },
+            "answer": "{\"sum\": 13, \"label\": \"sample-0\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 48,
+              "completion_tokens": 16,
+              "total_tokens": 64
+            }
+          },
+          {
+            "name": "json-1",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 14 + 7, and \"label\" equal to \"sample-1\". No markdown.",
+            "expected": {
+              "sum": 21,
+              "label": "sample-1"
+            },
+            "answer": "{\"sum\": 21, \"label\": \"sample-1\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 48,
+              "completion_tokens": 16,
+              "total_tokens": 64
+            }
+          },
+          {
+            "name": "json-2",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 15 + 14, and \"label\" equal to \"sample-2\". No markdown.",
+            "expected": {
+              "sum": 29,
+              "label": "sample-2"
+            },
+            "answer": "{\"sum\": 29, \"label\": \"sample-2\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-3",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 16 + 21, and \"label\" equal to \"sample-3\". No markdown.",
+            "expected": {
+              "sum": 37,
+              "label": "sample-3"
+            },
+            "answer": "{\"sum\": 37, \"label\": \"sample-3\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-4",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 17 + 28, and \"label\" equal to \"sample-4\". No markdown.",
+            "expected": {
+              "sum": 45,
+              "label": "sample-4"
+            },
+            "answer": "{\"sum\": 45, \"label\": \"sample-4\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-5",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 18 + 35, and \"label\" equal to \"sample-5\". No markdown.",
+            "expected": {
+              "sum": 53,
+              "label": "sample-5"
+            },
+            "answer": "{\"sum\": 53, \"label\": \"sample-5\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-6",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 19 + 42, and \"label\" equal to \"sample-6\". No markdown.",
+            "expected": {
+              "sum": 61,
+              "label": "sample-6"
+            },
+            "answer": "{\"sum\": 61, \"label\": \"sample-6\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-7",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 20 + 49, and \"label\" equal to \"sample-7\". No markdown.",
+            "expected": {
+              "sum": 69,
+              "label": "sample-7"
+            },
+            "answer": "{\"sum\": 69, \"label\": \"sample-7\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          }
+        ]
+      },
+      "telemetry": {
+        "samples": 1535,
+        "duration_s": 1599.990877098986,
+        "swap_start_bytes": 3024416768,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 3007504384,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-22789aa0-aba2-4504-97eb-e23bbe599565.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 86872064,
+            "swap_peak_bytes": 348413952,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-22789aa0-aba2-4504-97eb-e23bbe599565.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 88752128,
+            "swap_peak_bytes": 348413952,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": 1880064
+          }
+        },
+        "power_w_avg": 42.1971986970684,
+        "power_w_peak": 58.03,
+        "temperature_c_peak": 70.0,
+        "utilization_pct_avg": 81.24104234527687,
+        "request_energy_j_est": 67515.13295444266,
+        "mem_available_gib_min": 22.661762237548828,
+        "nvme_temperature_c_peak": 53.85,
+        "swap_in_pages_delta": 20148,
+        "swap_out_pages_delta": 7737,
+        "page_faults_delta": 49462338,
+        "major_faults_delta": 20504,
+        "oom_kill_delta": 0
+      }
+    },
+    "optimized": {
+      "source": {
+        "git_revision": "3f259fb04d7d28a4d78b49f96502083e8586012f",
+        "files": {
+          "python/sparklab/attention/qsa.py": "e3fc2207af3bde024b909e9077d4fcacb7d0248449acd724c8d9076ae097852c",
+          "python/sparklab/kernels/triton/qwen4.py": "073492d8e5efd68c73ec3c5b52bdc845917819211e52c018973422d298d7882b",
+          "python/sparklab/kernels/triton/qwen4_qsa_prefill.py": "17d4e69beb173579bccd3ef5ba70b8e85deacfb5425ad648bbbf76558b7edefd",
+          "python/sparklab/models/qwen4_exp/ple.py": "0d63b2324f87c88e207054e8c54c185ceb5dbedde3ba0a4b7ed5b804ee1fd850",
+          "tests/kernels/test_qwen4_qsa_prefill.py": "30f5a4e772080530cafe1a10e85fb5114de6207a7a6462a8b9a126c72280d656",
+          "tests/models/test_qwen4_ple_batch.py": "2e635981a17dcb105fe99afd74e535e69871f247346c754a3ba10f0f52c75c49"
+        },
+        "tracked_dirty": true
+      },
+      "configuration": {
+        "argv": [
+          "$HOME/projects/sparklab/.venv/bin/python",
+          "-m",
+          "sparklab",
+          "serve",
+          "--model",
+          "$HOME/models/qwen38-nvidia/prepared/fab0aecb760c",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          "1938",
+          "--moe-backend",
+          "offload",
+          "--nvfp4-backend",
+          "triton",
+          "--moe-storage",
+          "disk",
+          "--moe-host-cache-gb",
+          "0.0",
+          "--max-running-requests",
+          "1",
+          "--max-seq-len-override",
+          "12288",
+          "--attention-backend",
+          "qsa",
+          "--page-size",
+          "16",
+          "--cache-type",
+          "radix",
+          "--memory-ratio",
+          "0.9",
+          "--cuda-graph-max-bs",
+          "1",
+          "--moe-hybrid-max-fetch",
+          "-1",
+          "--moe-cache-policy",
+          "lru",
+          "--speculative-method",
+          "mtp",
+          "--speculative-tokens",
+          "3",
+          "--draft-sample-method",
+          "greedy",
+          "--dspark-confidence-threshold",
+          "0.0",
+          "--dspark-draft-cache-slots",
+          "0",
+          "--dspark-draft-cache-quotas",
+          "",
+          "--dsv4-kv-storage",
+          "bf16",
+          "--dsv4-index-storage",
+          "bf16",
+          "--qwen4-dense-storage",
+          "bf16",
+          "--num-tokens",
+          "131072",
+          "--disable-moe-prefill-overlap",
+          "--moe-preload-all",
+          "--moe-collect-stats",
+          "--moe-cache-size",
+          "24576"
+        ],
+        "environment": {
+          "PYTHONPATH": "/tmp/sparklab-flash-next-opt/python",
+          "SPARKLAB_DISABLE_KERNEL_CACHE": "1",
+          "SPARKLAB_QWEN4_DRAFT_HEAD": "fp8",
+          "SPARKLAB_QWEN4_LIGHT_VERIFY_SNAPSHOT": "1",
+          "SPARKLAB_QWEN4_DRAFT_VOCAB_SIZE": "0",
+          "SPARKLAB_QWEN4_REJECT_DRAFT": "1",
+          "SPARKLAB_QWEN4_FAST_QSA_METADATA": "0"
+        }
+      },
+      "workloads": {
+        "short": {
+          "aggregation": "median",
+          "warmup_requests": 1,
+          "metrics": {
+            "decode_tps": 42.14476540368395,
+            "ttft_s": 0.24315965303685516,
+            "request_s": 3.2558643949450925,
+            "output_tps": 39.31367663798498
+          },
+          "trials": [
+            {
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "ttft_s": 0.26579982496332377,
+              "request_s": 3.2942035789601505,
+              "decode_tps": 41.93628403491045,
+              "output_tps": 38.8561292378914,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "ttft_s": 0.24244152300525457,
+              "request_s": 3.2558643949450925,
+              "decode_tps": 42.14476540368395,
+              "output_tps": 39.31367663798498,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 96,
+                "completion_tokens": 128,
+                "total_tokens": 224
+              },
+              "ttft_s": 0.24315965303685516,
+              "request_s": 3.2546968610258773,
+              "decode_tps": 42.17115420758997,
+              "output_tps": 39.32777934951967,
+              "output_sha256": "d10cecf60588dacadf7aceb15af2b04fda2371e10d3c1593e094db3599f8d946"
+            }
+          ]
+        },
+        "random1k": {
+          "aggregation": "mean",
+          "warmup_requests": 3,
+          "metrics": {
+            "decode_tps": 30.56872898328276,
+            "ttft_s": 1.980999252999512,
+            "request_s": 10.536346367560327,
+            "output_tps": 24.731387703010878
+          },
+          "trials": [
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9837413100758567,
+              "request_s": 8.807763356016949,
+              "decode_tps": 37.36799182113916,
+              "output_tps": 29.06526772487771,
+              "output_sha256": "2c2df7d5cdb1918cff359315001a4b45e2f797b2c1b9069b7132c6cd99a9eca0"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9823998819338158,
+              "request_s": 8.970825416967273,
+              "decode_tps": 36.48890565144717,
+              "output_tps": 28.53695040322664,
+              "output_sha256": "184c490918b270620d8cad0ed494cad4dab5a00ef592cf4ae3267ded95aaf115"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9756743659963831,
+              "request_s": 9.408089242060669,
+              "decode_tps": 34.309171951799215,
+              "output_tps": 27.21062624018306,
+              "output_sha256": "126e874af6c05ac4c0684ace73810ef6b2415d87674dab0906950e47b4a66152"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9582884670235217,
+              "request_s": 9.520618814975023,
+              "decode_tps": 33.71976471102917,
+              "output_tps": 26.889008474673567,
+              "output_sha256": "1e67040cfe6e821adaef80becdf4917747d8ef2d756ea76119691c64863fee31"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.984833751921542,
+              "request_s": 9.642635060939938,
+              "decode_tps": 33.29937533110098,
+              "output_tps": 26.548759585125875,
+              "output_sha256": "6e24f2e9c9f98a6b56693ffe8ec9acc146bae58f7db9df5b0c570ba7f5ed7f50"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9776144749484956,
+              "request_s": 10.536898051970638,
+              "decode_tps": 29.79221306378506,
+              "output_tps": 24.295575295247563,
+              "output_sha256": "9b79a7de50a49c7868c94d9d2e25a9d8866e9e828084ba882da806f7212ea8e0"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9797896950040013,
+              "request_s": 11.054948321077973,
+              "decode_tps": 28.09868240400292,
+              "output_tps": 23.157050812430874,
+              "output_sha256": "ab41d8d2363c6192db0c38eef40af54d39409b7adf15f6f27a01011d14903a54"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9588470400776714,
+              "request_s": 10.006946705048904,
+              "decode_tps": 31.68449828098786,
+              "output_tps": 25.582228780217026,
+              "output_sha256": "34f4575e126969971f7a076e368b3284c249bbd35f74a90ce3aa04f06d46fd88"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.989275660016574,
+              "request_s": 9.61843317898456,
+              "decode_tps": 33.424398351457086,
+              "output_tps": 26.61556151986768,
+              "output_sha256": "f3e54e6f09e158a7196d88f968bf9e9a7d2aabb7418e6e08fe21d5c3614bb12a"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.998518935055472,
+              "request_s": 10.453764265985228,
+              "decode_tps": 30.158793745131895,
+              "output_tps": 24.488786382239407,
+              "output_sha256": "7048a15d1217b83c21db462cd7a49fdf90f8f84fcd94b16ae3af6c787fa6d56f"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9839334220159799,
+              "request_s": 9.852199135930277,
+              "decode_tps": 32.40866656918515,
+              "output_tps": 25.98404645175979,
+              "output_sha256": "3ade04c90ff24c7e18bf6d363f801b56cdffde1559e17b4005a419fbb714ec3d"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9799830740084872,
+              "request_s": 12.118329738965258,
+              "decode_tps": 25.152030052533945,
+              "output_tps": 21.125023457387698,
+              "output_sha256": "2e299f9309ab725c9713f0f37b9b10dee109fd62c851fa9904e102fcf31fa6a2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9883953930111602,
+              "request_s": 11.915415243944153,
+              "decode_tps": 25.68746752088279,
+              "output_tps": 21.484773695160015,
+              "output_sha256": "fb6df3d6fe8dc764a2ad9cac3f0fab3c9c61592da736b2054c2b5df7ae26c414"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9886631679255515,
+              "request_s": 10.546659705927595,
+              "decode_tps": 29.79669352139426,
+              "output_tps": 24.273088080780585,
+              "output_sha256": "bd3b035f5a828f5f070139e4dafa36958cba5d7c6fdd584081fdde065e9c61ae"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9518066410673782,
+              "request_s": 10.95448546204716,
+              "decode_tps": 28.32490251743178,
+              "output_tps": 23.369422588302843,
+              "output_sha256": "29a6c2b2f86697ef4544682aa211929f3d9cb1ea6801766e6005233ba429d049"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9850830259965733,
+              "request_s": 9.873204743023962,
+              "decode_tps": 32.327087378679025,
+              "output_tps": 25.928764434960193,
+              "output_sha256": "b40ab3029b5b1d7aee6c68a3ada8c28b48455326258a4d0734595d2a6df767ec"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.997251710970886,
+              "request_s": 10.417443608981557,
+              "decode_tps": 30.284345426883384,
+              "output_tps": 24.57416709981379,
+              "output_sha256": "35250ff8674ecc5675d7572cf727b607fc71bb06bd663bdeb9e93e2a49f014fd"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.978930793935433,
+              "request_s": 11.498923759907484,
+              "decode_tps": 26.785734076848964,
+              "output_tps": 22.26295306805823,
+              "output_sha256": "e2f322ad5a813c69e157b42bfa66d282273e6bf5cefe2e0090c49d7bca7781b9"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9865982099436224,
+              "request_s": 10.51511211192701,
+              "decode_tps": 29.899699165724208,
+              "output_tps": 24.345912556617066,
+              "output_sha256": "1a0a75b94e37d129cb6057f971891d930d708f8d19e4375116c4075d083c3702"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9311149409040809,
+              "request_s": 9.400168235995807,
+              "decode_tps": 34.14087300295109,
+              "output_tps": 27.233555142099075,
+              "output_sha256": "558d6a25d9d5e80bf9445e7ad70da626224b6850c81eb4125644446a5524e698"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9745226519880816,
+              "request_s": 9.913076733006164,
+              "decode_tps": 32.121718564559735,
+              "output_tps": 25.82447477155434,
+              "output_sha256": "f06a19db153f82a907a6e53c7805d692c18ee441be486fd2adcb6bc5c45a94d3"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.0209301450522617,
+              "request_s": 18.795519371982664,
+              "decode_tps": 15.2015644943851,
+              "output_tps": 13.62026741232826,
+              "output_sha256": "8f68a84aae05b06f22a9c5e1285209f5b662f308ad8fbdb4bb12c134de054115"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.975618652999401,
+              "request_s": 9.892575779929757,
+              "decode_tps": 32.20934456403596,
+              "output_tps": 25.877992314132946,
+              "output_sha256": "d8d6021a1fd40efa4f827c74076ce559c2fa9c02721f1b0c447650c5f37774cd"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9257233070675284,
+              "request_s": 10.995793113019317,
+              "decode_tps": 28.11444734776669,
+              "output_tps": 23.28163119919827,
+              "output_sha256": "41f9f3f33cfb90ab9aed5ace4d86d1a73996c1d63cd2cc594a3d5211cf897aad"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.955773926107213,
+              "request_s": 10.508257803041488,
+              "decode_tps": 29.81589952922628,
+              "output_tps": 24.361792867881856,
+              "output_sha256": "1cfe2eee7427647ecabf6cf8aed072ffb890345ae06b6f5bd41c0e7e4040eb5a"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9739556909771636,
+              "request_s": 9.81817345903255,
+              "decode_tps": 32.508021518532566,
+              "output_tps": 26.07409627342491,
+              "output_sha256": "abccd7d2665017a2ec1cf9d29e9ba3186371850bb5b3b01bc1427f7cb3b8b372"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.0085367320571095,
+              "request_s": 9.811441704048775,
+              "decode_tps": 32.68013655367023,
+              "output_tps": 26.09198604261792,
+              "output_sha256": "e9126314ddefef9172f92046bf3fd0e1ba17572ab325cb7686834364ebcd491a"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.995420328923501,
+              "request_s": 10.595624277950265,
+              "decode_tps": 29.65045962995528,
+              "output_tps": 24.160917118658297,
+              "output_sha256": "a955a2b0b1ef26911fc012d55f69fa8de01a04f3d6997cf6a3b0e10b4cae0c1d"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 2.0670991169754416,
+              "request_s": 9.905324036022648,
+              "decode_tps": 32.53287608273904,
+              "output_tps": 25.844687066168248,
+              "output_sha256": "ab78c2c43b470bc86322b647a861f7a2e19bfa0834dcecb4f72e128e0a87b9d4"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 1024,
+                "completion_tokens": 256,
+                "total_tokens": 1280
+              },
+              "ttft_s": 1.9716530760051683,
+              "request_s": 10.741740588098764,
+              "decode_tps": 29.07610666921685,
+              "output_tps": 23.83226423133262,
+              "output_sha256": "721a869a6a4f799dec84cbc39462d4b8c4b9911ddc51e4d396b3d0e4cb21a716"
+            }
+          ]
+        },
+        "speedbench8k": {
+          "aggregation": "mean",
+          "warmup_requests": 3,
+          "metrics": {
+            "decode_tps": 26.27709379851059,
+            "ttft_s": 19.373677716916426,
+            "request_s": 29.17076454370205,
+            "output_tps": 8.78991468805226
+          },
+          "trials": [
+            {
+              "usage": {
+                "prompt_tokens": 8383,
+                "completion_tokens": 256,
+                "total_tokens": 8639
+              },
+              "ttft_s": 19.41459341207519,
+              "request_s": 28.322873875964433,
+              "decode_tps": 28.6250529531117,
+              "output_tps": 9.038630794357653,
+              "output_sha256": "fa988b392c38318d33f68a9be940130658aed7d2a59d8d9f4de53333013be2ca"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8835,
+                "completion_tokens": 256,
+                "total_tokens": 9091
+              },
+              "ttft_s": 20.23623421508819,
+              "request_s": 29.715387823060155,
+              "decode_tps": 26.901135960656344,
+              "output_tps": 8.615065080905161,
+              "output_sha256": "1606b13c910a7e0933337a15551c880c2d03b1d9bd8828748b0c2fa57c66ffa2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8207,
+                "completion_tokens": 256,
+                "total_tokens": 8463
+              },
+              "ttft_s": 19.083196014049463,
+              "request_s": 29.99517749901861,
+              "decode_tps": 23.36880797967382,
+              "output_tps": 8.534705287487492,
+              "output_sha256": "ab645328925c4aeeadbd4ff543289c4d724fe3bfaed1721928f3aa8c637582f2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8519,
+                "completion_tokens": 256,
+                "total_tokens": 8775
+              },
+              "ttft_s": 19.616751363966614,
+              "request_s": 28.843993829912506,
+              "decode_tps": 27.63555861256538,
+              "output_tps": 8.875331256468257,
+              "output_sha256": "01e36186ffc8bbb8db01f8f294b7927c7b6eab040345d3491690c22a17d618ff"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8617,
+                "completion_tokens": 256,
+                "total_tokens": 8873
+              },
+              "ttft_s": 19.57093063299544,
+              "request_s": 29.01054736599326,
+              "decode_tps": 27.01380863362844,
+              "output_tps": 8.824376760987567,
+              "output_sha256": "9069d7f2a41a0c21ae004450c3d9fb5e640df85f3dfef4c0f5530b5d3fc17b70"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8229,
+                "completion_tokens": 256,
+                "total_tokens": 8485
+              },
+              "ttft_s": 19.119435763102956,
+              "request_s": 28.978063820046373,
+              "decode_tps": 25.865667973993997,
+              "output_tps": 8.83426862435526,
+              "output_sha256": "100dfd8da7bdeb8d7a44cae10d0b1545e56cf41cfa516f9ebee833b198f97d06"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8351,
+                "completion_tokens": 256,
+                "total_tokens": 8607
+              },
+              "ttft_s": 19.170002234051935,
+              "request_s": 27.999900717986748,
+              "decode_tps": 28.87915421269554,
+              "output_tps": 9.142889561588666,
+              "output_sha256": "fb72b7b2bde1148cfbd5fb8d579eae5805670b0771085ba73e8c12603371fe61"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8724,
+                "completion_tokens": 256,
+                "total_tokens": 8980
+              },
+              "ttft_s": 19.7984117079759,
+              "request_s": 29.425122263026424,
+              "decode_tps": 26.48879890402623,
+              "output_tps": 8.70004881242828,
+              "output_sha256": "f25cd6a9438e304a9ad2d02186d3a03fe48fbeff27895e1aa45ea1b5b440a5e2"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8681,
+                "completion_tokens": 256,
+                "total_tokens": 8937
+              },
+              "ttft_s": 20.36218088492751,
+              "request_s": 29.76609396794811,
+              "decode_tps": 27.116371424191467,
+              "output_tps": 8.60038943220628,
+              "output_sha256": "afe8c1264a2a4190c99a72953087ee09fcdb623aae2d7ff8f62c6913f253f9e9"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8947,
+                "completion_tokens": 256,
+                "total_tokens": 9203
+              },
+              "ttft_s": 19.890912706963718,
+              "request_s": 30.405551992938854,
+              "decode_tps": 24.251901854600913,
+              "output_tps": 8.4195149642227,
+              "output_sha256": "4590427b35569a13fdb02200468ff29916a2ed2e1059ee2d51ade57efe382463"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8742,
+                "completion_tokens": 256,
+                "total_tokens": 8998
+              },
+              "ttft_s": 19.918380007031374,
+              "request_s": 30.245644701994024,
+              "decode_tps": 24.691920613246392,
+              "output_tps": 8.464028541045533,
+              "output_sha256": "e587f15eb73ae5170413f02314519b58af48d85484c18199240fb49696d365c6"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8856,
+                "completion_tokens": 256,
+                "total_tokens": 9112
+              },
+              "ttft_s": 20.374186292057857,
+              "request_s": 31.078031411976553,
+              "decode_tps": 23.82321466194168,
+              "output_tps": 8.237329984206953,
+              "output_sha256": "973f0f88a03289980491d84c2758baf9a2dbfc5f081d329475e847f485495334"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8983,
+                "completion_tokens": 256,
+                "total_tokens": 9239
+              },
+              "ttft_s": 19.619624206097797,
+              "request_s": 29.575350027065724,
+              "decode_tps": 25.613401231172926,
+              "output_tps": 8.655856981091448,
+              "output_sha256": "069251a1c7fe8c954bfac0da107445490bf7577281c817da0523388d90444a98"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8694,
+                "completion_tokens": 256,
+                "total_tokens": 8950
+              },
+              "ttft_s": 19.57963466004003,
+              "request_s": 30.135014763101935,
+              "decode_tps": 24.158296291578313,
+              "output_tps": 8.495101197476524,
+              "output_sha256": "17e58fa9c549e0a556085cd4c46ae1ad0268719cdac5ea0c9cffefbd51fbc892"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8400,
+                "completion_tokens": 256,
+                "total_tokens": 8656
+              },
+              "ttft_s": 19.94842677807901,
+              "request_s": 30.550165090011433,
+              "decode_tps": 24.052659337289388,
+              "output_tps": 8.379660117899029,
+              "output_sha256": "9eec4d5cbcf5293d0a1369777db50862fd632257516377684dccd56f15204859"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8485,
+                "completion_tokens": 256,
+                "total_tokens": 8741
+              },
+              "ttft_s": 18.90123548009433,
+              "request_s": 27.992028777021915,
+              "decode_tps": 28.050357286880818,
+              "output_tps": 9.145460732383398,
+              "output_sha256": "57aab0acc30ac6ba8421fb9676f8ef9bf13a7f20d795d3614cc5e83094115081"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 7908,
+                "completion_tokens": 256,
+                "total_tokens": 8164
+              },
+              "ttft_s": 17.505990427103825,
+              "request_s": 27.329528245027177,
+              "decode_tps": 25.958061619587244,
+              "output_tps": 9.367157665686426,
+              "output_sha256": "6361ebbabaeb1916093c62e620bd60c037b84c6eece389bc4b38bed258d77611"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8221,
+                "completion_tokens": 256,
+                "total_tokens": 8477
+              },
+              "ttft_s": 18.858542799949646,
+              "request_s": 29.089675838011317,
+              "decode_tps": 24.92392573250233,
+              "output_tps": 8.800373074817363,
+              "output_sha256": "2b3804b4eb4ddd413024bfe9a575d4756fcf68786b595532195e9099444b0688"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8911,
+                "completion_tokens": 256,
+                "total_tokens": 9167
+              },
+              "ttft_s": 19.216945266001858,
+              "request_s": 28.79588678397704,
+              "decode_tps": 26.62089537987935,
+              "output_tps": 8.890158581344565,
+              "output_sha256": "dfb67a5f7d3d87cdb63a572747d6d01f470d34751c04c98ab09717dcd0cca509"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8658,
+                "completion_tokens": 256,
+                "total_tokens": 8914
+              },
+              "ttft_s": 19.61204905307386,
+              "request_s": 30.104987819097005,
+              "decode_tps": 24.302057382218553,
+              "output_tps": 8.503574276074186,
+              "output_sha256": "391b2dd5e08572df2d7dca785383835940449d6d8d609f455238fb3a5bc873fa"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8322,
+                "completion_tokens": 256,
+                "total_tokens": 8578
+              },
+              "ttft_s": 19.272326479898766,
+              "request_s": 30.345814112923108,
+              "decode_tps": 23.027975327259703,
+              "output_tps": 8.436089374546702,
+              "output_sha256": "f0915b49f8fe55169accee2264ec34172a17d59cbe0995a30bbc0af3b6ecd523"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8352,
+                "completion_tokens": 256,
+                "total_tokens": 8608
+              },
+              "ttft_s": 19.063993503921665,
+              "request_s": 27.426086411927827,
+              "decode_tps": 30.49475804745652,
+              "output_tps": 9.334179005892125,
+              "output_sha256": "ddc2a4c0e1366f2568710adfc96cd86ef7cb7ce52ebe61734e4cf6cc66e19b91"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8603,
+                "completion_tokens": 256,
+                "total_tokens": 8859
+              },
+              "ttft_s": 18.710542054963298,
+              "request_s": 28.53576986398548,
+              "decode_tps": 25.953596695828463,
+              "output_tps": 8.971196544554887,
+              "output_sha256": "8f4090330add2413a58c0885a949cfb2295aa63b8f036ab706a74e37f7d9c4fa"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8814,
+                "completion_tokens": 256,
+                "total_tokens": 9070
+              },
+              "ttft_s": 19.424324208055623,
+              "request_s": 27.59694448299706,
+              "decode_tps": 31.20174331136745,
+              "output_tps": 9.276389281346923,
+              "output_sha256": "a9a1a6cf39ed8eeaeccc58b1af1109005bd0105bc420c44ebad661a15a94cc51"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8758,
+                "completion_tokens": 256,
+                "total_tokens": 9014
+              },
+              "ttft_s": 19.264003165997565,
+              "request_s": 29.03175009705592,
+              "decode_tps": 26.10632746730778,
+              "output_tps": 8.81793206211019,
+              "output_sha256": "8ab67494c9b5cef926ac0ac55b1c5ee041c6485b2be02d35cf98c8be1bd371fe"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8685,
+                "completion_tokens": 256,
+                "total_tokens": 8941
+              },
+              "ttft_s": 19.505793128046207,
+              "request_s": 27.006505190045573,
+              "decode_tps": 33.996772292046636,
+              "output_tps": 9.479197630293903,
+              "output_sha256": "b066e5d3d6d7d7207806f7e285d892398c01df037a352f61893ae732d0e760dd"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8204,
+                "completion_tokens": 256,
+                "total_tokens": 8460
+              },
+              "ttft_s": 18.555629162932746,
+              "request_s": 27.38194373692386,
+              "decode_tps": 28.890880543893108,
+              "output_tps": 9.349226718875713,
+              "output_sha256": "527e67eb649f837c5c89d8c8c522b957091a06a0faddcd15147688664fec14c9"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8817,
+                "completion_tokens": 256,
+                "total_tokens": 9073
+              },
+              "ttft_s": 19.37679865292739,
+              "request_s": 30.781187013955787,
+              "decode_tps": 22.359813777597914,
+              "output_tps": 8.316768287198702,
+              "output_sha256": "eac315a9b1d6bc63c0fe71bf7c19319198a0325efd90c8e1ee0811497433cf12"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8357,
+                "completion_tokens": 256,
+                "total_tokens": 8613
+              },
+              "ttft_s": 18.787666703923605,
+              "request_s": 28.62497208197601,
+              "decode_tps": 25.921732649361445,
+              "output_tps": 8.943240163409378,
+              "output_sha256": "a7e68fc8f27b03e9f14579384716922a302bee63720a29f93ca5e89b209e0ec6"
+            },
+            {
+              "usage": {
+                "prompt_tokens": 8331,
+                "completion_tokens": 256,
+                "total_tokens": 8587
+              },
+              "ttft_s": 19.45159054209944,
+              "request_s": 31.032936706091277,
+              "decode_tps": 22.01816579775792,
+              "output_tps": 8.249299846306561,
+              "output_sha256": "4a1442b4f666e52da7c76dc191a20a1d3ff09bfa9f5e2c388535de7a6ca443f8"
+            }
+          ]
+        }
+      },
+      "quality": {
+        "status": "complete",
+        "expected_total": 52,
+        "passed": 42,
+        "total": 52,
+        "cases": [
+          {
+            "name": "multiply-0",
+            "prompt": "Compute 23 * 11. Reply only with FINAL=<integer>.",
+            "expected": "253",
+            "answer": "FINAL=253",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 6,
+              "total_tokens": 34
+            }
+          },
+          {
+            "name": "multiply-1",
+            "prompt": "计算 30 乘以 14。 Reply only with FINAL=<integer>.",
+            "expected": "420",
+            "answer": "FINAL=420",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 6,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-2",
+            "prompt": "Compute 37 * 17. Reply only with FINAL=<integer>.",
+            "expected": "629",
+            "answer": "FINAL=629",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 6,
+              "total_tokens": 34
+            }
+          },
+          {
+            "name": "multiply-3",
+            "prompt": "计算 44 乘以 20。 Reply only with FINAL=<integer>.",
+            "expected": "880",
+            "answer": "FINAL=880",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 6,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-4",
+            "prompt": "Compute 51 * 23. Reply only with FINAL=<integer>.",
+            "expected": "1173",
+            "answer": "FINAL=1173",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-5",
+            "prompt": "计算 58 乘以 26。 Reply only with FINAL=<integer>.",
+            "expected": "1508",
+            "answer": "FINAL=1508",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-6",
+            "prompt": "Compute 65 * 29. Reply only with FINAL=<integer>.",
+            "expected": "1885",
+            "answer": "FINAL=1885",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-7",
+            "prompt": "计算 72 乘以 32。 Reply only with FINAL=<integer>.",
+            "expected": "2304",
+            "answer": "FINAL=2304",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-8",
+            "prompt": "Compute 79 * 35. Reply only with FINAL=<integer>.",
+            "expected": "2765",
+            "answer": "FINAL=2765",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-9",
+            "prompt": "计算 86 乘以 38。 Reply only with FINAL=<integer>.",
+            "expected": "3268",
+            "answer": "FINAL=3268",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-10",
+            "prompt": "Compute 93 * 41. Reply only with FINAL=<integer>.",
+            "expected": "3813",
+            "answer": "FINAL=3813",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 28,
+              "completion_tokens": 7,
+              "total_tokens": 35
+            }
+          },
+          {
+            "name": "multiply-11",
+            "prompt": "计算 100 乘以 44。 Reply only with FINAL=<integer>.",
+            "expected": "4400",
+            "answer": "FINAL=4400",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-12",
+            "prompt": "Compute 107 * 47. Reply only with FINAL=<integer>.",
+            "expected": "5029",
+            "answer": "FINAL=5029",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-13",
+            "prompt": "计算 114 乘以 50。 Reply only with FINAL=<integer>.",
+            "expected": "5700",
+            "answer": "FINAL=5700",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-14",
+            "prompt": "Compute 121 * 53. Reply only with FINAL=<integer>.",
+            "expected": "6413",
+            "answer": "FINAL=6413",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-15",
+            "prompt": "计算 128 乘以 56。 Reply only with FINAL=<integer>.",
+            "expected": "7168",
+            "answer": "FINAL=7168",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-16",
+            "prompt": "Compute 135 * 59. Reply only with FINAL=<integer>.",
+            "expected": "7965",
+            "answer": "FINAL=7965",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-17",
+            "prompt": "计算 142 乘以 62。 Reply only with FINAL=<integer>.",
+            "expected": "8804",
+            "answer": "FINAL=8804",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 7,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-18",
+            "prompt": "Compute 149 * 65. Reply only with FINAL=<integer>.",
+            "expected": "9685",
+            "answer": "FINAL=9685",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 7,
+              "total_tokens": 36
+            }
+          },
+          {
+            "name": "multiply-19",
+            "prompt": "计算 156 乘以 68。 Reply only with FINAL=<integer>.",
+            "expected": "10608",
+            "answer": "FINAL=10608",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 8,
+              "total_tokens": 38
+            }
+          },
+          {
+            "name": "multiply-20",
+            "prompt": "Compute 163 * 71. Reply only with FINAL=<integer>.",
+            "expected": "11573",
+            "answer": "FINAL=11573",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 8,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-21",
+            "prompt": "计算 170 乘以 74。 Reply only with FINAL=<integer>.",
+            "expected": "12580",
+            "answer": "FINAL=12580",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 8,
+              "total_tokens": 38
+            }
+          },
+          {
+            "name": "multiply-22",
+            "prompt": "Compute 177 * 77. Reply only with FINAL=<integer>.",
+            "expected": "13629",
+            "answer": "FINAL=13629",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 29,
+              "completion_tokens": 8,
+              "total_tokens": 37
+            }
+          },
+          {
+            "name": "multiply-23",
+            "prompt": "计算 184 乘以 80。 Reply only with FINAL=<integer>.",
+            "expected": "14720",
+            "answer": "FINAL=14720",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 30,
+              "completion_tokens": 8,
+              "total_tokens": 38
+            }
+          },
+          {
+            "name": "remainder-0",
+            "prompt": "What is the remainder when (107 * 7 + 3) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "4",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 42,
+              "completion_tokens": 4,
+              "total_tokens": 46
+            }
+          },
+          {
+            "name": "remainder-1",
+            "prompt": "What is the remainder when (126 * 8 + 5) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "10",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 42,
+              "completion_tokens": 4,
+              "total_tokens": 46
+            }
+          },
+          {
+            "name": "remainder-2",
+            "prompt": "What is the remainder when (145 * 9 + 7) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "3",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 42,
+              "completion_tokens": 4,
+              "total_tokens": 46
+            }
+          },
+          {
+            "name": "remainder-3",
+            "prompt": "What is the remainder when (164 * 10 + 9) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "0",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 43,
+              "completion_tokens": 4,
+              "total_tokens": 47
+            }
+          },
+          {
+            "name": "remainder-4",
+            "prompt": "What is the remainder when (183 * 11 + 11) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "1",
+            "answer": "FINAL=1",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 4,
+              "total_tokens": 48
+            }
+          },
+          {
+            "name": "remainder-5",
+            "prompt": "What is the remainder when (202 * 12 + 13) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "6",
+            "answer": "To find the remainder when $(202 \\times 12 + 13)$ is divided by $17$, we can perform the calculation using modular arithmetic.\n\n1.  **Find $202 \\pmod{17}$:**\n    $$202 \\div 17 = 11 \\text{ with a remainder of } 15$$\n    $$17 \\times 11 = 187$$\n    $$202 - 187 = 15$$\n    So, $202 \\equiv 15 \\pmod{17}$.\n    Note that $15 \\equiv -2 \\pmod{17}$, which might make calculations easier. Let's use $-2$.\n\n2.  **Find $12 \\pmod{17}$:**\n    $$12 \\equiv 12 \\pmod{17}$$\n    Note that $12 \\equiv -5 \\pmod{17}$.\n\n3.  **Calculate the product $202 \\times 12 \\pmod{17}$:**\n    Using the simplified residues:\n    $$20",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "remainder-6",
+            "prompt": "What is the remainder when (221 * 13 + 15) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "15",
+            "answer": "To find the remainder when $(221 \\times 13 + 15)$ is divided by $17$, we can use modular arithmetic properties.\n\n1.  **Analyze the term $221$ modulo $17$:**\n    We check if $221$ is divisible by $17$.\n    $$ 221 \\div 17 = 13 $$\n    Since $17 \\times 13 = 221$, we have:\n    $$ 221 \\equiv 0 \\pmod{17} $$\n\n2.  **Substitute this back into the expression:**\n    The expression is $221 \\times 13 + 15$.\n    $$ 221 \\times 13 + 15 \\equiv 0 \\times 13 + 15 \\pmod{17} $$\n    $$ 0 + 15 \\equiv 15 \\pmod{17} $$\n\n3.  **Conclusion:**\n    The remainder is $15$.\n\nFINAL=15",
+            "passed": false,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 239,
+              "total_tokens": 283
+            }
+          },
+          {
+            "name": "remainder-7",
+            "prompt": "What is the remainder when (240 * 14 + 17) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "11",
+            "answer": "FINAL=1",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 4,
+              "total_tokens": 48
+            }
+          },
+          {
+            "name": "remainder-8",
+            "prompt": "What is the remainder when (259 * 15 + 19) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "11",
+            "answer": "To find the remainder when $(259 \\times 15 + 19)$ is divided by $17$, we can use modular arithmetic properties. We want to compute:\n$$ (259 \\times 15 + 19) \\pmod{17} $$\n\n**Step 1: Reduce each term modulo 17.**\n\n1.  **Reduce 259 modulo 17:**\n    Divide 259 by 17:\n    $$ 259 \\div 17 = 15 \\text{ with a remainder of } 4 $$\n    $$ 17 \\times 15 = 255 $$\n    $$ 259 - 255 = 4 $$\n    So, $259 \\equiv 4 \\pmod{17}$.\n\n2.  **Reduce 15 modulo 17:**\n    Since $15 < 17$,\n    $$ 15 \\equiv 15 \\pmod{17} $$\n    Alternatively, $15 \\equiv -2 \\pmod{17}$, which might make multiplication easier. Let's use $",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "remainder-9",
+            "prompt": "What is the remainder when (278 * 16 + 21) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "15",
+            "answer": "To find the remainder when $(278 \\times 16 + 21)$ is divided by $17$, we can use modular arithmetic properties. We want to compute:\n$$ (278 \\times 16 + 21) \\pmod{17} $$\n\n**Step 1: Reduce each term modulo 17.**\n\n1.  **Reduce 278 modulo 17:**\n    Divide 278 by 17:\n    $$ 278 \\div 17 = 16 \\text{ with a remainder of } 6 $$\n    $$ 17 \\times 16 = 272 $$\n    $$ 278 - 272 = 6 $$\n    So, $278 \\equiv 6 \\pmod{17}$.\n\n2.  **Reduce 16 modulo 17:**\n    $$ 16 \\equiv -1 \\pmod{17} $$\n    (Using $-1$ is often easier for multiplication).\n\n3.  **Reduce 21 modulo 17:**\n    $$ 21 \\div 17 = ",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "remainder-10",
+            "prompt": "What is the remainder when (297 * 17 + 23) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "6",
+            "answer": "FINAL=6",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 4,
+              "total_tokens": 48
+            }
+          },
+          {
+            "name": "remainder-11",
+            "prompt": "What is the remainder when (316 * 18 + 25) is divided by 17? Reply only with FINAL=<integer>.",
+            "expected": "1",
+            "answer": "To find the remainder when $(316 \\times 18 + 25)$ is divided by $17$, we can use modular arithmetic properties. We want to compute:\n$$ (316 \\times 18 + 25) \\pmod{17} $$\n\n**Step 1: Reduce each term modulo 17.**\n\n1.  **Reduce 316 modulo 17:**\n    Divide 316 by 17:\n    $$ 316 \\div 17 = 18 \\text{ with a remainder of } 10 $$\n    $$ 17 \\times 18 = 306 $$\n    $$ 316 - 306 = 10 $$\n    So, $316 \\equiv 10 \\pmod{17}$.\n\n2.  **Reduce 18 modulo 17:**\n    $$ 18 = 17 \\times 1 + 1 $$\n    So, $18 \\equiv 1 \\pmod{17}$.\n\n3.  **Reduce 25 modulo 17:**\n    $$ 2",
+            "passed": false,
+            "answer_correct": false,
+            "usage": {
+              "prompt_tokens": 44,
+              "completion_tokens": 256,
+              "total_tokens": 300
+            }
+          },
+          {
+            "name": "recall-0",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7319.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7319",
+            "answer": "violet-7319",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-1",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7456.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7456",
+            "answer": "violet-7456",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-2",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7593.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7593",
+            "answer": "violet-7593",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-3",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7730.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7730",
+            "answer": "violet-7730",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-4",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-7867.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-7867",
+            "answer": "violet-7867",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-5",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-8004.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-8004",
+            "answer": "violet-8004",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-6",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-8141.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-8141",
+            "answer": "violet-8141",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "recall-7",
+            "prompt": "The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nThe verification key is violet-8278.\nThe record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. The record contains ordinary inventory notes. \nReturn only the verification key.",
+            "expected": "violet-8278",
+            "answer": "violet-8278",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 1712,
+              "completion_tokens": 8,
+              "total_tokens": 1720
+            }
+          },
+          {
+            "name": "json-0",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 13 + 0, and \"label\" equal to \"sample-0\". No markdown.",
+            "expected": {
+              "sum": 13,
+              "label": "sample-0"
+            },
+            "answer": "{\"sum\": 13, \"label\": \"sample-0\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 48,
+              "completion_tokens": 16,
+              "total_tokens": 64
+            }
+          },
+          {
+            "name": "json-1",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 14 + 7, and \"label\" equal to \"sample-1\". No markdown.",
+            "expected": {
+              "sum": 21,
+              "label": "sample-1"
+            },
+            "answer": "{\"sum\": 21, \"label\": \"sample-1\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 48,
+              "completion_tokens": 16,
+              "total_tokens": 64
+            }
+          },
+          {
+            "name": "json-2",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 15 + 14, and \"label\" equal to \"sample-2\". No markdown.",
+            "expected": {
+              "sum": 29,
+              "label": "sample-2"
+            },
+            "answer": "{\"sum\": 29, \"label\": \"sample-2\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-3",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 16 + 21, and \"label\" equal to \"sample-3\". No markdown.",
+            "expected": {
+              "sum": 37,
+              "label": "sample-3"
+            },
+            "answer": "{\"sum\": 37, \"label\": \"sample-3\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-4",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 17 + 28, and \"label\" equal to \"sample-4\". No markdown.",
+            "expected": {
+              "sum": 45,
+              "label": "sample-4"
+            },
+            "answer": "{\"sum\": 45, \"label\": \"sample-4\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-5",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 18 + 35, and \"label\" equal to \"sample-5\". No markdown.",
+            "expected": {
+              "sum": 53,
+              "label": "sample-5"
+            },
+            "answer": "{\"sum\": 53, \"label\": \"sample-5\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-6",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 19 + 42, and \"label\" equal to \"sample-6\". No markdown.",
+            "expected": {
+              "sum": 61,
+              "label": "sample-6"
+            },
+            "answer": "{\"sum\": 61, \"label\": \"sample-6\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          },
+          {
+            "name": "json-7",
+            "prompt": "Return only a JSON object with exactly these fields: \"sum\" equal to 20 + 49, and \"label\" equal to \"sample-7\". No markdown.",
+            "expected": {
+              "sum": 69,
+              "label": "sample-7"
+            },
+            "answer": "{\"sum\": 69, \"label\": \"sample-7\"}",
+            "passed": true,
+            "answer_correct": true,
+            "usage": {
+              "prompt_tokens": 49,
+              "completion_tokens": 16,
+              "total_tokens": 65
+            }
+          }
+        ]
+      },
+      "telemetry": {
+        "samples": 1409,
+        "duration_s": 1471.0477565199835,
+        "swap_start_bytes": 3007504384,
+        "memory_guard_gib": 12,
+        "memory_guard_triggered": false,
+        "swap_end_bytes": 3003359232,
+        "swap_growth_bytes": 0,
+        "cgroup": {
+          "start": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-22789aa0-aba2-4504-97eb-e23bbe599565.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 88752128,
+            "swap_peak_bytes": 348413952,
+            "oom_kill": 0
+          },
+          "end": {
+            "path": "/user.slice/user-1000.slice/user@1000.service/tmux-spawn-22789aa0-aba2-4504-97eb-e23bbe599565.scope",
+            "swap_max": "max",
+            "swap_current_bytes": 87773184,
+            "swap_peak_bytes": 348413952,
+            "oom_kill": 0
+          },
+          "delta": {
+            "oom_kill": 0,
+            "swap_current_bytes": -978944
+          }
+        },
+        "power_w_avg": 44.76761533002129,
+        "power_w_peak": 56.46,
+        "temperature_c_peak": 68.0,
+        "utilization_pct_avg": 84.83534421575585,
+        "request_energy_j_est": 65855.30009597745,
+        "mem_available_gib_min": 27.106670379638672,
+        "nvme_temperature_c_peak": 53.85,
+        "swap_in_pages_delta": 1354,
+        "swap_out_pages_delta": 0,
+        "page_faults_delta": 38025808,
+        "major_faults_delta": 1414,
+        "oom_kill_delta": 0
+      }
+    }
+  },
+  "comparison": {
+    "short": {
+      "requests": 3,
+      "identical_output_count": 3,
+      "changed_output_indices": [],
+      "ttft_reduction_percent": -0.0715123842062404,
+      "decode_change_percent": -0.13110552774474593,
+      "request_time_reduction_percent": -0.10473306446474595
+    },
+    "random1k": {
+      "requests": 30,
+      "identical_output_count": 30,
+      "changed_output_indices": [],
+      "ttft_reduction_percent": 10.503657963519487,
+      "decode_change_percent": -0.25033167062017414,
+      "request_time_reduction_percent": 1.9663708366132848
+    },
+    "speedbench8k": {
+      "requests": 30,
+      "identical_output_count": 30,
+      "changed_output_indices": [],
+      "ttft_reduction_percent": 15.801855168787194,
+      "decode_change_percent": 0.676137272675903,
+      "request_time_reduction_percent": 11.281182939032375
+    }
+  },
+  "quality_comparison": {
+    "baseline_passed": 42,
+    "optimized_passed": 42,
+    "total": 52,
+    "new_failures": [],
+    "identical_answers": 52
+  },
+  "tests": {
+    "passed": 223,
+    "final_verification_command": "PYTHONPATH=$REPO/python SPARKLAB_DISABLE_KERNEL_CACHE=1 $REPO/.venv/bin/python -m pytest -q tests/kernels/test_qwen4_qsa_prefill.py tests/models/test_qwen4_ple_batch.py tests/models/test_qwen4_exp.py tests/models/test_qwen4_qsa_metadata.py",
+    "final_verification_log": "results/qwen38-flash-next-opt-20260910/final-tests.log",
+    "commands": [
+      "PYTHONPATH=$SOURCE/python SPARKLAB_DISABLE_KERNEL_CACHE=1 $REPO/.venv/bin/python -m pytest -q $SOURCE/tests/kernels/test_qwen4_qsa_prefill.py",
+      "PYTHONPATH=$SOURCE/python SPARKLAB_DISABLE_KERNEL_CACHE=1 $REPO/.venv/bin/python -m pytest -q $SOURCE/tests/models/test_qwen4_ple_batch.py $SOURCE/tests/models/test_qwen4_exp.py $SOURCE/tests/models/test_qwen4_qsa_metadata.py"
+    ],
+    "coverage": [
+      "Exact selected-row equality for causal/dense/sparse boundaries, cached prefixes, tails, production budget and tied scores.",
+      "Raw and safetensors PLE batch lookups across shards, scaled FP8/BF16, repeats, eviction, async order and short-read failure.",
+      "Bitwise attention-output equality through the backend for a batch mixing sparse prefill, dense prefill and sparse decode requests.",
+      "Existing Qwen4 model, MTP, PLE, and QSA metadata regressions."
+    ],
+    "final_verification_result": "223 passed in 5.49s"
+  },
+  "component_benchmarks": {
+    "qsa": [
+      {
+        "variant": "batched",
+        "elapsed_s": 0.8811266570119187,
+        "exact_rows": true,
+        "selected_rows": 15081760
+      },
+      {
+        "variant": "legacy",
+        "elapsed_s": 2.717427844996564,
+        "exact_rows": true,
+        "selected_rows": 15081760
+      },
+      {
+        "variant": "batched",
+        "elapsed_s": 0.04458973603323102,
+        "exact_rows": true,
+        "selected_rows": 15081760
+      },
+      {
+        "variant": "legacy",
+        "elapsed_s": 0.19850754702929407,
+        "exact_rows": true,
+        "selected_rows": 15081760
+      }
+    ],
+    "ple_warm_file": [
+      {
+        "index": 0,
+        "variant": "legacy",
+        "seconds": 2.9977408300619572,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "1",
+        "seconds": 0.12525221600662917,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "2",
+        "seconds": 0.26494954200461507,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "4",
+        "seconds": 0.41977973002940416,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "8",
+        "seconds": 0.5328234980115667,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "16",
+        "seconds": 0.503192231990397,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "legacy",
+        "seconds": 2.9667569550219923,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 1,
+        "variant": "legacy",
+        "seconds": 2.5374918109737337,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 1,
+        "variant": "1",
+        "seconds": 0.10964766098186374,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 1,
+        "variant": "2",
+        "seconds": 0.23640954797156155,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 1,
+        "variant": "4",
+        "seconds": 0.315289327991195,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 1,
+        "variant": "8",
+        "seconds": 0.4151847430039197,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 1,
+        "variant": "16",
+        "seconds": 0.42993555299472064,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 1,
+        "variant": "legacy",
+        "seconds": 2.659327866975218,
+        "output_sha256": "8562bf23b5a7aee579a6754df94d64f46ff1b918db1a7318466b3f7247f2c369"
+      },
+      {
+        "index": 2,
+        "variant": "legacy",
+        "seconds": 3.343332424061373,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      },
+      {
+        "index": 2,
+        "variant": "1",
+        "seconds": 0.14236046303994954,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      },
+      {
+        "index": 2,
+        "variant": "2",
+        "seconds": 0.30566860898397863,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      },
+      {
+        "index": 2,
+        "variant": "4",
+        "seconds": 0.4200735379708931,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      },
+      {
+        "index": 2,
+        "variant": "8",
+        "seconds": 0.5360605869209394,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      },
+      {
+        "index": 2,
+        "variant": "16",
+        "seconds": 0.5666219700360671,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      },
+      {
+        "index": 2,
+        "variant": "legacy",
+        "seconds": 3.419467583997175,
+        "output_sha256": "69ba80128b6ede0bcc7538d3deec3b0711278cdcd7eb1650005277abbfae59b6"
+      }
+    ],
+    "ple_cold_file": [
+      {
+        "index": 0,
+        "variant": "legacy",
+        "seconds": 4.502395865973085,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "1",
+        "seconds": 25.29597711400129,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "2",
+        "seconds": 14.234060488059185,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "4",
+        "seconds": 6.987733021029271,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "8",
+        "seconds": 3.7276713229948655,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "16",
+        "seconds": 1.8554548689862713,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      },
+      {
+        "index": 0,
+        "variant": "legacy",
+        "seconds": 4.104494514060207,
+        "output_sha256": "32152059dc26e7ee031b64482b77f23d7d5d034b93103e4f4476d4c89f385ded"
+      }
+    ],
+    "ple_note": "Prototype sweep used 2048-row jobs; final implementation uses 512-row jobs and is measured in the full server comparison. Cold-file sweep used POSIX_FADV_DONTNEED on only the benchmark PLE file."
+  },
+  "source": {
+    "raw_directory": "results/qwen38-flash-next-opt-20260910",
+    "suite_sha256": "38316b0c391b4dc37c57923315389d69663a98aa90b20a5c8b1e04dc6f15f7fb",
+    "previous_framework_comparison": "GB10-QWEN38-FLASH-NEXT-FRAMEWORKS-001",
+    "raw_manifest": {
+      "path": "results/qwen38-flash-next-opt-20260910/raw-manifest.json",
+      "sha256": "6346b78f2b72a9319ed3af3b9a3eb3a430e044d2fce5ee77dfb968265a7d9f5e",
+      "file_count": 62
+    },
+    "promoted_files_match_measured_candidate": true
+  },
+  "limitations": [
+    "The measured profile is the existing opt-in fast MTP3 profile; its historical MGSM result was 92/100 versus 94/100 for the older profile. This optimization does not establish general quality parity or remove that limitation.",
+    "Quality validation is the fixed 52-case smoke suite plus paired fixed-budget speed outputs and exact kernel/row tests; MGSM and production endurance were not rerun.",
+    "One client, with 131072-token BF16 KV capacity and 12288-token sequence cap; no new long-context or concurrency certification.",
+    "Short repeats use prefix caching in both native runs; long distinct prompts use the same frozen corpus and warmup protocol.",
+    "Sequential fresh servers on the same host; no other benchmarks or downloads ran during speed measurements. Pre-existing host swap and any additional traffic are reported in telemetry.",
+    "Previous vLLM/SGLang figures are historical references with separate checkpoint/configuration limitations; external engines were not rerun for this optimization."
+  ],
+  "path_notation": "Published paths replace the benchmark host home directory with $HOME; expand that placeholder to reproduce commands. Raw local evidence retains the original paths."
+}

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -167,6 +167,22 @@ have the `SPARKLAB_QWEN4_` prefix). The measured speed runs additionally used
 See the [focused quality runner](../../benchmarks/quality/README.md#focused-qwen4-optimization-regressions)
 for the fixed paired evaluation protocols.
 
+## Prefill batching
+
+The native source runtime now batches large PLE row reads and sparse-QSA prompt
+selection automatically. A paired single-client run of the fast MTP3 profile
+above reduced mean TTFT from **2.21 to 1.98 seconds** for
+1,024-token prompts and **23.01 to 19.37 seconds** for approximately 8K-token
+prompts. Each workload used 30 requests with 256 output tokens. Decode speed was
+essentially unchanged; the short repeated prompt remained about 42 tok/s.
+
+Weights, precision and recipe flags are unchanged. The paired measured outputs
+matched for 63/63 requests. The arithmetic/recall/JSON smoke suite, run after the
+speed workloads, scored 42/52 before and 42/52 after, with 0 new failures.
+This preserves the measured baseline's existing failures; MGSM was not rerun.
+See the [prefill report](../../benchmarks/frameworks/QWEN38_FLASH_NEXT_PREFILL_20260910.md)
+and [versioned evidence](../../benchmarks/gb10/results/GB10-QWENNVIDIA-006.json).
+
 ## Experimental reduced draft vocabulary
 
 An independent experiment inspired by

--- a/python/sparklab/attention/qsa.py
+++ b/python/sparklab/attention/qsa.py
@@ -416,6 +416,7 @@ class QSAAttnBackend(BaseAttnBackend):
             raise RuntimeError("QSA index queries are required beyond the dense budget")
 
         selected: list[torch.Tensor] = []
+        counts_list: list[int] = []
         for req_idx, req in enumerate(reqs):
             q0, q1 = md.qo_indptr[req_idx : req_idx + 2]
             physical = ctx.page_table[req.table_idx, : req.device_len].to(torch.int32)
@@ -439,13 +440,27 @@ class QSAAttnBackend(BaseAttnBackend):
                 )
                 if sparse else None
             )
-            for local, iq in enumerate(index_q[q0:q1]):
-                selected.append(self._selected_rows(
-                    iq, pooled, physical, req.cached_len + local + 1,
-                ))
+            if sparse and self._fused_selection and index_q.is_cuda and q1 - q0 >= 32:
+                from sparklab.kernels.triton.qwen4_qsa_prefill import qsa_prefill_indices
+
+                rows, row_counts = qsa_prefill_indices(
+                    index_q[q0:q1].contiguous(), pooled.contiguous(), physical,
+                    cached_len=req.cached_len,
+                    ratio=self.args.index_compress_ratio,
+                    topk=self.args.index_block_topk,
+                )
+                selected.append(rows)
+                counts_list.extend(row_counts)
+            else:
+                for local, iq in enumerate(index_q[q0:q1]):
+                    rows = self._selected_rows(
+                        iq, pooled, physical, req.cached_len + local + 1,
+                    )
+                    selected.append(rows)
+                    counts_list.append(rows.numel())
 
         counts = torch.tensor(
-            [x.numel() for x in selected], dtype=torch.int32, device=self.device
+            counts_list, dtype=torch.int32, device=self.device
         )
         indptr = torch.cat((counts.new_zeros(1), counts.cumsum(0)))
         indices = torch.cat(selected) if selected else counts.new_empty(0)

--- a/python/sparklab/kernels/triton/qwen4.py
+++ b/python/sparklab/kernels/triton/qwen4.py
@@ -234,8 +234,19 @@ def _qsa_index_scores_kernel(
     dim: tl.constexpr,
     block_d: tl.constexpr,
     scale: tl.constexpr,
+    stride_qq=0,
+    cached_len=0,
+    ratio: tl.constexpr = 1,
+    batched: tl.constexpr = False,
 ):
     row = tl.program_id(0)
+    query_row = tl.program_id(1)
+    if batched:
+        query_ptr += query_row * stride_qq
+        score_ptr += query_row * rows
+        if row >= (cached_len + query_row + 1) // ratio:
+            tl.store(score_ptr + row, float("-inf"))
+            return
     offsets = tl.arange(0, block_d)
     mask = offsets < dim
     key = tl.load(

--- a/python/sparklab/kernels/triton/qwen4_qsa_prefill.py
+++ b/python/sparklab/kernels/triton/qwen4_qsa_prefill.py
@@ -1,0 +1,113 @@
+"""Batched causal QSA selection, preserving the single-query reduction and ties."""
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from .qwen4 import _qsa_index_scores_kernel
+
+
+@triton.jit
+def _dense_rows(physical, indptr, output, cached_len, block: tl.constexpr):
+    query = tl.program_id(0)
+    offsets = tl.arange(0, block)
+    visible = cached_len + query + 1
+    start = tl.load(indptr + query)
+    rows = tl.load(physical + offsets, offsets < visible, other=0)
+    tl.store(output + start + offsets, rows, offsets < visible)
+
+
+@triton.jit
+def _sparse_rows(
+    blocks, physical, indptr, output, query_start, cached_len,
+    stride_blocks, topk: tl.constexpr, ratio: tl.constexpr,
+):
+    local = tl.program_id(0)
+    query = query_start + local
+    visible = cached_len + query + 1
+    start = tl.load(indptr + query)
+    offsets = tl.arange(0, topk)
+    selected = tl.load(blocks + local * stride_blocks + offsets).to(tl.int32)
+    selected = tl.sort(selected, descending=False)
+    token = tl.arange(0, ratio)
+    logical = selected[:, None] * ratio + token[None, :]
+    rows = tl.load(physical + logical)
+    tl.store(output + start + offsets[:, None] * ratio + token[None, :], rows)
+    tail_start = visible // ratio * ratio
+    tail = tl.load(physical + tail_start + token, token < visible % ratio, other=0)
+    tl.store(output + start + topk * ratio + token, tail, token < visible % ratio)
+
+
+def qsa_prefill_indices(
+    query: torch.Tensor,
+    pooled_keys: torch.Tensor,
+    physical_rows: torch.Tensor,
+    *,
+    cached_len: int,
+    ratio: int,
+    topk: int,
+    chunk_size: int = 128,
+) -> tuple[torch.Tensor, list[int]]:
+    """Pack chronological physical rows for a contiguous span of query tokens.
+
+    Scores use the decode kernel's FP32 reduction, with a causal mask per query.
+    Boundary ties fall back to the original one-dimensional top-k: padding scores
+    with -inf can otherwise change which equally scored blocks PyTorch selects.
+    Chunking bounds the number of query rows in score/top-k scratch memory.
+    """
+    if not (query.is_cuda and pooled_keys.is_cuda and physical_rows.is_cuda):
+        raise ValueError("QSA prefill selection requires CUDA tensors")
+    if query.ndim != 3 or pooled_keys.ndim != 2 or physical_rows.ndim != 1:
+        raise ValueError("expected query [tokens, heads, dim], keys [blocks, dim], rows [tokens]")
+    if query.device != pooled_keys.device or query.device != physical_rows.device:
+        raise ValueError("QSA inputs must share a CUDA device")
+    if query.shape[-1] != pooled_keys.shape[-1]:
+        raise ValueError("QSA query/key dimensions must match")
+    if not all(x.is_contiguous() for x in (query, pooled_keys, physical_rows)):
+        raise ValueError("QSA prefill selection requires contiguous inputs")
+    if cached_len < 0 or chunk_size <= 0:
+        raise ValueError("cached_len must be nonnegative and chunk_size positive")
+    if any(x <= 0 or x & (x - 1) for x in (ratio, topk)):
+        raise ValueError("QSA ratio and topk must be positive powers of two")
+    tokens, heads, dim = query.shape
+    if cached_len + tokens > physical_rows.numel():
+        raise ValueError("physical rows do not cover the query span")
+    if (cached_len + tokens) // ratio > pooled_keys.shape[0]:
+        raise ValueError("pooled keys do not cover the query span")
+    counts = [min(v // ratio, topk) * ratio + v % ratio
+              for v in range(cached_len + 1, cached_len + tokens + 1)]
+    offsets = [0]
+    for count in counts:
+        offsets.append(offsets[-1] + count)
+    indptr = torch.tensor(offsets, dtype=torch.int64, device=query.device)
+    output = torch.empty(offsets[-1], dtype=physical_rows.dtype, device=query.device)
+    dense = min(tokens, max(0, (topk + 1) * ratio - 1 - cached_len))
+    if dense:
+        _dense_rows[(dense,)](
+            physical_rows, indptr, output, cached_len,
+            block=triton.next_power_of_2((topk + 1) * ratio - 1),
+        )
+    for start in range(dense, tokens, chunk_size):
+        stop = min(tokens, start + chunk_size)
+        # Do not score keys that are invisible to every query in this chunk.
+        key_count = (cached_len + stop) // ratio
+        scores = torch.empty((stop - start, key_count), dtype=torch.float32, device=query.device)
+        _qsa_index_scores_kernel[(key_count, stop - start)](
+            query[start:stop], pooled_keys, scores,
+            query.stride(1), pooled_keys.stride(0), key_count,
+            heads=heads, dim=dim, block_d=triton.next_power_of_2(dim),
+            scale=dim ** -0.5, stride_qq=query.stride(0),
+            cached_len=cached_len + start, ratio=ratio, batched=True, num_warps=4,
+        )
+        best = torch.topk(scores, topk + 1, dim=-1, sorted=True)
+        blocks = best.indices[:, :topk].contiguous()
+        tied = (best.values[:, topk - 1] == best.values[:, topk]).nonzero().flatten().tolist()
+        for local in tied:
+            complete = (cached_len + start + local + 1) // ratio
+            blocks[local] = torch.topk(scores[local, :complete], topk, sorted=False).indices
+        _sparse_rows[(stop - start,)](
+            blocks, physical_rows, indptr, output, start, cached_len,
+            blocks.stride(0), topk=topk, ratio=ratio, num_warps=8,
+        )
+    return output, counts

--- a/python/sparklab/models/qwen4_exp/ple.py
+++ b/python/sparklab/models/qwen4_exp/ple.py
@@ -97,6 +97,9 @@ class _CachedRowStore:
         self._row_cache_capacity = (cache_mb << 20) // self.row_bytes
         self._row_cache: OrderedDict[int, bytes] = OrderedDict()
 
+    def _read_batch(self, keys: list[int]) -> list[bytes]:
+        return [self._read_one(key) for key in keys]
+
     def _lookup_rows(self, keys: list[int]) -> list[bytes]:
         rows: list[bytes | None] = [None] * len(keys)
         missing_positions, missing_keys = [], []
@@ -109,7 +112,15 @@ class _CachedRowStore:
                 self._row_cache.move_to_end(key)
                 rows[position] = value
         if missing_keys:
-            loaded = list(self._executor.map(self._read_one, missing_keys))
+            if len(missing_keys) >= 4096:
+                # Keep parallel NVMe reads but amortize Future/queue overhead:
+                # long prompts can need over 100K tiny rows. map preserves batch
+                # order, so row reconstruction and cache insertion are unchanged.
+                batches = [missing_keys[i:i + 512] for i in range(0, len(missing_keys), 512)]
+                loaded = [row for batch in self._executor.map(self._read_batch, batches)
+                          for row in batch]
+            else:
+                loaded = list(self._executor.map(self._read_one, missing_keys))
             for position, key, value in zip(missing_positions, missing_keys, loaded):
                 rows[position] = value
                 if self._row_cache_capacity:

--- a/tests/kernels/test_qwen4_qsa_prefill.py
+++ b/tests/kernels/test_qwen4_qsa_prefill.py
@@ -1,0 +1,97 @@
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@pytest.mark.parametrize("cached,tokens,topk,ratio,heads,dim", [
+    (0, 40, 4, 4, 3, 16),       # dense prefix, causal boundary, all tail lengths
+    (15, 37, 4, 4, 3, 16),      # cached prefix straddling the sparse boundary
+    (63, 35, 8, 2, 4, 32),      # entirely sparse, partial chunks
+    (8001, 33, 512, 4, 16, 128), # production budget and long cached context
+    (0, 0, 4, 4, 3, 16),
+])
+@pytest.mark.parametrize("tied", [False, True])
+def test_prefill_selection_matches_per_query_reference(cached, tokens, topk, ratio, heads, dim, tied):
+    from sparklab.kernels.triton.qwen4 import qsa_index_scores
+    from sparklab.kernels.triton.qwen4_qsa_prefill import qsa_prefill_indices
+
+    torch.manual_seed(810)
+    query = torch.randn(tokens, heads, dim, device="cuda", dtype=torch.bfloat16)
+    keys = torch.randn((cached + tokens) // ratio, dim, device="cuda", dtype=torch.bfloat16)
+    if tied:
+        query.zero_()
+    physical = torch.randperm(cached + tokens, device="cuda", dtype=torch.int32)
+    actual, counts = qsa_prefill_indices(
+        query, keys, physical, cached_len=cached, ratio=ratio, topk=topk, chunk_size=17,
+    )
+    expected = []
+    for local in range(tokens):
+        visible = cached + local + 1
+        complete = visible // ratio
+        if complete <= topk:
+            rows = physical[:visible]
+        else:
+            score = qsa_index_scores(query[local], keys[:complete])
+            selected = torch.topk(score, topk, sorted=False).indices
+            logical = (selected[:, None] * ratio + torch.arange(ratio, device="cuda")).flatten()
+            logical = torch.cat((logical, torch.arange(complete * ratio, visible, device="cuda"))).sort().values
+            rows = physical[logical]
+        expected.append(rows)
+        assert counts[local] == rows.numel()
+    expected = torch.cat(expected) if expected else physical.new_empty(0)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_backend_packs_mixed_prefill_and_decode_requests(monkeypatch):
+    from types import SimpleNamespace
+
+    from sparklab.attention.qsa import QSAAttnBackend
+    from sparklab.kernels.triton.attention import paged_attention
+
+    torch.manual_seed(918)
+    device = torch.device("cuda")
+    page_table = torch.randperm(384, dtype=torch.int32, device=device).view(3, 128)
+    index_cache = torch.randn(384, 16, dtype=torch.bfloat16, device=device)
+    k_cache = torch.randn(384, 1, 128, dtype=torch.bfloat16, device=device)
+    v_cache = torch.randn_like(k_cache)
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.device = device
+    backend.args = SimpleNamespace(index_compress_ratio=4, index_block_topk=4, index_head_dim=16)
+    backend.config = SimpleNamespace(num_kv_heads=1, head_dim=128)
+    backend.sm_scale = 128 ** -0.5
+    backend._idx_slot = {0: 0}
+    backend._fused_selection = True
+    backend._fast_metadata = False
+    backend.kvcache = SimpleNamespace(
+        store_kv=lambda *args: None, store_index_k=lambda *args: None,
+        index_k_cache=lambda slot: index_cache,
+        k_cache=lambda layer: k_cache, v_cache=lambda layer: v_cache,
+    )
+    # Pooling is independent of selection; provide an already populated cache.
+    backend._pool_completed_keys = lambda *args: None
+    monkeypatch.setattr("sparklab.attention.qsa.get_global_ctx", lambda: SimpleNamespace(page_table=page_table))
+    reqs = [SimpleNamespace(table_idx=i, cached_len=c, extend_len=n, device_len=c+n)
+            for i, (c, n) in enumerate([(0, 40), (0, 5), (63, 1)])]
+    batch = SimpleNamespace(reqs=reqs, out_loc=torch.arange(46, device=device))
+    backend.prepare_metadata(batch)
+    assert batch.attn_metadata.dense_indices is None
+    query = torch.randn(46, 2, 128, dtype=torch.bfloat16, device=device)
+    index_query = torch.randn(46, 3, 16, dtype=torch.bfloat16, device=device)
+    actual = backend.qsa_forward(query, None, None, index_query, None, None, None, 0, batch)
+
+    rows = []
+    for i, req in enumerate(reqs):
+        q0, q1 = batch.attn_metadata.qo_indptr[i:i+2]
+        physical = page_table[i, :req.device_len]
+        pooled = index_cache[physical[3:req.device_len//4*4:4].long()]
+        rows.extend(backend._selected_rows(iq, pooled, physical, req.cached_len+j+1)
+                    for j, iq in enumerate(index_query[q0:q1]))
+    counts = torch.tensor([r.numel() for r in rows], dtype=torch.int32, device=device)
+    expected = paged_attention(
+        q=query, k_cache=k_cache, v_cache=v_cache,
+        indptr=torch.cat((counts.new_zeros(1), counts.cumsum(0))), indices=torch.cat(rows),
+        q_to_req=batch.attn_metadata.q_to_req, q_positions=counts.long()-1,
+        sm_scale=backend.sm_scale,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/models/test_qwen4_ple_batch.py
+++ b/tests/models/test_qwen4_ple_batch.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from sparklab.models.qwen4_exp.ple import RawNGramStore, SafetensorNGramStore
+
+
+@pytest.mark.parametrize("kind", ["raw", "safetensors"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_large_lookup_preserves_rows_scale_and_async_order(tmp_path, kind, dtype):
+    rows, dim = 5003, 4
+    values = ((torch.arange(rows * dim).reshape(rows, dim) % 81 - 40) / 4).to(dtype)
+    if kind == "raw":
+        data = values.view(torch.uint8).numpy().tobytes()
+        (tmp_path / "table.bin").write_bytes(data)
+        manifest = {"file": "table.bin", "dtype": str(dtype).removeprefix("torch."),
+                    "rows": rows, "dim": dim, "nbytes": len(data), "weight_scale": .125}
+        store = RawNGramStore(str(tmp_path), manifest, dim)
+    else:
+        prefix = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding"
+        tensors = {prefix + ".shard_0.weight": values[:2501].contiguous(),
+                   prefix + ".shard_1.weight": values[2501:].contiguous(),
+                   prefix + ".weight_scale": torch.tensor([.125], dtype=torch.bfloat16)}
+        save_file(tensors, tmp_path / "table.safetensors")
+        (tmp_path / "model.safetensors.index.json").write_text(json.dumps({
+            "weight_map": {k: "table.safetensors" for k in tensors}}))
+        store = SafetensorNGramStore(str(tmp_path), 2, dim)
+    store._row_cache_capacity = 64  # exercise eviction between mixed cached/missing lookups
+    torch.manual_seed(45)
+    ids = torch.cat((torch.randperm(rows), torch.tensor([5002, 0, 2500, 2501, 3])))
+    expected = (values.float() * .125).to(torch.bfloat16)[ids]
+    try:
+        torch.testing.assert_close(store.lookup(ids), expected, rtol=0, atol=0)
+        torch.testing.assert_close(store.lookup_async(ids).result(), expected, rtol=0, atol=0)
+        assert len(store._row_cache) <= 64
+    finally:
+        store.close()
+
+
+def test_large_lookup_propagates_short_read_without_caching_partial_result(tmp_path):
+    rows, dim = 5003, 4
+    (tmp_path / "table.bin").write_bytes(bytes(rows * dim * 2 - 1))
+    store = RawNGramStore(str(tmp_path), {
+        "file": "table.bin", "dtype": "bfloat16", "rows": rows,
+        "dim": dim, "nbytes": rows * dim * 2,
+    }, dim)
+    try:
+        with pytest.raises(OSError, match="short n-gram row read"):
+            store.lookup(torch.arange(rows))
+        assert not store._row_cache
+    finally:
+        store.close()


### PR DESCRIPTION
## Outcome

Reduce Qwen3.8-Flash-Next prompt latency by batching large PLE row reads on the existing I/O pool and batching causal QSA selection. Preserve the existing FP32 score reduction, chronological selected rows, and original top-k behavior at tied boundaries; small decode/MTP verification batches keep their existing path.

On the paired single-client NVIDIA fast MTP3 profile, 1K/256 mean TTFT improves from 2.21 to 1.98 seconds (10.5%), and ~8K/256 from 23.01 to 19.37 seconds (15.8%). Full ~8K request time falls 11.3%. Decode speed is essentially unchanged. Weights, precision, recipe flags and portfolio numbers are unchanged.

Includes the preceding vLLM/SGLang comparison referenced by the optimization report. Those external results use separately documented checkpoint/configuration choices; they were not rerun for this optimization.

Evidence: [prefill report](https://github.com/sixteen-miles-labs/sparklab/blob/62a90b2e169af0879d28246e558603d869eb5203/benchmarks/frameworks/QWEN38_FLASH_NEXT_PREFILL_20260910.md), [GB10-QWENNVIDIA-006](https://github.com/sixteen-miles-labs/sparklab/blob/62a90b2e169af0879d28246e558603d869eb5203/benchmarks/gb10/results/GB10-QWENNVIDIA-006.json), and [framework comparison](https://github.com/sixteen-miles-labs/sparklab/blob/62a90b2e169af0879d28246e558603d869eb5203/benchmarks/frameworks/QWEN38_FLASH_NEXT_20260909.md). Published evidence substitutes `$HOME` for the host home directory; metrics and hashes are preserved.

## Validation

- 223 focused tests passed in 5.49 seconds: `PYTHONPATH=python SPARKLAB_DISABLE_KERNEL_CACHE=1 .venv/bin/python -m pytest -q tests/kernels/test_qwen4_qsa_prefill.py tests/models/test_qwen4_ple_batch.py tests/models/test_qwen4_exp.py tests/models/test_qwen4_qsa_metadata.py`.
- 140 paired speed requests including warmups completed; all 63 measured output texts are identical. The same post-speed 52-case smoke suite scored 42/52 before and after, with all 52 answers identical and no new failures. Existing failures and the fast profile's historical MGSM limitation remain; MGSM was not rerun.
- Exact equality across all 15,081,760 selected physical rows in an 8K-shaped QSA component benchmark. Tests cover tied scores, cached prefixes, tails, mixed prefill/decode packing, scaled FP8/BF16 PLE stores, cache eviction and read failures.
- No OOM or memory-guard events in either run; both servers stopped. Source hashes match the measured candidate. Public-tree hygiene and `git diff --check` pass.
- The local hosted-equivalent CPU suite passed: 1,249 passed, 92 skipped in 8.33 seconds (`CUDA_VISIBLE_DEVICES="" PYTHONPATH=python SPARKLAB_DISABLE_JIT=1`, using the paths and marker filter in `.github/workflows/pr-checks.yml`). Hosted CPU tests and DCO checks must pass before merge.

Implementation and documentation were prepared with Codex assistance and validated against the recorded tests and measurements.

## Checklist

- [x] The change is focused and contains no unrelated generated files or credentials.
- [x] Behavior changes include tests and relevant documentation.
- [x] Model, performance, or certification claims link exact versioned evidence.
- [x] Public API, package, artifact-format, or compatibility changes have a design issue. (Not applicable: none changed.)
- [x] Every commit includes a DCO `Signed-off-by` line.
- [x] I have the right to submit all code, data, and documentation in this pull request.
