### PR TITLE
Add native vision support for Qwen 3.6, 3.8 and Flash-Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
   </tbody>
 </table>
 
+Qwen3.6-35B-A3B, Qwen3.8-27B and Flash-Next support [experimental native image inputs](docs/models/qwen-vision.md)
+through the source-only `--vision-model` option. The table reports their separate text profiles.
+
 Status meanings:
 
 - **Experimental:** implementation or measured evidence exists, but required gates remain

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -6,6 +6,9 @@ recipes. Raw logs and large result streams stay outside the source repository.
 - `results/GB10-DSV41-PORTFOLIO-001.json` records the native DeepSeek V4.1 Flash
   short probe: 0.244 decode tok/s and 343.131 s warm TTFT, medians of three
   trials after one warmup with 74 input and 128 output tokens.
+- `results/GB10-QWENVISION-001.json` records native image-input integration for
+  Qwen3.6-35B-A3B and Qwen3.8-27B: color/order/repeat and API checks pass;
+  both models fail the single OCR probe.
 - `result.schema.json` defines the versioned summary contract.
 - `results/GB10-QWEN38-27B-PORTFOLIO-001.json` reruns the original 96-input/
   128-output short probe on the default RadixArk + FP4 prefill + DFlash2-12 recipe:
@@ -129,3 +132,5 @@ sparklab gate <recipe> <evidence.json> --json
 
 Reduced-layer, dummy-weight, or mismatched-recipe evidence is rejected even for
 Research admission.
+
+- `results/GB10-QWENVISION-002.json` records native Flash-Next image integration: five short image checks, two sparse-context image checks and four API checks pass; the OCR exact-text check fails.

--- a/benchmarks/gb10/results/GB10-QWENVISION-001.json
+++ b/benchmarks/gb10/results/GB10-QWENVISION-001.json
@@ -1,0 +1,246 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWENVISION-001",
+  "status": "measured",
+  "date": "2026-09-10",
+  "hardware": "NVIDIA GB10, one GPU",
+  "backend": "native",
+  "configuration": {
+    "context_tokens": 4096,
+    "speculation": false,
+    "cuda_graphs": false,
+    "text_kernel": "triton",
+    "vision_dtype": "bfloat16",
+    "vision_attention": "Transformers Qwen3.5 SDPA"
+  },
+  "models": {
+    "qwen36-35b": {
+      "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+      "image_checks": [
+        {
+          "case": "red",
+          "expected": "red",
+          "text": " red",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 2,
+            "total_tokens": 95
+          },
+          "elapsed_s": 0.6521768759703264
+        },
+        {
+          "case": "blue",
+          "expected": "blue",
+          "text": " blue",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 2,
+            "total_tokens": 95
+          },
+          "elapsed_s": 0.23323484300635755
+        },
+        {
+          "case": "red_repeat",
+          "expected": "red",
+          "text": " red",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 2,
+            "total_tokens": 95
+          },
+          "elapsed_s": 0.23069187498185784
+        },
+        {
+          "case": "two_images",
+          "expected": "red, blue",
+          "text": "red, blue",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 161,
+            "completion_tokens": 4,
+            "total_tokens": 165
+          },
+          "elapsed_s": 0.34226184198632836
+        },
+        {
+          "case": "reversed",
+          "expected": "blue, red",
+          "text": "Blue, Red",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 161,
+            "completion_tokens": 4,
+            "total_tokens": 165
+          },
+          "elapsed_s": 0.3231698180316016
+        },
+        {
+          "case": "ocr",
+          "expected": "SPARK 42",
+          "text": "PSP 3000",
+          "passed": false,
+          "usage": {
+            "prompt_tokens": 154,
+            "completion_tokens": 8,
+            "total_tokens": 162
+          },
+          "elapsed_s": 0.4019084289902821
+        }
+      ],
+      "api_checks": [
+        {
+          "case": "multi_turn_stream",
+          "passed": true,
+          "status": 200
+        },
+        {
+          "case": "invalid_image",
+          "passed": true,
+          "status": 400
+        },
+        {
+          "case": "remote_url",
+          "passed": true,
+          "status": 400
+        },
+        {
+          "case": "text_after_image",
+          "passed": true,
+          "status": 200
+        }
+      ]
+    },
+    "qwen38-27b": {
+      "revision": "319f741cce68d7914884900c138a1fbb70a42f30",
+      "image_checks": [
+        {
+          "case": "red",
+          "expected": "red",
+          "text": "Red",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 2,
+            "total_tokens": 95
+          },
+          "elapsed_s": 0.9957417810801417
+        },
+        {
+          "case": "blue",
+          "expected": "blue",
+          "text": "Blue",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 2,
+            "total_tokens": 95
+          },
+          "elapsed_s": 0.640219505992718
+        },
+        {
+          "case": "red_repeat",
+          "expected": "red",
+          "text": "Red",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 2,
+            "total_tokens": 95
+          },
+          "elapsed_s": 0.6338611600222066
+        },
+        {
+          "case": "two_images",
+          "expected": "red, blue",
+          "text": "red, blue",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 161,
+            "completion_tokens": 4,
+            "total_tokens": 165
+          },
+          "elapsed_s": 0.9111467539332807
+        },
+        {
+          "case": "reversed",
+          "expected": "blue, red",
+          "text": "blue, red",
+          "passed": true,
+          "usage": {
+            "prompt_tokens": 161,
+            "completion_tokens": 4,
+            "total_tokens": 165
+          },
+          "elapsed_s": 0.8392434730194509
+        },
+        {
+          "case": "ocr",
+          "expected": "SPARK 42",
+          "text": "SPARK2",
+          "passed": false,
+          "usage": {
+            "prompt_tokens": 154,
+            "completion_tokens": 4,
+            "total_tokens": 158
+          },
+          "elapsed_s": 0.845859905006364
+        }
+      ],
+      "api_checks": [
+        {
+          "case": "multi_turn_stream",
+          "passed": true,
+          "status": 200
+        },
+        {
+          "case": "invalid_image",
+          "passed": true,
+          "status": 400
+        },
+        {
+          "case": "remote_url",
+          "passed": true,
+          "status": 400
+        },
+        {
+          "case": "text_after_image",
+          "passed": true,
+          "status": 200
+        }
+      ]
+    }
+  },
+  "limitations": [
+    "Six synthetic image checks per model; both fail OCR. No broad vision benchmark or full-model reference comparison.",
+    "Image requests bypass prefix caching; text-only portfolio performance does not transfer to this eager profile."
+  ],
+  "source": {
+    "raw_directory": "results/qwen-vision-20260910",
+    "probe_sha256": "dc512bef66f2f34091509b6df0fd92a95490cc27c9900e130ac705befec5242b",
+    "api_probe_sha256": "d6f86470016da924958d6f70ac891bebcf7a395a260b34fcec3cc86157ecbc6b"
+  },
+  "tests": {
+    "passed": 847,
+    "command": "SPARKLAB_DISABLE_KERNEL_CACHE=1 python -m pytest tests/multimodal tests/serving tests/tokenizer tests/sparklab tests/models/test_qwen3_5* tests/runtime/scheduler -q"
+  },
+  "reference_ocr": {
+    "engine": "vLLM 0.28.0",
+    "model": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+    "expected": "SPARK 42",
+    "actual": "B E A U T Y",
+    "passed": false,
+    "configuration": {
+      "max_model_len": 4096,
+      "max_num_seqs": 1,
+      "enforce_eager": true,
+      "temperature": 0,
+      "max_tokens": 32,
+      "enable_thinking": false
+    },
+    "note": "Same image and prompt. Different text kernels; this single failed check does not establish parity."
+  }
+}

--- a/benchmarks/gb10/results/GB10-QWENVISION-002.json
+++ b/benchmarks/gb10/results/GB10-QWENVISION-002.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-QWENVISION-002",
+  "status": "measured",
+  "date": "2026-09-10",
+  "hardware": "NVIDIA GB10, one GPU",
+  "backend": "native",
+  "model": "nvidia/Qwen3.8-Flash-Next-NVFP4",
+  "revision": "fab0aecb760cec45227f6656abcaafa11abca87a",
+  "configuration": {
+    "context_tokens": 8192,
+    "speculation": false,
+    "cuda_graphs": false,
+    "max_running_requests": 1,
+    "text_kernel": "triton",
+    "attention": "qsa",
+    "moe_backend": "offload",
+    "moe_storage": "disk",
+    "moe_cache_size": 24576,
+    "moe_preload_all": true,
+    "vision_dtype": "bfloat16",
+    "vision_attention": "Transformers Qwen4Exp SDPA",
+    "temperature": 0,
+    "max_output_tokens": 32,
+    "enable_thinking": false
+  },
+  "image_checks": [
+    {
+      "case": "red",
+      "expected": "red",
+      "text": " Red",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 93,
+        "completion_tokens": 2,
+        "total_tokens": 95
+      },
+      "elapsed_s": 11.017815373954363
+    },
+    {
+      "case": "blue",
+      "expected": "blue",
+      "text": " Blue",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 93,
+        "completion_tokens": 2,
+        "total_tokens": 95
+      },
+      "elapsed_s": 0.5553966109873727
+    },
+    {
+      "case": "red_repeat",
+      "expected": "red",
+      "text": " Red",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 93,
+        "completion_tokens": 2,
+        "total_tokens": 95
+      },
+      "elapsed_s": 0.5564784390153363
+    },
+    {
+      "case": "two_images",
+      "expected": "red, blue",
+      "text": "Red, Blue",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 161,
+        "completion_tokens": 4,
+        "total_tokens": 165
+      },
+      "elapsed_s": 0.8411950670415536
+    },
+    {
+      "case": "reversed",
+      "expected": "blue, red",
+      "text": "Blue, Red",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 161,
+        "completion_tokens": 4,
+        "total_tokens": 165
+      },
+      "elapsed_s": 0.7896557379281148
+    },
+    {
+      "case": "ocr",
+      "expected": "SPARK 42",
+      "text": "spark42",
+      "passed": false,
+      "usage": {
+        "prompt_tokens": 154,
+        "completion_tokens": 4,
+        "total_tokens": 158
+      },
+      "elapsed_s": 0.7378950139973313
+    }
+  ],
+  "sparse_image_checks": [
+    {
+      "case": "sparse_two_images",
+      "expected": "red, blue",
+      "text": "Red, Blue",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 2081,
+        "completion_tokens": 4,
+        "total_tokens": 2085
+      },
+      "elapsed_s": 4.622474379022606
+    },
+    {
+      "case": "sparse_reversed",
+      "expected": "blue, red",
+      "text": "Blue, Red",
+      "passed": true,
+      "usage": {
+        "prompt_tokens": 2081,
+        "completion_tokens": 4,
+        "total_tokens": 2085
+      },
+      "elapsed_s": 4.364169382955879
+    }
+  ],
+  "api_checks": [
+    {
+      "case": "multi_turn_stream",
+      "passed": true,
+      "status": 200
+    },
+    {
+      "case": "invalid_image",
+      "passed": true,
+      "status": 400
+    },
+    {
+      "case": "remote_url",
+      "passed": true,
+      "status": 400
+    },
+    {
+      "case": "text_after_image",
+      "passed": true,
+      "status": 200
+    }
+  ],
+  "method": {
+    "short_images": "256x256 solid red and blue PNGs; repeated red, two-image order and reversed order.",
+    "ocr": "512x256 white PNG, black DejaVuSans 64 text SPARK 42 at (35,85).",
+    "sparse_images": "Two 1024x1024 solid-color PNGs, in both orders; 2081 prompt tokens exceed the 2051-token dense QSA range.",
+    "grading": "Case-insensitive expected substring, including whitespace; OCR spark42 fails the expected SPARK 42.",
+    "timing": "Single request wall time including image preprocessing, prefill and output; first request includes warmup. Not a throughput benchmark."
+  },
+  "limitations": [
+    "Experimental image integration; no broad vision benchmark or full-model reference parity.",
+    "OCR returned spark42, losing the space and case from SPARK 42.",
+    "Vision requires matching local source weights; published FTW and Hugging Face artifacts were not changed."
+  ],
+  "source": {
+    "raw_directory": "results/qwen-vision-20260910",
+    "probe_sha256": "dc512bef66f2f34091509b6df0fd92a95490cc27c9900e130ac705befec5242b",
+    "sparse_probe_sha256": "0526e59cdc75d35470a669ae99916a1432e226346d26f4d4f8adfa56fa8bc2fc",
+    "api_probe_sha256": "d6f86470016da924958d6f70ac891bebcf7a395a260b34fcec3cc86157ecbc6b"
+  },
+  "tests": {
+    "passed": 1261,
+    "command": "SPARKLAB_DISABLE_KERNEL_CACHE=1 python -m pytest tests/multimodal tests/serving tests/tokenizer tests/sparklab tests/models/test_qwen3_5* tests/models/test_qwen4* tests/kernels/test_qwen4_qsa_prefill.py tests/runtime/scheduler -q"
+  }
+}

--- a/docs/models/qwen-vision.md
+++ b/docs/models/qwen-vision.md
@@ -1,0 +1,128 @@
+# Native Qwen image inputs
+
+Qwen3.6-35B-A3B, Qwen3.8-27B and Qwen3.8-Flash-Next have an **experimental, opt-in native image path**.
+It loads the publisher's BF16 vision tower alongside the existing prepared text
+checkpoint and accepts OpenAI `image_url` content parts containing base64 data URLs.
+The text decoder stays in SparkLab; the image tower and preprocessing use the
+installed Transformers Qwen implementation.
+
+## Start a vision server
+
+Install the vision dependencies in the source environment:
+
+```bash
+uv sync --extra vision
+```
+
+Keep the pinned source snapshot, including its safetensors, `config.json`,
+`preprocessor_config.json` and tokenizer files. The source must correspond to the
+prepared text checkpoint: NVIDIA revision `491c2f1ea524c639598bf8fa787a93fed5a6fbce`
+for Qwen3.6, RadixArk revision `319f741cce68d7914884900c138a1fbb70a42f30` for Qwen3.8-27B,
+or NVIDIA revision `fab0aecb760cec45227f6656abcaafa11abca87a` for Flash-Next.
+`--vision-model` points to that local source directory. It reads only vision
+weights from the source and adds their GPU allocation to the text model's memory.
+
+For Qwen3.8-27B:
+
+```bash
+sparklab serve --model /path/to/qwen27/prepared \
+  --vision-model /path/to/qwen27/source \
+  --nvfp4-backend triton --attention-backend triton \
+  --num-tokens 4096 --max-seq-len-override 4096 \
+  --host 127.0.0.1 --port 8000
+```
+
+For Qwen3.6-35B-A3B, use the retained native Triton FTW (recipe 0.5.0), or
+prepare a separate Triton artifact from the pinned NVIDIA source:
+
+```bash
+sparklab checkpoint --model /path/to/qwen36/source \
+  --out /path/to/qwen36/vision-text-ftw --nvfp4-backend triton
+sparklab serve --model /path/to/qwen36/vision-text-ftw \
+  --vision-model /path/to/qwen36/source \
+  --moe-backend offload --moe-storage disk --moe-host-cache-gb 0 \
+  --moe-cache-size 10240 --moe-preload-all \
+  --nvfp4-backend triton --attention-backend triton \
+  --num-tokens 4096 --max-seq-len-override 4096 \
+  --host 127.0.0.1 --port 8000
+```
+
+The released Qwen3.6 Marlin container needs a new build containing these source
+changes before it can use this path. Its default MTP4 text profile and the
+Qwen3.8 DFlash2 text profile have separate performance evidence.
+
+For Qwen3.8-Flash-Next, use the prepared NVIDIA text artifact and its matching
+source snapshot:
+
+```bash
+sparklab serve --model /path/to/flash-next/prepared \
+  --vision-model /path/to/flash-next/source \
+  --moe-backend offload --moe-storage disk --moe-host-cache-gb 0 \
+  --moe-cache-size 24576 --moe-preload-all \
+  --nvfp4-backend triton --attention-backend qsa \
+  --num-tokens 8192 --max-seq-len-override 8192 \
+  --host 127.0.0.1 --port 8000
+```
+
+Flash-Next inserts image features before its residual streams split. Both its
+attention keys and pooled sparse-index keys use image spatial positions through
+prefill and decode. The existing FTW stays usable; no Hugging Face weight update
+is required when supplying the matching local source through `--vision-model`.
+
+## Send an image
+
+Wait until `/health` returns `"status": "ok"`. Then:
+
+```python
+import base64
+import json
+import urllib.request
+from pathlib import Path
+
+image = base64.b64encode(Path("example.png").read_bytes()).decode()
+body = {
+    "model": "qwen",
+    "messages": [{"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64," + image}},
+        {"type": "text", "text": "Describe this image."},
+    ]}],
+    "max_tokens": 128,
+    "temperature": 0,
+    "chat_template_kwargs": {"enable_thinking": False},
+}
+request = urllib.request.Request(
+    "http://127.0.0.1:8000/v1/chat/completions",
+    data=json.dumps(body).encode(),
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(request) as response:
+    print(json.load(response)["choices"][0]["message"]["content"])
+```
+
+## Bounds and evidence
+
+This path supports still images, up to four per request, base64 data URLs only,
+16 MiB encoded per image, and 16 megapixels before preprocessing. Images resize
+to at most 1,048,576 pixels. Remote image URLs, video and Anthropic image inputs
+are not implemented. Image prompts must fit in one prefill chunk and in the
+configured prompt-plus-output context budget.
+
+Enabling vision selects TP=1, one active request, eager execution and target-only
+decoding. Image requests bypass shared prefix caching, including on repeated
+prompts, and carry spatial positions through decode. Text-only servers retain
+their existing execution profiles.
+
+Qwen3.6-35B-A3B and Qwen3.8-27B passed five color/order/repeat image checks and four API checks
+(streamed image follow-up, malformed-image rejection, remote-URL rejection and
+text generation after images) on GB10. Both failed the single OCR probe: expected
+`SPARK 42`, observed `SPARK2` on Qwen3.8 and `PSP 3000` on Qwen3.6. The same Qwen3.6 checkpoint in vLLM 0.28.0 also failed this exact OCR input,
+returning `B E A U T Y`. This is bounded integration evidence, not general
+vision-quality or full-model reference parity.
+See [the exact results](../../benchmarks/gb10/results/GB10-QWENVISION-001.json).
+
+Flash-Next passed the same five color/order/repeat checks and four API checks.
+It also passed both image-order checks at 2,081 prompt tokens, exercising sparse
+QSA. Its OCR response was `spark42`, failing the expected `SPARK 42` text.
+See [Flash-Next results](../../benchmarks/gb10/results/GB10-QWENVISION-002.json).
+These checks validate the native image path within the tested bounds; they do
+not establish broad vision quality.

--- a/docs/models/qwen3.6-35b-a3b.md
+++ b/docs/models/qwen3.6-35b-a3b.md
@@ -1,5 +1,7 @@
 # Run Qwen3.6-35B-A3B
 
+An experimental native image-input path is available from source; see [vision setup and limits](qwen-vision.md).
+
 Recipe **0.6.0** makes the fast Marlin/MTP4 container the default on one 128 GiB
 NVIDIA GB10. SparkLab still runs the model and scheduler; the container supplies
 PyTorch 2.13 and vLLM 0.28's Marlin kernels. The host environment stays unchanged.

--- a/docs/models/qwen3.8-27b.md
+++ b/docs/models/qwen3.8-27b.md
@@ -1,5 +1,7 @@
 # Run Qwen3.8-27B
 
+An experimental native image-input path is available from source; see [vision setup and limits](qwen-vision.md).
+
 Recipe 0.4.0 uses the pinned RadixArk NVFP4 checkpoint, FP4 prefill in 2K-token
 chunks, and DFlash2-12 by default. It is an Experimental, text-only recipe for one
 NVIDIA GB10. DFlash accelerates greedy requests; model-default sampling remains

--- a/docs/models/qwen3.8-flash-next.md
+++ b/docs/models/qwen3.8-flash-next.md
@@ -1,6 +1,6 @@
 # Run Qwen3.8-Flash-Next
 
-Qwen3.8-Flash-Next is an Experimental, text-only Frontier recipe for one NVIDIA
+Qwen3.8-Flash-Next is an Experimental Frontier recipe for one NVIDIA
 GB10. Recipe 0.9.0 uses NVIDIA's mixed-precision checkpoint: native NVFP4 target
 experts, native block-FP8 MTP experts, BF16 resident projections, and scaled FP8
 PLE n-gram embeddings.
@@ -226,3 +226,10 @@ Saving verified intermediate states can change floating-point rounding relative
 to replaying smaller prefixes; exact generated-text parity is not guaranteed.
 
 See the [quick start](../quickstart.md) for API and agent examples.
+
+## Image inputs
+
+The source runtime supports [experimental native vision](qwen-vision.md) with
+`--vision-model` pointing to the matching NVIDIA source snapshot. The default
+recipe and performance measurements remain text-only. Vision uses eager,
+single-request, target-only decoding; the prepared FTW does not need replacing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ sparklab = "sparklab.cli:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=6.0"]
+vision = ["Pillow>=10", "torchvision==0.26.0"]
 # Native fused-kernel packages. Without them the runtime falls back to the pure-Triton
 # kernels in sparklab.kernels.triton (and the 'triton' attention backend). Install
 # `sparklab[accel]` for the full native fast path.
@@ -97,6 +98,7 @@ accel = ["sparklab[fi,sgl]"]
 # which would otherwise shadow PyPI under uv's first-index strategy).
 [tool.uv.sources]
 torch = { index = "pytorch-cu130" }
+torchvision = { index = "pytorch-cu130" }
 sglang-kernel = { index = "sglang-cu130" }
 
 [[tool.uv.index]]

--- a/python/sparklab/attention/qsa.py
+++ b/python/sparklab/attention/qsa.py
@@ -321,7 +321,11 @@ class QSAAttnBackend(BaseAttnBackend):
             )
             # RotaryEmbedding mutates both arguments. The query clone is unused but
             # keeps its in-place write from aliasing the pooled key.
-            _, pooled = rotary.forward(starts, pooled.clone(), pooled)
+            rotary_positions = starts
+            if getattr(req, "mm_positions", None) is not None:
+                from sparklab.models.qwen3_5_moe.vision import request_positions
+                rotary_positions = request_positions(req, starts)
+            _, pooled = rotary.forward(rotary_positions, pooled.clone(), pooled)
             cache[rows[:, -1]] = pooled
 
     def _pool_completed_keys_capture(

--- a/python/sparklab/core.py
+++ b/python/sparklab/core.py
@@ -46,6 +46,8 @@ class Req:
     # Optional precomputed multimodal soft-token embeddings (GPU, [num_image_tokens,
     # hidden]) scattered at image-token positions during this request's prefill.
     mm_embeds: torch.Tensor | None = None
+    mm_positions: torch.Tensor | None = None
+    mm_delta: int = 0
 
     # --- hybrid-radix (GDN linear-state) per-request slots; None for non-hybrid models or
     # until allocated from LinearStatePool. Set by the scheduler (P2). ---
@@ -152,6 +154,7 @@ class Batch:
     attn_metadata: BaseAttnMetadata = field(init=False)
     # concatenated multimodal soft-token embeddings for a prefill batch (or None)
     mm_embeds: torch.Tensor | None = field(default=None, init=False)
+    mm_positions: torch.Tensor | None = field(default=None, init=False)
     # Prefill log stats snapshotted at schedule time (before forward's complete_one()
     # advances cached_len), so the prefill log reports the tokens actually forwarded and
     # the prefix-cache hit -- matching SGLang's #new-token / #cached-token. Set by the

--- a/python/sparklab/message/backend.py
+++ b/python/sparklab/message/backend.py
@@ -37,6 +37,9 @@ class UserMsg(BaseBackendMsg):
     # Optional precomputed multimodal soft-token embeddings (GPU tensor). Only used by
     # the in-process offline path; remains None for the (serialized) online path.
     mm_embeds: torch.Tensor | None = None
+    mm_inputs: dict | None = None
+    mm_positions: torch.Tensor | None = None
+    mm_delta: int = 0
 
 
 @dataclass

--- a/python/sparklab/message/tokenizer.py
+++ b/python/sparklab/message/tokenizer.py
@@ -74,6 +74,7 @@ class TokenizeMsg(BaseTokenizerMsg):
     sampling_params: SamplingParams
     chat_template_kwargs: Dict[str, Any] | None = None
     tools: List[Dict[str, Any]] | None = None
+    mm_inputs: dict | None = None
 
 
 @dataclass

--- a/python/sparklab/models/qwen3_5_moe/attention.py
+++ b/python/sparklab/models/qwen3_5_moe/attention.py
@@ -33,6 +33,8 @@ class Qwen3_5Attention(BaseOP):
         self.num_q = config.num_qo_heads
         self.num_kv = config.num_kv_heads
         self.head_dim = head_dim
+        self._rotary_dim = config.rotary_config.rotary_dim
+        self._rotary_base = config.rotary_config.base
         self.qo_attn_dim = self.num_q * head_dim
         self.kv_attn_dim = self.num_kv * head_dim
 
@@ -73,7 +75,13 @@ class Qwen3_5Attention(BaseOP):
         v = v.contiguous()  # split view has the qkv row stride; the KV store needs contiguous
         q = self.q_norm.forward(q).reshape(-1, self.qo_attn_dim)
         k = self.k_norm.forward(k).reshape(-1, self.kv_attn_dim)
-        q, k = self.rotary.forward(positions, q, k)
+        mm_positions = getattr(get_global_ctx().batch, "mm_positions", None)
+        if mm_positions is not None:
+            from .vision import apply_mrope
+            q, k = apply_mrope(q, k, mm_positions, self.head_dim, self._rotary_dim,
+                              self._rotary_base, self._mrope_section)
+        else:
+            q, k = self.rotary.forward(positions, q, k)
         return q.view(-1, self.num_q, self.head_dim), k, v, gate
 
     def _combine(self, attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:

--- a/python/sparklab/models/qwen3_5_moe/config.py
+++ b/python/sparklab/models/qwen3_5_moe/config.py
@@ -265,7 +265,7 @@ def parse_config(hf_config: Any) -> ModelConfig:
         use_qk_norm=True,
         model_type=getattr(hf_config, "model_type", "qwen3_5_moe"),
         architectures=getattr(hf_config, "architectures", ["Qwen3_5MoeForConditionalGeneration"]),
-        vision_config=None,  # text-only milestone
+        vision_config=None,  # --vision-model attaches a source tower after text weight loading
         image_token_id=getattr(hf_config, "image_token_id", None),
         attention_groups=groups,
         expert_quant=expert_quant,

--- a/python/sparklab/models/qwen3_5_moe/model.py
+++ b/python/sparklab/models/qwen3_5_moe/model.py
@@ -86,6 +86,12 @@ class Qwen3_5Model(BaseOP):
 
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         x = self.embed_tokens.forward(input_ids)
+        embeds = getattr(get_global_ctx().batch, "mm_embeds", None)
+        if embeds is not None:
+            mask = input_ids == self._image_token_id
+            if int(mask.sum()) != embeds.shape[0]:
+                raise ValueError("Image embeddings and placeholders differ")
+            x = x.masked_scatter(mask.unsqueeze(-1), embeds.to(x.dtype))
         residual: torch.Tensor | None = None
         captures: list[torch.Tensor] = []
         for layer_id, layer in enumerate(self.layers.op_list):

--- a/python/sparklab/models/qwen3_5_moe/vision.py
+++ b/python/sparklab/models/qwen3_5_moe/vision.py
@@ -1,0 +1,151 @@
+"""Native Qwen image tower and three-axis rotary positions.
+
+The image tower uses the matching installed Transformers reference module;
+text generation remains in SparkLab's native scheduler and decoder.
+"""
+from pathlib import Path
+import json
+
+import torch
+from safetensors import safe_open
+
+
+def load_vision(model, source, device):
+    source = Path(source)
+    config = json.loads((source / 'config.json').read_text())
+    flash_next = config.get('model_type') == 'qwen4_exp'
+    if flash_next:
+        from transformers.models.qwen4_exp.configuration_qwen4_exp import Qwen4ExpVisionConfig as VisionConfig
+        from transformers.models.qwen4_exp.modeling_qwen4_exp import (
+            Qwen4ExpVisionModel as VisionModel,
+            Qwen4ExpVisionRotaryEmbedding as VisionRotary,
+        )
+    else:
+        from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5VisionConfig as VisionConfig
+        from transformers.models.qwen3_5.modeling_qwen3_5 import (
+            Qwen3_5VisionModel as VisionModel,
+            Qwen3_5VisionRotaryEmbedding as VisionRotary,
+        )
+    vc = VisionConfig(**config['vision_config'])
+    if vc.deepstack_visual_indexes:
+        raise ValueError('Qwen vision deepstack is not supported')
+    if vc.out_hidden_size != model.model.embed_tokens.weight.shape[1]:
+        raise ValueError('Vision output width does not match the text checkpoint')
+    vc._attn_implementation = 'sdpa'
+    with torch.device('meta'):
+        tower = VisionModel(vc)
+    expected = tower.state_dict()
+    weights = {}
+    for path in sorted(source.glob('*.safetensors')):
+        with safe_open(path, framework='pt', device='cpu') as f:
+            keys = set(f.keys())
+            for raw in keys:
+                prefix = next((p for p in ('model.visual.', 'visual.') if raw.startswith(p)), None)
+                if prefix is None:
+                    continue
+                name = raw[len(prefix):]
+                if name not in expected:
+                    if name.endswith(('weight_scale', 'weight_scale_2', 'input_scale')):
+                        continue
+                    raise ValueError(f'Unexpected vision tensor: {raw}')
+                from .weight import _load_maybe_quantized
+                tensor = _load_maybe_quantized(f, raw, keys)
+                if tensor.shape != expected[name].shape:
+                    raise ValueError(f'Vision tensor shape mismatch: {raw}')
+                weights[name] = tensor.to(device=device, dtype=torch.bfloat16)
+    tower.load_state_dict(weights, strict=True, assign=True)
+    tower.eval()
+    # Nonpersistent rotary buffers are not checkpoint tensors.
+    tower.rotary_pos_emb = VisionRotary(vc.hidden_size // vc.num_heads // 2).to(device)
+    model._vision = tower
+    model.model._image_token_id = config['image_token_id']
+    text = config.get('text_config', config)
+    rope = text.get('rope_parameters', text.get('rope_scaling', {}))
+    if rope.get('rope_type', 'default') != 'default' or not rope.get('mrope_interleaved', False):
+        raise ValueError('Qwen vision requires default interleaved MRoPE')
+    for layer in model.model.layers.op_list:
+        attn = getattr(layer, 'self_attn', None)
+        if attn is not None:
+            attn._mrope_section = tuple(rope['mrope_section'])
+            if flash_next:
+                rotary_dim = int(text['head_dim'] * rope['partial_rotary_factor'])
+                attn.rotary = MultimodalRotary(
+                    attn.rotary, attn.head_dim, rotary_dim, rope['rope_theta'], attn._mrope_section,
+                )
+                attn.index_rotary = MultimodalRotary(
+                    attn.index_rotary, attn.index_dim, rotary_dim, rope['rope_theta'], attn._mrope_section,
+                )
+
+
+def image_positions(input_ids, grid_thw, image_token_id, merge):
+    """Image-only MRoPE: spatial grid at each placeholder run; text advances all axes."""
+    ids = input_ids.tolist()
+    grids = iter(grid_thw.tolist())
+    positions = torch.empty(3, len(ids), dtype=torch.int64)
+    offset = cursor = 0
+    while cursor < len(ids):
+        if ids[cursor] != image_token_id:
+            positions[:, cursor] = offset
+            cursor += 1
+            offset += 1
+            continue
+        try:
+            t, h, w = next(grids)
+        except StopIteration as exc:
+            raise ValueError('Image placeholders exceed image grids') from exc
+        if t != 1 or h % merge or w % merge:
+            raise ValueError('Only still images with aligned spatial grids are supported')
+        h, w = h // merge, w // merge
+        length = h * w
+        if ids[cursor:cursor + length] != [image_token_id] * length:
+            raise ValueError('Image grid and placeholder count differ')
+        positions[0, cursor:cursor + length] = offset
+        positions[1, cursor:cursor + length] = torch.arange(h).repeat_interleave(w) + offset
+        positions[2, cursor:cursor + length] = torch.arange(w).repeat(h) + offset
+        offset += max(h, w)
+        cursor += length
+    if next(grids, None) is not None:
+        raise ValueError('Unused image grid')
+    return positions, offset - len(ids)
+
+
+def apply_mrope(q, k, positions, head_dim, rotary_dim, base, sections):
+    inv = 1.0 / (base ** (torch.arange(0, rotary_dim, 2, device=q.device).float() / rotary_dim))
+    freqs = positions.float().unsqueeze(-1) * inv
+    mixed = freqs[0].clone()
+    for axis in (1, 2):
+        mixed[..., axis:sections[axis] * 3:3] = freqs[axis, ..., axis:sections[axis] * 3:3]
+    angles = torch.cat((mixed, mixed), -1)
+    cos, sin = angles.cos().to(q.dtype).unsqueeze(1), angles.sin().to(q.dtype).unsqueeze(1)
+    def rotate(x):
+        original_shape = x.shape
+        x = x.reshape(-1, x.shape[-1] // head_dim, head_dim)
+        part = x[..., :rotary_dim]
+        half = rotary_dim // 2
+        rotated = part * cos + torch.cat((-part[..., half:], part[..., :half]), -1) * sin
+        return torch.cat((rotated, x[..., rotary_dim:]), -1).reshape(original_shape)
+    return rotate(q), rotate(k)
+
+
+class MultimodalRotary:
+    """Preserve ordinary text RoPE while accepting three-axis image positions."""
+    def __init__(self, text_rotary, head_dim, rotary_dim, base, sections):
+        self.text_rotary = text_rotary
+        self.head_dim, self.rotary_dim = head_dim, rotary_dim
+        self.base, self.sections = base, sections
+
+    def forward(self, positions, q, k):
+        if positions.ndim == 1:
+            return self.text_rotary.forward(positions, q, k)
+        return apply_mrope(q, k, positions, self.head_dim, self.rotary_dim, self.base, self.sections)
+
+
+def request_positions(req, logical):
+    """Positions for arbitrary QSA group starts, including prompt/decode boundaries."""
+    prompt = req.mm_positions
+    if prompt is None:
+        return logical
+    within_prompt = logical < prompt.shape[1]
+    prompt_rows = prompt.index_select(1, logical.clamp(max=prompt.shape[1] - 1).long())
+    continuation = (logical + req.mm_delta).expand(3, -1)
+    return torch.where(within_prompt.unsqueeze(0), prompt_rows, continuation)

--- a/python/sparklab/models/qwen4_exp/attention.py
+++ b/python/sparklab/models/qwen4_exp/attention.py
@@ -70,6 +70,9 @@ class Qwen4ExpAttention(BaseOP):
     @nvtx_annotate("QSA")
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         ctx = get_global_ctx()
+        positions = getattr(ctx.batch, "mm_positions", None)
+        if positions is None:
+            positions = ctx.batch.positions
         qg, k, v = self.qkv_proj.forward(x).split(self._split, dim=-1)
         qg = qg.view(-1, self.num_q, 2 * self.head_dim)
         q, gate = qg.chunk(2, dim=-1)
@@ -79,7 +82,7 @@ class Qwen4ExpAttention(BaseOP):
         self.q_norm.forward_inplace(q)
         self.k_norm.forward_inplace(k)
         q_flat, k_flat = self.rotary.forward(
-            ctx.batch.positions, q.view(-1, self.q_dim), k.view(-1, self.kv_dim)
+            positions, q.view(-1, self.q_dim), k.view(-1, self.kv_dim)
         )
 
         if ctx.attn_backend.needs_index_query(ctx.batch):
@@ -92,7 +95,7 @@ class Qwen4ExpAttention(BaseOP):
             # Only queries are normalized/rotated here. QSA first averages raw key
             # groups, then normalizes and rotates the pooled key at the group start.
             iq_flat, _ = self.index_rotary.forward(
-                ctx.batch.positions,
+                positions,
                 iq.view(-1, self.index_q_dim),
                 raw_ik.clone(),
             )

--- a/python/sparklab/models/qwen4_exp/model.py
+++ b/python/sparklab/models/qwen4_exp/model.py
@@ -88,7 +88,14 @@ class Qwen4ExpModel(BaseOP):
     def forward(
         self, input_ids: torch.Tensor, *, return_multi: bool = False
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        hidden = self.embed_tokens.forward(input_ids).repeat(1, self._hc_count)
+        hidden = self.embed_tokens.forward(input_ids)
+        embeds = getattr(get_global_ctx().batch, "mm_embeds", None)
+        if embeds is not None:
+            mask = input_ids == self._image_token_id
+            if int(mask.sum()) != embeds.shape[0]:
+                raise ValueError("Image embeddings and placeholders differ")
+            hidden = hidden.masked_scatter(mask.unsqueeze(-1), embeds.to(hidden.dtype))
+        hidden = hidden.repeat(1, self._hc_count)
         for layer in self.layers.op_list:
             hidden = layer.forward(hidden)
         sample = self.hyper_connection_mixer.forward(hidden)

--- a/python/sparklab/multimodal/__init__.py
+++ b/python/sparklab/multimodal/__init__.py
@@ -1,0 +1,1 @@
+"""Image preprocessing for native multimodal generation."""

--- a/python/sparklab/multimodal/qwen.py
+++ b/python/sparklab/multimodal/qwen.py
@@ -1,0 +1,72 @@
+"""Bounded OpenAI image parts -> Qwen patches, placeholders and MRoPE."""
+import base64
+from io import BytesIO
+import json
+from pathlib import Path
+
+import torch
+
+
+def has_images(messages):
+    return isinstance(messages, list) and any(
+        isinstance(m.get('content'), list) and any(p.get('type') == 'image_url' for p in m['content'])
+        for m in messages
+    )
+
+
+class QwenImageProcessor:
+    def __init__(self, source, tokenizer):
+        from transformers import AutoImageProcessor
+        self.config = json.loads((Path(source) / 'config.json').read_text())
+        self.tokenizer = tokenizer
+        self.processor = AutoImageProcessor.from_pretrained(source, local_files_only=True)
+        self.processor.size = {'shortest_edge': 65536, 'longest_edge': 1048576}
+
+    def prepare(self, messages, tools, kwargs):
+        from PIL import Image
+        images, rendered = [], []
+        for message in messages:
+            m = dict(message)
+            if isinstance(m.get('content'), list):
+                parts = []
+                for part in m['content']:
+                    if part.get('type') == 'text':
+                        parts.append(part.get('text', ''))
+                    elif part.get('type') == 'image_url':
+                        if len(images) >= 4:
+                            raise ValueError('At most four images are supported per request')
+                        value = part.get('image_url')
+                        url = value.get('url') if isinstance(value, dict) else value
+                        if not isinstance(url, str) or not url.startswith('data:image/') or ';base64,' not in url:
+                            raise ValueError('Images must be base64 data:image URLs')
+                        if len(url) > 16 * 1024 * 1024:
+                            raise ValueError('Encoded image exceeds 16 MiB')
+                        raw = base64.b64decode(url.split(';base64,', 1)[1], validate=True)
+                        with Image.open(BytesIO(raw)) as image:
+                            if image.width * image.height > 16_000_000:
+                                raise ValueError('Image exceeds 16 megapixels')
+                            images.append(image.convert('RGB'))
+                        parts.append('<|vision_start|><|image_pad|><|vision_end|>')
+                    else:
+                        raise ValueError('Only text and image_url content parts are supported')
+                m['content'] = ''.join(parts)
+            rendered.append(m)
+        processed = self.processor(images=images, return_tensors='pt')
+        grids = processed['image_grid_thw'].to(torch.int64)
+        prompt = self.tokenizer.apply_chat_template(rendered, tools=tools, tokenize=False,
+                                                   add_generation_prompt=True, **kwargs)
+        marker = '<|image_pad|>'
+        if prompt.count(marker) != len(images):
+            raise ValueError('Image placeholders do not match uploaded images')
+        chunks = prompt.split(marker)
+        merge = self.config['vision_config']['spatial_merge_size']
+        prompt = chunks[0]
+        for grid, suffix in zip(grids, chunks[1:], strict=True):
+            prompt += marker * (int(grid.prod()) // merge**2) + suffix
+        ids = torch.tensor(self.tokenizer.encode(prompt, add_special_tokens=False), dtype=torch.int32)
+        from sparklab.models.qwen3_5_moe.vision import image_positions
+        positions, delta = image_positions(ids, grids, self.config['image_token_id'], merge)
+        pixels = processed['pixel_values'].float()
+        payload = {'pixels': pixels.flatten(), 'pixel_shape': list(pixels.shape),
+                   'grids': grids.flatten(), 'positions': positions.flatten(), 'delta': delta}
+        return prompt, ids, payload

--- a/python/sparklab/recipes/qwen3.6-35b-a3b.json
+++ b/python/sparklab/recipes/qwen3.6-35b-a3b.json
@@ -76,6 +76,7 @@
     "Default selected for speed; quality equivalence is not established. The fixed core screen scored 17/20 versus native target-only 18/20 and vLLM 17/20; capped 16K AIME scored 0/5 versus 1/5 for both references.",
     "Requires Docker with NVIDIA GPU access and the separately built sparklab-qwen36:gb10-v1 image (PyTorch 2.13); the host PyTorch 2.11 environment is unchanged.",
     "Requires a separate nvfp4_marlin FTW converted from the pinned NVIDIA source; the previous hosted Triton FTW is incompatible.",
-    "Validated for text on one 128 GiB GB10, one actively decoded request, BF16 KV, FP32 recurrent state and 32,832 total sequence tokens. Sampled requests use target-only decoding."
+    "Validated for text on one 128 GiB GB10, one actively decoded request, BF16 KV, FP32 recurrent state and 32,832 total sequence tokens. Sampled requests use target-only decoding.",
+    "Source builds support opt-in native image inputs through --vision-model using the host Triton profile. The pinned released container does not include this feature; see docs/models/qwen-vision.md."
   ]
 }

--- a/python/sparklab/recipes/qwen3.8-27b.json
+++ b/python/sparklab/recipes/qwen3.8-27b.json
@@ -53,7 +53,7 @@
     "GB10-QWEN38-27B-PORTFOLIO-001"
   ],
   "limitations": [
-    "Text-only serving; the published checkpoint includes a vision tower.",
+    "Default recipe serves text. Source builds support opt-in native image inputs through --vision-model; see docs/models/qwen-vision.md for the target-only profile and measured limitations.",
     "RadixArk changes the weight quantization from the previous Inferact profile. Dynamic FP4 activation prefill changes numerics and retains an extra packed weight layout; BF16 KV and FP32 recurrent state remain native.",
     "DFlash2-12 accelerates batch-one greedy requests only. Default model sampling remains temperature 1.0; sampled requests fall back to target-only. Multiple clients queue behind one active generation.",
     "The fixed quality screen passed 70/74 checks, versus 68/74 for both the previous native profile and vLLM. Failures include arithmetic, JSON, one HumanEval task, and an AIME token-budget limit. This does not establish general quality parity.",

--- a/python/sparklab/recipes/qwen3.8-flash-next.json
+++ b/python/sparklab/recipes/qwen3.8-flash-next.json
@@ -63,7 +63,7 @@
     "The approximately 51.2 GB FP8 n-gram payload retains its published global BF16 scale.",
     "Full preload requires all 24,576 target routed experts to fit in unified memory and eliminates steady-state routed-expert disk reads.",
     "Native MTP is opt-in, batch-one greedy, and supports one to three draft tokens. Dense-QSA verification uses a dedicated CUDA graph; sparse-QSA verification falls back to eager execution.",
-    "Text-only experimental runtime. NVIDIA has not been shown to outperform Inferact in quality.",
+    "Default profile is text-only. Source builds offer experimental image inputs with --vision-model and the matching NVIDIA source; vision requires eager, single-request, target-only decoding. NVIDIA has not been shown to outperform Inferact in quality.",
     "Previous Inferact FTW remains available at immutable Hub revision 5ab790b83f149a96594237a35905d84be24599a3."
   ]
 }

--- a/python/sparklab/runtime/engine/config.py
+++ b/python/sparklab/runtime/engine/config.py
@@ -18,6 +18,7 @@ class EngineConfig:
     model_path: str
     tp_info: DistributedInfo
     dtype: torch.dtype
+    vision_model: str | None = None
     max_running_req: int = 4
     attention_backend: str = "auto"
     moe_backend: str = "auto"

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -730,6 +730,9 @@ class Engine:
                 config.model_path, dummy=config.use_dummy_weight
             )
         self.model.load_state_dict(self._load_weight_state_dict(config))
+        if config.vision_model:
+            from sparklab.models.qwen3_5_moe.vision import load_vision
+            load_vision(self.model, config.vision_model, self.device)
         if hasattr(self.model, "load_speculative_weights"):
             self.model.load_speculative_weights(
                 config.model_path, self.device, dummy=config.use_dummy_weight
@@ -1985,6 +1988,16 @@ def _adjust_config(config: EngineConfig):
         object.__setattr__(config, attr, value)
 
     model_config = config.model_config
+    if config.vision_model:
+        if not any("Qwen3_5" in a or "Qwen3_6" in a or "Qwen3_8" in a or "Qwen4Exp" in a for a in model_config.architectures):
+            raise ValueError("--vision-model requires a supported native Qwen decoder")
+        if config.tp_info.size != 1:
+            raise ValueError("Qwen vision currently requires TP=1")
+        override("cuda_graph_bs", [])
+        override("cuda_graph_max_bs", 0)
+        override("speculative_method", "none")
+        override("speculative_tokens", 0)
+        override("max_running_req", 1)
     single_stream_only = getattr(model_config, "single_stream_only", False)
     is_dsv4 = getattr(model_config, "dsv4_args", None) is not None
     is_qwen4 = getattr(model_config, "qwen4_exp_args", None) is not None

--- a/python/sparklab/runtime/scheduler/prefill.py
+++ b/python/sparklab/runtime/scheduler/prefill.py
@@ -179,6 +179,8 @@ class PrefillAdder:
             cache_handle=cache_handle,
             sampling_params=pending_req.sampling_params,
             mm_embeds=pending_req.mm_embeds,
+            mm_positions=pending_req.mm_positions,
+            mm_delta=pending_req.mm_delta,
         )
         # Hybrid GDN per-request state slots (None for non-hybrid). On a fresh admit these are
         # freshly allocated; on a chunked continuation they are inherited from the prior chunk.
@@ -245,7 +247,8 @@ class PrefillManager:
 
     def add_one_req(self, req: UserMsg) -> None:
         self.pending_list.append(
-            PendingReq(req.uid, req.input_ids, req.sampling_params, mm_embeds=req.mm_embeds)
+            PendingReq(req.uid, req.input_ids, req.sampling_params, mm_embeds=req.mm_embeds,
+                       mm_positions=req.mm_positions, mm_delta=req.mm_delta)
         )
 
     def schedule_next_batch(self, prefill_budget: int) -> Batch | None:

--- a/python/sparklab/runtime/scheduler/scheduler.py
+++ b/python/sparklab/runtime/scheduler/scheduler.py
@@ -584,6 +584,23 @@ class Scheduler(SchedulerIOMixin):
                 logger.warning_rank0(
                     f"Adjust max_tokens to {max_output_len} for request {msg.uid}."
                 )
+            if msg.mm_inputs is not None:
+                try:
+                    tower = getattr(self.engine.model, "_vision", None)
+                    if tower is None:
+                        raise ValueError("Image inputs require a loaded vision tower")
+                    if input_len > self.prefill_budget:
+                        raise ValueError("Image prompt exceeds single-prefill budget; shorten it or increase --max-extend-tokens")
+                    payload = msg.mm_inputs
+                    pixels = payload['pixels'].reshape(payload['pixel_shape']).to(self.device, dtype=torch.bfloat16)
+                    grids = payload['grids'].reshape(-1, 3).to(self.device)
+                    msg.mm_embeds = tower(pixels, grid_thw=grids, return_dict=True).pooler_output
+                    msg.mm_positions = payload['positions'].reshape(3, -1).to(self.device)
+                    msg.mm_delta = payload['delta']
+                    msg.mm_inputs = None
+                except Exception as exc:
+                    self.send_result([ErrorReplyMsg(uid=msg.uid, error=f"could not encode images: {exc}")])
+                    return
             self.prefill_manager.add_one_req(msg)
         elif isinstance(msg, AbortBackendMsg):
             logger.debug_rank0("Aborting request %d", msg.uid)
@@ -873,6 +890,17 @@ class Scheduler(SchedulerIOMixin):
         if batch.is_prefill:
             self._gather_multimodal(batch)
         batch.positions = _make_positions(batch, self.device)
+        if any(req.mm_positions is not None for req in batch.reqs):
+            parts = []
+            for req in batch.reqs:
+                start, end = req.cached_len, req.device_len
+                if req.mm_positions is None:
+                    parts.append(torch.arange(start, end, device=self.device).expand(3, -1))
+                elif batch.is_prefill:
+                    parts.append(req.mm_positions[:, start:end])
+                else:
+                    parts.append((torch.arange(start, end, device=self.device) + req.mm_delta).expand(3, -1))
+            batch.mm_positions = torch.cat(parts, dim=1)
         input_mapping = _make_input_tuple(batch, self.device)
         write_mapping = _make_write_tuple(batch, self.device)
         batch.out_loc = self.engine.page_table[input_mapping]

--- a/python/sparklab/runtime/scheduler/utils.py
+++ b/python/sparklab/runtime/scheduler/utils.py
@@ -18,6 +18,8 @@ class PendingReq:
     sampling_params: SamplingParams
     chunked_req: ChunkedReq | None = None
     mm_embeds: torch.Tensor | None = None
+    mm_positions: torch.Tensor | None = None
+    mm_delta: int = 0
 
     @property
     def input_len(self) -> int:

--- a/python/sparklab/serving/api_server.py
+++ b/python/sparklab/serving/api_server.py
@@ -208,6 +208,7 @@ class FrontendManager:
                 from sparklab.utils import load_tokenizer
 
                 self._frontend_tokenizer = TokenizeManager(load_tokenizer(self.config.model_path))
+                self._frontend_tokenizer._vision_source = getattr(self.config, "vision_model", None)
             return self._frontend_tokenizer
 
     def warm_frontend_tokenizer(self) -> None:

--- a/python/sparklab/serving/args.py
+++ b/python/sparklab/serving/args.py
@@ -209,6 +209,7 @@ def parse_args(
 
     parser = argparse.ArgumentParser(prog=prog, description="SparkLab Server Arguments")
 
+    parser.add_argument("--vision-model", help="Local Qwen source snapshot containing vision weights and processor files")
     parser.add_argument(
         "--model-path",
         "--model",

--- a/python/sparklab/serving/generation.py
+++ b/python/sparklab/serving/generation.py
@@ -194,18 +194,21 @@ def resolve_sampling(
     )
 
 
-def render_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def render_messages(messages: list[dict[str, Any]], *, allow_images: bool = False) -> list[dict[str, Any]]:
     """Normalize OpenAI-shaped message dicts for the chat template: flatten text
     content parts to a string and decode tool-call arguments from JSON. Raises
     ValueError on a non-text content part (text-only server). Shared by all adapters."""
-    return [_render_message(m) for m in messages]
+    return [_render_message(m, allow_images=allow_images) for m in messages]
 
 
-def _render_message(message: dict[str, Any]) -> dict[str, Any]:
+def _render_message(message: dict[str, Any], *, allow_images: bool = False) -> dict[str, Any]:
     m = dict(message)
     content = m.get("content")
     if isinstance(content, list):
-        m["content"] = _flatten_text_parts(content)
+        if allow_images and any(isinstance(p, dict) and p.get("type") == "image_url" for p in content):
+            m["content"] = content
+        else:
+            m["content"] = _flatten_text_parts(content)
     # Templates read different reasoning keys (reasoning_content: most; reasoning:
     # gemma4; thinking: gpt-oss) — accept any, emit both.
     reasoning = m.get("reasoning_content") or m.get("reasoning") or m.get("thinking")

--- a/python/sparklab/serving/launch.py
+++ b/python/sparklab/serving/launch.py
@@ -156,6 +156,7 @@ def launch_server(
             kwargs={
                 "detach": detach,
                 "tokenizer_path": server_args.model_path,
+                "vision_model": server_args.vision_model,
                 "addr": server_args.zmq_detokenizer_addr,
                 "backend_addr": server_args.zmq_backend_addr,
                 "frontend_addr": server_args.zmq_frontend_addr,
@@ -175,6 +176,7 @@ def launch_server(
                 kwargs={
                     "detach": detach,
                     "tokenizer_path": server_args.model_path,
+                    "vision_model": server_args.vision_model,
                     "addr": server_args.zmq_tokenizer_addr,
                     "backend_addr": server_args.zmq_backend_addr,
                     "frontend_addr": server_args.zmq_frontend_addr,

--- a/python/sparklab/serving/openai_api.py
+++ b/python/sparklab/serving/openai_api.py
@@ -59,6 +59,7 @@ def _thinking_type(req: Any) -> str | None:
 def chat_request_to_genspec(
     req: ChatCompletionRequest,
     model_sampling: dict[str, Any],
+    *, allow_images: bool = False,
 ) -> GenSpec:
     """OpenAI ChatCompletionRequest -> GenSpec (the OpenAI 'to_sampling_params')."""
     from .model_meta import effort_toggle_kwargs
@@ -68,7 +69,7 @@ def chat_request_to_genspec(
     if req.reasoning_effort or thinking_type:
         ctk = effort_toggle_kwargs(req.reasoning_effort, ctk, thinking_type=thinking_type)
     return GenSpec(
-        messages=render_messages([m.model_dump(exclude_none=True) for m in req.messages]),
+        messages=render_messages([m.model_dump(exclude_none=True) for m in req.messages], allow_images=allow_images),
         sampling_params=resolve_sampling(
             temperature=req.temperature,
             top_k=req.top_k,
@@ -180,7 +181,7 @@ async def handle_chat_completion(
             )
 
     try:
-        spec = chat_request_to_genspec(req, model_sampling)
+        spec = chat_request_to_genspec(req, model_sampling, allow_images=bool(getattr(state.config, "vision_model", None)))
     except ValueError:
         return create_error_response("invalid generation parameters")
 

--- a/python/sparklab/tokenizer/server.py
+++ b/python/sparklab/tokenizer/server.py
@@ -128,6 +128,7 @@ def _tokenize_requests(
 def tokenize_worker(
     *,
     tokenizer_path: str,
+    vision_model: str | None = None,
     addr: str,
     create: bool,
     backend_addr: str,
@@ -147,7 +148,7 @@ def tokenize_worker(
     from .detokenize import DetokenizeManager
     from .tokenize import TokenizeManager
 
-    tokenize_manager = TokenizeManager(tokenizer)
+    tokenize_manager = TokenizeManager(tokenizer, vision_model=vision_model)
     detokenize_manager = DetokenizeManager(
         tokenizer, load_eos_token_ids(tokenizer_path, tokenizer)
     )
@@ -255,7 +256,7 @@ def tokenize_worker(
                     )
                 if ok_msgs:
                     backend = [
-                        UserMsg(uid=msg.uid, input_ids=t, sampling_params=msg.sampling_params)
+                        UserMsg(uid=msg.uid, input_ids=t, sampling_params=msg.sampling_params, mm_inputs=msg.mm_inputs)
                         for msg, t in zip(ok_msgs, ok_tensors, strict=True)
                     ]
                     send_backend.put(backend[0] if len(backend) == 1 else BatchBackendMsg(data=backend))

--- a/python/sparklab/tokenizer/tokenize.py
+++ b/python/sparklab/tokenizer/tokenize.py
@@ -47,8 +47,10 @@ _EFFORT_PROBE_MESSAGES = [{"role": "user", "content": "ping"}]
 
 
 class TokenizeManager:
-    def __init__(self, tokenizer: PreTrainedTokenizerBase) -> None:
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, vision_model: str | None = None) -> None:
         self.tokenizer = tokenizer
+        self._vision_source = vision_model
+        self._image_processor = None
         self._dsv4_encoder = _load_dsv4_encoder_if_needed(tokenizer)
         self._effort_profile: EffortProfile | None = None
         self._thinking_profile: ThinkingProfile | None = None
@@ -59,6 +61,11 @@ class TokenizeManager:
         results: List[torch.Tensor] = []
         # TODO: batch tokenization
         for msg in msgs:
+            from sparklab.multimodal.qwen import has_images
+            if has_images(msg.text):
+                _, ids, msg.mm_inputs = self._prepare_images(msg)
+                results.append(ids)
+                continue
             prompt = self.render_prompt(msg)
             # A jinja chat template owns every special token (HF's apply_chat_template
             # tokenizes with add_special_tokens=False for the same reason): tokenizers
@@ -74,11 +81,22 @@ class TokenizeManager:
             results.append(input_ids.view(-1).to(torch.int32))
         return results
 
+    def _prepare_images(self, msg):
+        if not self._vision_source:
+            raise ValueError("Image inputs require --vision-model")
+        if self._image_processor is None:
+            from sparklab.multimodal.qwen import QwenImageProcessor
+            self._image_processor = QwenImageProcessor(self._vision_source, self.tokenizer)
+        return self._image_processor.prepare(msg.text, msg.tools, self._sanitize_effort(msg.chat_template_kwargs or {}))
+
     def render_prompt(self, msg: TokenizeMsg) -> str:
         """The template/encoder half of ``tokenize``, exposed so the frontend can
         validate a request before committing an SSE stream. Sanitizes
         ``reasoning_effort`` first: every render path (worker, frontend
         validation, count_tokens) must quantize identically."""
+        from sparklab.multimodal.qwen import has_images
+        if has_images(msg.text):
+            return self._prepare_images(msg)[0]
         if not isinstance(msg.text, list):
             return msg.text
         return self._render(

--- a/tests/multimodal/test_flash_next_vision.py
+++ b/tests/multimodal/test_flash_next_vision.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sparklab.models.qwen3_5_moe.vision import MultimodalRotary, image_positions, request_positions
+
+
+def test_image_features_are_inserted_before_residual_stream_replication(monkeypatch):
+    from sparklab.models.qwen4_exp.model import Qwen4ExpModel
+
+    model = Qwen4ExpModel.__new__(Qwen4ExpModel)
+    ids = torch.tensor([1, 99, 99, 2])
+    image = torch.tensor([[10., 20.], [30., 40.]])
+    model.embed_tokens = SimpleNamespace(forward=lambda ids: ids[:, None].float().expand(-1, 2))
+    model.layers = SimpleNamespace(op_list=[])
+    model.hyper_connection_mixer = SimpleNamespace(forward=lambda hidden: hidden[:, :2])
+    model._hc_count, model._image_token_id = 4, 99
+    monkeypatch.setattr('sparklab.models.qwen4_exp.model.get_global_ctx',
+                        lambda: SimpleNamespace(batch=SimpleNamespace(mm_embeds=image)))
+    sample, streams = model.forward(ids, return_multi=True)
+    torch.testing.assert_close(sample[1:3], image)
+    for stream in range(4):
+        torch.testing.assert_close(streams[:, stream * 2:(stream + 1) * 2], sample)
+    assert ids.tolist() == [1, 99, 99, 2]  # PLE retains the original placeholder history.
+
+
+def test_flash_next_positions_and_index_rotations_match_publisher():
+    from transformers.models.qwen4_exp.configuration_qwen4_exp import Qwen4ExpTextConfig
+    from transformers.models.qwen4_exp.modeling_qwen4_exp import (
+        Qwen4ExpModel, Qwen4ExpTextRotaryEmbedding, apply_rotary_pos_emb,
+    )
+    cfg = Qwen4ExpTextConfig(hidden_size=256, num_attention_heads=1, head_dim=256,
+        rope_parameters={'rope_type':'default','rope_theta':10000000.,'partial_rotary_factor':.25,
+                         'mrope_section':[11,11,10],'mrope_interleaved':True})
+    ids = torch.tensor([1] + [99] * 16 + [2, 3])
+    grids = torch.tensor([[1, 8, 8]])
+    p, delta = image_positions(ids, grids, 99, 2)
+    shim = SimpleNamespace(config=SimpleNamespace(vision_config=SimpleNamespace(spatial_merge_size=2)))
+    shim.get_vision_position_ids = Qwen4ExpModel.get_vision_position_ids.__get__(shim)
+    expected, shift = Qwen4ExpModel.get_rope_index(shim, ids[None], (ids == 99).long()[None], grids)
+    torch.testing.assert_close(p, expected[:, 0])
+    assert delta == shift.item()
+    # Four-token pooled-key starts can land inside images or after the prompt.
+    starts = torch.tensor([0, 4, 8, 12, 16, 20, 24])
+    req = SimpleNamespace(mm_positions=p, mm_delta=delta)
+    positions = request_positions(req, starts)
+    full = torch.cat((expected[:, 0], (torch.arange(len(ids), 25) + delta).expand(3, -1)), 1)
+    torch.testing.assert_close(positions, full[:, starts])
+    q, k = torch.randn(len(starts), 4 * 128), torch.randn(len(starts), 128)
+    rotary = MultimodalRotary(None, 128, 64, 10000000., [11, 11, 10])
+    aq, ak = rotary.forward(positions, q, k)
+    cos, sin = Qwen4ExpTextRotaryEmbedding(cfg)(q, positions[:, None])
+    eq, ek = apply_rotary_pos_emb(q.view(-1, 4, 128).transpose(0, 1)[None],
+                                k[:, None, :].transpose(0, 1)[None], cos, sin)
+    torch.testing.assert_close(aq, eq[0].transpose(0, 1).reshape_as(q))
+    torch.testing.assert_close(ak, ek[0].transpose(0, 1).reshape_as(k))
+
+
+def test_qsa_pool_uses_spatial_group_starts_and_decode_delta(monkeypatch):
+    from sparklab.attention.qsa import QSAAttnBackend
+
+    backend = QSAAttnBackend.__new__(QSAAttnBackend)
+    backend.args = SimpleNamespace(index_compress_ratio=4)
+    backend.config = SimpleNamespace(rms_norm_eps=1e-6)
+    backend.device = torch.device('cpu')
+    cache = torch.randn(32, 8)
+    backend.kvcache = SimpleNamespace(index_k_cache=lambda slot: cache)
+    monkeypatch.setattr('sparklab.attention.qsa.get_global_ctx',
+                        lambda: SimpleNamespace(page_table=torch.arange(32)[None]))
+    p, delta = image_positions(torch.tensor([1]+[99]*4+[2]), torch.tensor([[1,4,4]]), 99, 2)
+    req = SimpleNamespace(cached_len=0, extend_len=12, table_idx=0, mm_positions=p, mm_delta=delta)
+    seen = []
+    rotary = SimpleNamespace(forward=lambda positions, q, k: (seen.append(positions.clone()) or q, k))
+    backend._pool_completed_keys(0, [req], torch.zeros(8), rotary)
+    torch.testing.assert_close(seen[0], request_positions(req, torch.tensor([0,4,8])))
+    assert seen[0].shape == (3,3)
+
+
+def test_text_rotary_still_uses_original_kernel():
+    q,k,p = torch.randn(3,8),torch.randn(3,8),torch.arange(3)
+    base = SimpleNamespace(forward=lambda pos,q,k:(q+1,k+2))
+    aq,ak = MultimodalRotary(base,8,4,10000.,[1,1,0]).forward(p,q,k)
+    torch.testing.assert_close(aq,q+1)
+    torch.testing.assert_close(ak,k+2)

--- a/tests/multimodal/test_qwen_vision.py
+++ b/tests/multimodal/test_qwen_vision.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sparklab.models.qwen3_5_moe.vision import apply_mrope, image_positions
+from sparklab.message import UserMsg
+from sparklab.core import SamplingParams
+
+
+def test_image_positions_match_publisher_with_two_different_grids():
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Model
+    ids = torch.tensor([2, 3] + [99] * 6 + [4, 5] + [99] * 4 + [6])
+    grids = torch.tensor([[1, 4, 6], [1, 4, 4]])
+    positions, delta = image_positions(ids, grids, 99, 2)
+    shim = SimpleNamespace(config=SimpleNamespace(vision_config=SimpleNamespace(spatial_merge_size=2)))
+    shim.get_vision_position_ids = Qwen3_5Model.get_vision_position_ids.__get__(shim)
+    expected, shift = Qwen3_5Model.get_rope_index(shim, ids[None], (ids == 99).long()[None], grids)
+    torch.testing.assert_close(positions, expected[:, 0])
+    assert delta == shift.item()
+    assert positions[:, -1].tolist() == [9, 9, 9]
+
+
+def test_interleaved_partial_rope_matches_publisher():
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5TextRotaryEmbedding, apply_rotary_pos_emb
+    cfg = Qwen3_5TextConfig(hidden_size=256, num_attention_heads=2, head_dim=128,
+        rope_parameters={'rope_type':'default','rope_theta':10000000.,'partial_rotary_factor':.5,
+                         'mrope_section':[11,11,10],'mrope_interleaved':True})
+    rope = Qwen3_5TextRotaryEmbedding(cfg)
+    p = torch.tensor([[0,1,1,2],[0,1,2,3],[0,2,1,3]])
+    q, k = torch.randn(4,256), torch.randn(4,128)
+    actual_q, actual_k = apply_mrope(q,k,p,128,64,10000000.,[11,11,10])
+    cos,sin = rope(q,p[:,None])
+    eq,ek = apply_rotary_pos_emb(q.view(4,2,128).transpose(0,1)[None],k.view(4,1,128).transpose(0,1)[None],cos,sin)
+    torch.testing.assert_close(actual_q,eq[0].transpose(0,1).reshape(4,-1))
+    torch.testing.assert_close(actual_k,ek[0].transpose(0,1).reshape(4,-1))
+
+
+def test_image_payload_survives_backend_serialization():
+    payload={'pixels':torch.arange(12,dtype=torch.float32),'pixel_shape':[2,6],
+             'grids':torch.tensor([1,2,4]),'positions':torch.arange(9),'delta':-2}
+    msg=UserMsg(1,torch.tensor([1,2,3],dtype=torch.int32),SamplingParams(),mm_inputs=payload)
+    restored=UserMsg.decoder(msg.encoder())
+    for name in ('pixels','grids','positions'):
+        torch.testing.assert_close(restored.mm_inputs[name],payload[name])
+    assert restored.mm_inputs['pixel_shape']==[2,6]
+
+
+def test_bad_image_placeholder_counts_fail():
+    with pytest.raises(ValueError,match='placeholder count'):
+        image_positions(torch.tensor([1,99,2]),torch.tensor([[1,4,4]]),99,2)
+
+
+def test_text_only_manager_rejects_images_before_loading_processor():
+    from sparklab.tokenizer.tokenize import TokenizeManager
+    manager = TokenizeManager.__new__(TokenizeManager)
+    manager._vision_source = None
+    with pytest.raises(ValueError, match='--vision-model'):
+        manager._prepare_images(SimpleNamespace())
+
+
+def test_vision_messages_are_opt_in_and_preserve_image_order():
+    from sparklab.serving.generation import render_messages
+    parts = [{'type':'image_url','image_url':{'url':'data:image/png;base64,AA=='}},
+             {'type':'text','text':'Compare these'},
+             {'type':'image_url','image_url':{'url':'data:image/png;base64,AQ=='}}]
+    messages = [{'role':'user','content':parts}]
+    with pytest.raises(ValueError,match='text-only'):
+        render_messages(messages)
+    assert render_messages(messages,allow_images=True)[0]['content']==parts
+
+
+def test_image_decode_shift_preserves_text_continuation():
+    ids = torch.tensor([2] + [99] * 16 + [3, 4])
+    positions,delta = image_positions(ids,torch.tensor([[1,8,8]]),99,2)
+    continuation = torch.arange(len(ids),len(ids)+3)+delta
+    assert continuation.tolist()==[int(positions.max())+i for i in (1,2,3)]
+
+
+def test_remote_images_are_rejected_without_network_access():
+    pytest.importorskip('PIL')
+    from sparklab.multimodal.qwen import QwenImageProcessor
+    processor = QwenImageProcessor.__new__(QwenImageProcessor)
+    with pytest.raises(ValueError,match='base64 data:image'):
+        processor.prepare([{'role':'user','content':[
+            {'type':'image_url','image_url':{'url':'https://example.com/image.png'}}]}],None,{})


### PR DESCRIPTION
Adds opt-in native image inputs for Qwen3.6-35B-A3B, Qwen3.8-27B and Qwen3.8-Flash-Next. `serve --vision-model` loads the matching local source vision tower alongside the existing prepared text checkpoint; OpenAI chat requests can supply base64 image URLs.

Image features enter the native decoder with spatial rotary positions preserved through prefill and decode. Flash-Next inserts features before residual-stream replication and applies spatial positions to pooled sparse-index keys. Vision selects eager, TP=1, single-request, target-only execution and bypasses shared image prefix caching. Published weights are unchanged.

Validation:
- 1,261 focused regression tests passed on the isolated committed tree. Public-tree hygiene and whitespace checks passed.
- All three real models passed five color/order/repeat checks and four API checks on GB10. Flash-Next also passed two 2,081-token image prompts exercising sparse QSA.
- OCR did not match the expected `SPARK 42`: Qwen3.6 returned `PSP 3000`, Qwen3.8-27B returned `SPARK2`, and Flash-Next returned `spark42`. This remains experimental integration support, without broad vision-quality or full-model parity claims.

Setup, bounds and exact results are documented in `docs/models/qwen-vision.md` and `GB10-QWENVISION-001/002.json`. Supports up to four still images via data URLs; remote URLs and video are unsupported.
