### PR TITLE
Optimize native DeepSeek V4.1 Flash inference

### DIFF
--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -3,9 +3,10 @@
 This directory contains compact, reviewable summaries for SparkLab model
 recipes. Raw logs and large result streams stay outside the source repository.
 
-- `results/GB10-DSV41-PORTFOLIO-001.json` records the native DeepSeek V4.1 Flash
-  short probe: 0.244 decode tok/s and 343.131 s warm TTFT, medians of three
-  trials after one warmup with 74 input and 128 output tokens.
+- `results/GB10-DSV41-OPT-002.json` records the optimized native DeepSeek V4.1
+  Flash short probe: 0.969 decode tok/s and 74.387 s warm TTFT, medians of three
+  trials after one full-length warmup with 74 input and 128 output tokens. The
+  prior `GB10-DSV41-PORTFOLIO-001` result was 0.244 tok/s and 343.131 s TTFT.
 - `results/GB10-QWENVISION-001.json` records native image-input integration for
   Qwen3.6-35B-A3B and Qwen3.8-27B: color/order/repeat and API checks pass;
   both models fail the single OCR probe.

--- a/benchmarks/gb10/results/GB10-DSV41-OPT-002.json
+++ b/benchmarks/gb10/results/GB10-DSV41-OPT-002.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-DSV41-OPT-002",
+  "status": "measured",
+  "date": "2026-09-11",
+  "recipe": {
+    "slug": "deepseek-v4.1-flash",
+    "recipe_version": "0.2.0",
+    "revision": "df42c109f1defefcbfcedbe7d905718a12266e40"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "git_revision": "7b866d5971463d573d096f4a7574dd5b275b9e0b",
+    "git_tracked_dirty": true,
+    "source_sha256": {
+      "python/sparklab/models/deepseek_v41/model.py": "7f6e36d1f6eb193e7d4cf441b2976908269b403243cf6a3f54fef2ac6e0566f1",
+      "python/sparklab/models/deepseek_v41/ops.py": "f71eb5799954cf5b53ed8a0a371de45c7c323e29c8a2d14908d3e72238afc753",
+      "python/sparklab/models/deepseek_v41/weight.py": "160c5f2f19e244e25e1f1b7b4e12e63377ed28ac37b14ebc63b65ea779ad1650",
+      "python/sparklab/models/deepseek_v41/expert_cache.py": "ccc602b1010c296aa8c65748fd9306569370d7aef4466fae3ad133ffb9e07b5c",
+      "python/sparklab/kernels/triton/dsv41_linear.py": "52062a6066d4f6f17261296a59b23a328a7fea99f144a84203016090489423cb",
+      "python/sparklab/kernels/triton/dsv4/skinny.py": "04c933bd26cdbd916e97ec16770b31401560389c9292e389637043f5295e5a04",
+      "python/sparklab/moe/fused_ds_fp4.py": "8b160bd0fe46f4037428a8197adafaad09b1e90c1b4ebd7c2b4dad1908be19fc"
+    }
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "os": "Linux-6.17.0-1014-nvidia-aarch64-with-glibc2.39",
+    "unified_memory_gib": 128,
+    "machine": "aarch64",
+    "python": "3.11.15",
+    "packages": {
+      "torch": "2.11.0+cu130",
+      "triton": "3.6.0",
+      "transformers": "5.16.1"
+    },
+    "gpu_driver": "NVIDIA GB10, 580.126.09"
+  },
+  "checkpoint": {
+    "repository": "deepseek-ai/DeepSeek-V4.1-Flash",
+    "revision": "df42c109f1defefcbfcedbe7d905718a12266e40",
+    "format": "safetensors",
+    "bytes": 510313345254
+  },
+  "workload": {
+    "name": "Original AIME-25 problem 0 portfolio probe",
+    "prompt_sha256": "51e1235f1c85cf333085c9e2889a20fb7e7ef65f320856975bac705eb04e43d4",
+    "prompt_tokens": 74,
+    "completion_tokens": 128,
+    "clients": 1,
+    "temperature": 0,
+    "thinking": true,
+    "ignore_eos": true,
+    "warmup_requests": 1,
+    "measured_trials": 3,
+    "aggregation": "median",
+    "metric": "(completion_tokens - 1) / (last content event - first content event)"
+  },
+  "configuration": {
+    "backend": "native",
+    "expert_cache_gib": 64,
+    "weight_cache_gib": 24,
+    "expert_read_workers": 8,
+    "context_tokens": 2048,
+    "prefix_reuse": false,
+    "speculation": false,
+    "prefill": "layer-major MoE with sequential causal attention",
+    "quantized_linears": "direct packed MXFP4/MXFP8 Triton kernels"
+  },
+  "metrics": {
+    "decode_tokens_per_second_trials": [
+      0.969032549661657,
+      0.9715390021997505,
+      0.9692250183829233
+    ],
+    "decode_tokens_per_second_median": 0.9692250183829233,
+    "warm_ttft_seconds_trials": [
+      74.36858827096876,
+      74.50880825798959,
+      74.38668339408468
+    ],
+    "warm_ttft_seconds_median": 74.38668339408468,
+    "elapsed_seconds_trials": [
+      205.42812377598602,
+      205.22933713905513,
+      205.42017520603258
+    ],
+    "elapsed_seconds_median": 205.42017520603258,
+    "prior_decode_tokens_per_second": 0.24350497465775373,
+    "prior_warm_ttft_seconds": 343.13075944792945,
+    "prior_elapsed_seconds": 864.6815347810043,
+    "decode_speedup": 3.980306888370122,
+    "ttft_speedup": 4.612793019724797,
+    "elapsed_speedup": 4.209330150509891,
+    "device_allocation_gib_observed": 73.03125,
+    "minimum_system_memory_available_gib_observed": 37.0
+  },
+  "warmup": {
+    "decode_tokens_per_second": 0.9526616564995584,
+    "ttft_seconds": 72.90125450596679,
+    "elapsed_seconds": 206.21220136689954,
+    "output_sha256": "4d81d182dc00c34a3e6ae7934832dbc23a6eac9ede6bf61c27cf82e204f286a5"
+  },
+  "validation": {
+    "focused_tests_passed": 48,
+    "focused_test_command": "PYTHONPATH=python SPARKLAB_DISABLE_KERNEL_CACHE=1 .venv/bin/python -m pytest -q tests/dsv41/test_native.py tests/dsv41/test_expert_cache.py tests/kernels/test_dsv41_packed_linear.py tests/models/test_dsv4_dspark.py tests/kernels/test_dsv4_skinny.py",
+    "api_streams_completed": 4,
+    "all_measured_output_hashes_match": true,
+    "output_sha256": "4d81d182dc00c34a3e6ae7934832dbc23a6eac9ede6bf61c27cf82e204f286a5",
+    "prior_output_sha256": "dd72a88bc44b474e2a0b1f14fa29d8786b0ce8efa482ba0eb04d3a3f6f34c349",
+    "oom_count": 0,
+    "swap_growth_observed": false
+  },
+  "ablations": {
+    "fixed_32_output_probe": {
+      "global_lru_64_gib": {
+        "ttft_seconds": 105.57397510891315,
+        "decode_tokens_per_second": 0.6500408060473133
+      },
+      "per_layer_hybrid_64_gib": {
+        "ttft_seconds": 109.42244399001356,
+        "decode_tokens_per_second": 0.29477674917097435
+      },
+      "output_hashes_match": true
+    }
+  },
+  "source": {
+    "summary": "Three full measured requests after one full-length warmup, using the same prompt and metric as GB10-DSV41-PORTFOLIO-001.",
+    "raw_artifact": "/tmp/dsv41-global64-three-trials.jsonl and /tmp/dsv41-global64-fourth.jsonl",
+    "benchmark_sha256": "d1fe83f8bbbf8b11f511e11f0a317f16a3ecec11cdcc908b7fa0207b76c4e207",
+    "prior_evidence": "GB10-DSV41-PORTFOLIO-001"
+  },
+  "limitations": [
+    "One fixed 74-input/128-output prompt; this is not a completed-answer quality, long-context, concurrent or endurance test.",
+    "The packed/fused path changes numerical rounding and did not reproduce the prior implementation's 128-token output hash; both outputs are truncated before the final answer.",
+    "Focused source-tree optimization evidence, not a clean-release certification result.",
+    "Swap was already in use before measurement. No additional swap growth was observed, but per-trial VM telemetry was not captured.",
+    "The first full-length warmup followed one 32-token cache-layout probe in the same server process."
+  ]
+}

--- a/docs/models/deepseek-v4.1-flash.md
+++ b/docs/models/deepseek-v4.1-flash.md
@@ -25,17 +25,19 @@ sparklab run deepseek-v4.1-flash
 Omit `--prepare`: the decoder reads the original safetensors snapshot directly.
 FTW conversion is unsupported. The native engine fixes this path to TP=1, one
 request, BF16 computation, eager execution, naive prefix caching and a 2,048-token
-total context. Prefill processes tokens sequentially. Vision, prefix reuse,
-CUDA graphs and DSpark speculation are not implemented.
+total context. Prompt-wide Engram, hyper-connection and MoE work runs
+layer-by-layer; attention and its projections still advance causally. Vision, prefix reuse, CUDA
+graphs and DSpark speculation are not implemented.
 
-The model owns a 24 GiB device weight LRU and reads Engram embedding rows from disk
-only when requested. Quantized projections are dequantized during computation;
-the stored MXFP4 expert weights and MXFP8 dense weights remain packed in the cache.
-The recipe's 32 GiB memory budget includes an estimated allowance for transient
-projections, request state and scheduler KV storage. It is an engineering budget,
-not a measured full-model memory result. The engine's `fused` MoE setting prevents
-generic expert-bank allocation; execution still uses this model's disk reader.
-Generic MoE cache and offload tuning flags do not tune this reader.
+The model owns a 64 GiB packed-expert LRU plus a bounded 24 GiB device-weight LRU,
+and reads Engram embedding rows from disk only when requested. MXFP4 experts run
+directly from their packed checkpoint representation; MXFP8 dense projections use
+a packed small-row kernel. Eight parallel bounded reads fill missing expert slots.
+`SPARKLAB_DSV41_EXPERT_CACHE_GB` can lower the expert budget, though values below
+the 64 GiB measured profile may reduce decode speed. The recipe reserves 96 GiB
+for these caches, transient projections, request state and scheduler KV storage.
+The engine's `fused` MoE setting prevents generic expert-bank allocation;
+generic FTW cache and offload controls do not tune this model-owned cache.
 
 ## API example
 
@@ -73,16 +75,19 @@ the loader's geometry validation. The real tokenizer produces the expected
 
 ## Measured performance
 
-The native GB10 README probe measured **0.244 decode tok/s**, **343.131 s warm
-TTFT**, and **864.682 s total request time**, medians of three trials after one
-warmup. The unchanged AIME prompt encodes to 74 input tokens and generates 128
-output tokens, with greedy sampling and thinking enabled. All three output hashes
-match. See [versioned benchmark evidence](../../benchmarks/gb10/results/GB10-DSV41-PORTFOLIO-001.json).
+The optimized native GB10 profile measured **0.969 decode tok/s**, **74.387 s warm
+TTFT**, and **205.420 s total request time**, medians of three trials after one
+full-length warmup. The unchanged AIME prompt encodes to 74 input tokens and
+generates 128 output tokens, with greedy sampling, thinking enabled and EOS ignored.
+This is 3.98x the prior decode rate, with 4.61x faster TTFT and 4.21x lower total
+time. See [optimized evidence](../../benchmarks/gb10/results/GB10-DSV41-OPT-002.json)
+and the [prior baseline](../../benchmarks/gb10/results/GB10-DSV41-PORTFOLIO-001.json).
 
-This complete-checkpoint run uses the 24 GiB weight cache and eager disk decoder
-above. Host swap-out was observed. It is a bounded performance probe, not a
-completed-answer quality check. General numerical parity, generated tool calls,
-agent tasks and endurance remain unverified. No V4 certification transfers to V4.1.
+All optimized trials produced the same output hash. The packed/fused arithmetic
+did not reproduce the prior decoder's output hash, and both 128-token traces end
+before the answer. This remains a bounded performance probe rather than a quality
+result. General numerical parity, completed answers, generated tool calls, agent
+tasks and endurance remain unverified. No V4 certification transfers to V4.1.
 
 ## Architecture provenance
 

--- a/python/sparklab/kernels/triton/dsv4/skinny.py
+++ b/python/sparklab/kernels/triton/dsv4/skinny.py
@@ -52,7 +52,12 @@ def _bf16_skinny_kernel(
     )
 
 
-def bf16_skinny_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+def bf16_skinny_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
     """Compute a contiguous bias-free BF16 linear for one to six rows."""
     *lead, k = x.shape
     m = x.numel() // k
@@ -60,7 +65,7 @@ def bf16_skinny_linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     if not 1 <= m <= 6:
         raise ValueError(f"DSV4 skinny linear requires 1 <= M <= 6, got {m}")
     x2 = x.reshape(m, k).contiguous()
-    out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    out = torch.empty((m, n), dtype=out_dtype or x.dtype, device=x.device)
     num_warps = 8 if m == 1 else 2 if m == 3 else 4
     _bf16_skinny_kernel[(n,)](
         x2,

--- a/python/sparklab/kernels/triton/dsv41_linear.py
+++ b/python/sparklab/kernels/triton/dsv41_linear.py
@@ -1,0 +1,53 @@
+"""Small-row packed linears for the DeepSeek V4.1 reference decoder."""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+from sparklab.moe.fused_ds_fp4 import _grouped_decode
+
+
+@functools.lru_cache(maxsize=None)
+def _single_slot(device_index: int, rows: int) -> torch.Tensor:
+    return torch.zeros((rows, 1), dtype=torch.int32, device=torch.device("cuda", device_index))
+
+
+def mxfp4_linear(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scale_codes: torch.Tensor,
+) -> torch.Tensor:
+    """Compute ``x @ W.T`` directly from block-32 E2M1/E8M0 checkpoint data.
+
+    ``x`` has already undergone the checkpoint's FP8 activation round-trip.
+    The shared DSV4 decode kernel performs FP32 accumulation while expanding
+    each packed nibble and scale in registers.
+    """
+    *lead, width = x.shape
+    rows = x.numel() // width
+    if not (
+        x.is_cuda
+        and packed_weight.is_cuda
+        and scale_codes.is_cuda
+        and packed_weight.ndim == 2
+        and packed_weight.shape[1] * 2 == width
+        and scale_codes.shape == (packed_weight.shape[0], width // 32)
+    ):
+        raise ValueError("V4.1 packed FP4 linear requires compatible CUDA tensors")
+    x2 = x.reshape(rows, width).contiguous()
+    slots = _single_slot(x.device.index or 0, rows)
+    result = _grouped_decode(
+        x2,
+        packed_weight.unsqueeze(0),
+        scale_codes.view(torch.uint8).unsqueeze(0),
+        slots,
+        None,
+        a_row_is_route=False,
+        mul_routed_weight=False,
+    )
+    return result[:, 0].reshape(*lead, packed_weight.shape[0])
+
+
+__all__ = ["mxfp4_linear"]

--- a/python/sparklab/models/deepseek_v41/expert_cache.py
+++ b/python/sparklab/models/deepseek_v41/expert_cache.py
@@ -1,0 +1,130 @@
+"""Bounded packed expert bank for DeepSeek V4.1 Flash."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
+import math
+import os
+
+import torch
+
+
+class ExpertBank:
+    """LRU of complete routed experts in checkpoint-native GPU tensors."""
+
+    def __init__(self, args, store):
+        raw = os.getenv("SPARKLAB_DSV41_EXPERT_CACHE_GB", "64")
+        try:
+            budget = int(raw) << 30
+        except ValueError as exc:
+            raise ValueError(f"invalid SPARKLAB_DSV41_EXPERT_CACHE_GB={raw!r}") from exc
+        if budget < 0:
+            raise ValueError("SPARKLAB_DSV41_EXPERT_CACHE_GB must be non-negative")
+        self.args = args
+        self.store = store
+        self.device = store.device
+        self.entries: OrderedDict[tuple[int, int], int] = OrderedDict()
+        self.executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="dsv41-expert")
+        self.free_slots: list[int] = []
+        self.gate_up = self.gate_up_scale = self.down = self.down_scale = None
+
+        prefix = "layers.0.ffn.experts.0"
+        specs = [
+            store.metadata[prefix + suffix]
+            for suffix in (
+                ".w1.weight", ".w3.weight", ".w1.scale", ".w3.scale",
+                ".w2.weight", ".w2.scale",
+            )
+        ]
+        bytes_per = sum(
+            torch.empty((), dtype=spec[3]).element_size()
+            * math.prod(spec[2])
+            for spec in specs
+        )
+        self.capacity = budget // bytes_per
+        if self.capacity and self.capacity < args.n_routed_experts:
+            raise ValueError("V4.1 expert cache must hold one layer's routed experts")
+
+    def _allocate(self):
+        if self.gate_up is not None or not self.capacity:
+            return
+        a = self.args
+        self.gate_up = torch.empty(
+            self.capacity, 2 * a.moe_inter_dim, a.dim // 2,
+            dtype=torch.uint8, device=self.device,
+        )
+        self.gate_up_scale = torch.empty(
+            self.capacity, 2 * a.moe_inter_dim, a.dim // 32,
+            dtype=torch.uint8, device=self.device,
+        )
+        self.down = torch.empty(
+            self.capacity, a.dim, a.moe_inter_dim // 2,
+            dtype=torch.uint8, device=self.device,
+        )
+        self.down_scale = torch.empty(
+            self.capacity, a.dim, a.moe_inter_dim // 32,
+            dtype=torch.uint8, device=self.device,
+        )
+        self.free_slots = list(range(self.capacity - 1, -1, -1))
+
+    def _read_expert(self, key):
+        layer, expert = key
+        root = f"layers.{layer}.ffn.experts.{expert}"
+        return [self.store._read_host(root + suffix) for suffix in (
+            ".w1.weight", ".w3.weight", ".w1.scale", ".w3.scale",
+            ".w2.weight", ".w2.scale",
+        )]
+
+    def _copy_expert(self, tensors, slot: int):
+        width = self.args.moe_inter_dim
+        for tensor, start in zip(tensors[:2], (0, width)):
+            self.gate_up[slot, start:start + width].copy_(
+                tensor.view(torch.uint8)
+            )
+        for tensor, start in zip(tensors[2:4], (0, width)):
+            self.gate_up_scale[slot, start:start + width].copy_(
+                tensor.view(torch.uint8)
+            )
+        self.down[slot].copy_(tensors[4].view(torch.uint8))
+        self.down_scale[slot].copy_(tensors[5].view(torch.uint8))
+
+    def slots(self, layer: int, experts: torch.Tensor) -> torch.Tensor | None:
+        if not self.capacity:
+            return None
+        self._allocate()
+        keys = [(layer, int(expert)) for expert in experts.reshape(-1).cpu().tolist()]
+        unique = list(dict.fromkeys(keys))
+        protected = set(unique)
+        missing_count = sum(key not in self.entries for key in unique)
+        while len(self.free_slots) < missing_count:
+            victim = next(key for key in self.entries if key not in protected)
+            self.free_slots.append(self.entries.pop(victim))
+
+        missing = []
+        for key in unique:
+            slot = self.entries.get(key)
+            if slot is None:
+                slot = self.free_slots.pop()
+                self.entries[key] = slot
+                missing.append((key, slot))
+            self.entries.move_to_end(key)
+        result = [self.entries[key] for key in keys]
+        # Limit staged host data to roughly 150 MiB while keeping NVMe queue
+        # depth high enough for the large, independently located tensors.
+        for start in range(0, len(missing), 8):
+            chunk = missing[start:start + 8]
+            loaded = self.executor.map(self._read_expert, (key for key, _ in chunk))
+            for (key, slot), tensors in zip(chunk, loaded):
+                self._copy_expert(tensors, slot)
+        return torch.tensor(result, dtype=torch.int32, device=self.device).reshape(experts.shape)
+
+    def close(self):
+        self.executor.shutdown(wait=True)
+
+    def __del__(self):
+        executor = getattr(self, "executor", None)
+        if executor is not None:
+            executor.shutdown(wait=False)
+
+__all__ = ["ExpertBank"]

--- a/python/sparklab/models/deepseek_v41/model.py
+++ b/python/sparklab/models/deepseek_v41/model.py
@@ -2,8 +2,8 @@
 
 Math follows DeepSeek's MIT-licensed inference/model.py at
 df42c109f1defefcbfcedbe7d905718a12266e40 (see LICENSE.deepseek).
-This initial research path evaluates tokens eagerly, including prefill. It
-prioritizes a bounded complete-model path over throughput or prefix reuse.
+This research path batches prompt work layer-by-layer and evaluates decode
+eagerly. It prioritizes bounded complete-model execution over prefix reuse.
 """
 import torch
 import torch.nn.functional as F
@@ -19,6 +19,7 @@ from .ops import (
     sparse_attention, candidate_mask,
 )
 from .weight import DiskWeights
+from .expert_cache import ExpertBank
 
 
 class Decoder:
@@ -40,6 +41,10 @@ class Decoder:
                     args.rope_factor, args.beta_fast, args.beta_slow,
                 ) for compressed in (False, True)
             }
+        packed_experts = "layers.0.ffn.experts.0.w1.scale" in store.metadata
+        self.expert_bank = (
+            ExpertBank(args, store) if self.device.type == "cuda" and packed_experts else None
+        )
         self.reset()
 
     def reset(self):
@@ -160,13 +165,44 @@ class Decoder:
         if a.norm_topk_prob and a.n_activated_experts > 1:
             weights = weights / (weights.sum(-1, keepdim=True) + 1e-20)
         weights = weights * a.route_scale
-        output = torch.zeros_like(x, dtype=torch.float32)
+        if self.expert_bank is not None:
+            order = indices.argsort(-1)
+            sorted_indices = indices.gather(-1, order)
+            sorted_weights = weights.gather(-1, order)
+            slots = self.expert_bank.slots(layer, sorted_indices)
+            if slots is not None:
+                from sparklab.moe.fused_ds_fp4 import routed_experts_fp4
+
+                flat = x.reshape(-1, x.shape[-1])
+                output = routed_experts_fp4(
+                    flat,
+                    slots.reshape(flat.shape[0], -1),
+                    sorted_weights.reshape(flat.shape[0], -1),
+                    self.expert_bank.gate_up,
+                    self.expert_bank.gate_up_scale,
+                    self.expert_bank.down,
+                    self.expert_bank.down_scale,
+                    a.swiglu_limit,
+                    activation_block=32,
+                    sum_in_fp32=True,
+                ).reshape_as(x)
+                output += self._expert(name + ".shared_experts", x).float()
+                return output.to(x.dtype)
+        flat_x = x.reshape(-1, x.shape[-1])
+        flat_indices = indices.reshape(flat_x.shape[0], -1)
+        flat_weights = weights.reshape_as(flat_indices)
+        output = torch.zeros_like(flat_x, dtype=torch.float32)
         # Upstream accumulates in expert-ID order, with weighting before w2.
-        for slot in indices.reshape(-1).argsort().tolist():
-            expert = int(indices.reshape(-1)[slot])
-            output += self._expert(f"{name}.experts.{expert}", x, weights.reshape(-1)[slot])
-        output += self._expert(name + ".shared_experts", x)
-        return output.to(x.dtype)
+        for slot in flat_indices.flatten().argsort().tolist():
+            row, route = divmod(slot, flat_indices.shape[1])
+            expert = int(flat_indices[row, route])
+            output[row:row + 1] += self._expert(
+                f"{name}.experts.{expert}",
+                flat_x[row:row + 1],
+                flat_weights[row, route],
+            )
+        output += self._expert(name + ".shared_experts", flat_x)
+        return output.reshape_as(x).to(x.dtype)
 
     def _engram(self, layer, h, hashes):
         a, store = self.args, self.store
@@ -190,9 +226,11 @@ class Decoder:
         name = f"layers.{layer}.hc_{kind}"
         x = h.flatten(2).float()
         mixes = F.linear(x, store.get(name + "_fn").float()) * torch.rsqrt(x.square().mean(-1, keepdim=True) + a.norm_eps)
-        pre, post, comb = hc_split_sinkhorn(mixes.reshape(1, -1), store.get(name + "_scale"), store.get(name + "_base"),
+        pre, post, comb = hc_split_sinkhorn(mixes.reshape(-1, mixes.shape[-1]), store.get(name + "_scale"), store.get(name + "_base"),
                                            a.hc_mult, a.hc_sinkhorn_iters, a.hc_eps)
-        return pre.view(1, 1, a.hc_mult), post.view(1, 1, a.hc_mult), comb.view(1, 1, a.hc_mult, a.hc_mult)
+        lead = mixes.shape[:-1]
+        return (pre.reshape(*lead, a.hc_mult), post.reshape(*lead, a.hc_mult),
+                comb.reshape(*lead, a.hc_mult, a.hc_mult))
 
     @staticmethod
     def _pre(h, pre):
@@ -226,8 +264,61 @@ class Decoder:
             x = self._norm(f"layers.{layer}.ffn_norm", self._pre(h, attn_pre))
             h = self._post(self._moe(layer, x), h, post, comb)
         h = self._norm("norm", self._pre(h, pre))
-        logits = F.linear(h[:, -1].float(), self.store.get("head.weight").float())
+        head = self.store.get("head.weight")
+        if h.is_cuda and head.is_cuda:
+            from sparklab.kernels.triton.dsv4.skinny import bf16_skinny_linear
+
+            logits = bf16_skinny_linear(h[:, -1], head, out_dtype=torch.float32)
+        else:
+            logits = F.linear(h[:, -1].float(), head.float())
         self.position += 1
+        return logits
+
+    @torch.inference_mode()
+    def prefill(self, tokens):
+        """Evaluate a prompt layer-by-layer while retaining sequential state.
+
+        Attention and its projections still advance each query causally, while
+        Engram reads, hyper-connections, and MoE routing/compute operate on the
+        whole prompt. Each selected expert is loaded at most once per layer.
+        """
+        a, start = self.args, self.position
+        tokens = [int(token) for token in tokens]
+        if not tokens:
+            raise ValueError("DeepSeek V4.1 prefill requires at least one token")
+        if start + len(tokens) > a.max_seq_len:
+            raise ValueError("DeepSeek V4.1 research context limit exceeded")
+        if any(not 0 <= token < a.vocab_size or token == a.image_token_id for token in tokens):
+            raise ValueError("DeepSeek V4.1 native research supports text token IDs only")
+        ids = torch.tensor([tokens], dtype=torch.int64, device="cpu")
+        hashes = self.hash(ids, start) if self.hash is not None else None
+        h = self.store.rows("embed.weight", ids).to(torch.bfloat16).unsqueeze(2).repeat(1, 1, a.hc_mult, 1)
+        pre = torch.zeros((1, len(tokens), a.hc_mult), device=self.device, dtype=torch.float32)
+        pre[..., 0] = 1
+        shared = [{} for _ in tokens]
+        for layer in range(a.n_layers):
+            if self.layout and layer in self.layout.layer_ids:
+                h = self._engram(layer, h, hashes)
+            attn_pre, post, comb = self._mixes(layer, "attn", h)
+            x = self._norm(f"layers.{layer}.attn_norm", self._pre(h, pre))
+            attention = torch.cat([
+                self._attention(layer, x[:, local:local + 1], start + local, shared[local])
+                for local in range(len(tokens))
+            ], dim=1)
+            h = self._post(attention, h, post, comb)
+            pre, post, comb = self._mixes(layer, "ffn", h)
+            x = self._norm(f"layers.{layer}.ffn_norm", self._pre(h, attn_pre))
+            h = self._post(self._moe(layer, x), h, post, comb)
+        h = self._norm("norm", self._pre(h, pre))
+        head = self.store.get("head.weight")
+        last = h[:, -1]
+        if last.is_cuda and head.is_cuda:
+            from sparklab.kernels.triton.dsv4.skinny import bf16_skinny_linear
+
+            logits = bf16_skinny_linear(last, head, out_dtype=torch.float32)
+        else:
+            logits = F.linear(last.float(), head.float())
+        self.position += len(tokens)
         return logits
 
 
@@ -264,8 +355,11 @@ class DeepseekV41ForCausalLM(BaseLLMModel):
             self.uid = req.uid
         if positions != list(range(self.decoder.position, self.decoder.position + len(positions))):
             raise ValueError("DeepSeek V4.1 state requires consecutive tokens without prefix reuse")
+        tokens = batch.input_ids.cpu().tolist()
+        if len(tokens) > 1 and not batch.return_all_logits:
+            return self.decoder.prefill(tokens)
         outputs = []
-        for token in batch.input_ids.cpu().tolist():
+        for token in tokens:
             result = self.decoder.step(token)
             if batch.return_all_logits:
                 outputs.append(result)

--- a/python/sparklab/models/deepseek_v41/ops.py
+++ b/python/sparklab/models/deepseek_v41/ops.py
@@ -50,6 +50,16 @@ def linear(store, name, x):
     if name + ".scale" in store.metadata:
         scale = store.get(name + ".scale")
         fp4 = weight.dtype in (torch.uint8, torch.int8)
+        if x.is_cuda and weight.is_cuda and scale.is_cuda:
+            rounded = fp8_roundtrip(x)
+            if fp4:
+                from sparklab.kernels.triton.dsv41_linear import mxfp4_linear
+
+                return mxfp4_linear(rounded, weight, scale)
+            from sparklab.kernels.triton.mxfp8_linear import mxfp8_linear
+
+            codes = store.linear_scale_codes(name + ".scale", weight.shape[0])
+            return mxfp8_linear(rounded, weight, codes)
         weight = dequant(weight, scale, fp4)
         return F.linear(fp8_roundtrip(x).float(), weight).to(x.dtype)
     return F.linear(x, weight.to(x.dtype))

--- a/python/sparklab/models/deepseek_v41/weight.py
+++ b/python/sparklab/models/deepseek_v41/weight.py
@@ -22,6 +22,7 @@ class DiskWeights:
         self.cache_limit = cache_bytes
         self.cache = OrderedDict()
         self.cache_bytes = 0
+        self.derived = {}
         self.metadata = {}
         self.fds = {}
         try:
@@ -65,6 +66,7 @@ class DiskWeights:
             os.close(fd)
         self.fds.clear()
         self.cache.clear()
+        self.derived.clear()
         self.cache_bytes = 0
 
     def validate_geometry(self, args):
@@ -138,6 +140,10 @@ class DiskWeights:
         self.close()
 
     def _read(self, name, first=0, rows=None):
+        return self._read_host(name, first, rows).to(self.device)
+
+    def _read_host(self, name, first=0, rows=None):
+        """Read a tensor range into CPU memory without a device allocation."""
         fd, offset, shape, dtype = self.metadata[name]
         count = shape[0] if rows is None else rows
         if first < 0 or count < 0 or first + count > shape[0]:
@@ -147,7 +153,7 @@ class DiskWeights:
         data = bytearray(os.pread(fd, size, offset + first * stride))
         if len(data) != size:
             raise ValueError(f"truncated tensor: {name}")
-        tensor = torch.frombuffer(data, dtype=dtype).reshape(count, *shape[1:]).to(self.device)
+        tensor = torch.frombuffer(data, dtype=dtype).reshape(count, *shape[1:])
         # pread avoids mmap retaining a 100 GB table; evict clean read pages too.
         if hasattr(os, "posix_fadvise"):
             os.posix_fadvise(fd, offset + first * stride, size, os.POSIX_FADV_DONTNEED)
@@ -177,6 +183,23 @@ class DiskWeights:
         return torch.cat([unique[index] for index in ids]).reshape(
             *indices.shape, *self.metadata[name][2][1:]
         )
+
+    def linear_scale_codes(self, name, output_rows):
+        """Return E8M0 codes with one scale row per output row.
+
+        Dense MXFP8 tensors store one scale for each 32-by-32 weight tile;
+        the small-row kernel consumes the equivalent expanded row view. Keep
+        that compact derived tensor beside the packed weight across requests.
+        Expert MXFP4 scales are already row-wise and pass through unchanged.
+        """
+        key = (name, output_rows)
+        value = self.derived.get(key)
+        if value is None:
+            codes = self.get(name).view(torch.uint8)
+            if codes.shape[0] != output_rows:
+                codes = codes.repeat_interleave(32, dim=0)[:output_rows].contiguous()
+            value = self.derived[key] = codes
+        return value
 
 
 def iter_weights(model_path, device, *, include_moe_experts=True, include_non_moe=True):

--- a/python/sparklab/moe/fused_ds_fp4.py
+++ b/python/sparklab/moe/fused_ds_fp4.py
@@ -103,6 +103,8 @@ def routed_experts_fp4(
     down_packed: torch.Tensor,     # [S, H, I//2] uint8
     down_scale: torch.Tensor,      # [S, H, I//32] e8m0
     swiglu_limit: float,
+    activation_block: int = 128,
+    sum_in_fp32: bool = False,
 ) -> torch.Tensor:
     """Full routed-expert output (summed over the top-k routes), excludes shared expert.
 
@@ -116,7 +118,7 @@ def routed_experts_fp4(
     two_I = gate_up_packed.shape[1]
     I = two_I // 2
 
-    x = act_quant_fp8_roundtrip(x, 128)  # gate_up activation -> FP8 round-trip (no clone)
+    x = act_quant_fp8_roundtrip(x, activation_block)
     gate_up = _grouped_decode(
         x, gate_up_packed, gate_up_scale, slots, None,
         a_row_is_route=False, mul_routed_weight=False,
@@ -124,12 +126,12 @@ def routed_experts_fp4(
     act = fused_swiglu(gate_up, swiglu_limit)  # [T, top_k, I]
 
     act = act.reshape(T * top_k, I)
-    act_quant_fp8_inplace(act, 128)  # down activation -> FP8 round-trip
+    act_quant_fp8_inplace(act, activation_block)
     down = _grouped_decode(
         act, down_packed, down_scale, slots, topk_weights,
         a_row_is_route=True, mul_routed_weight=True,
     )  # [T, top_k, H]
-    return down.sum(dim=1)  # [T, H]
+    return down.float().sum(dim=1) if sum_in_fp32 else down.sum(dim=1)
 
 
 # Above this the grouped GEMM beats the per-route GEMV despite its padding;

--- a/python/sparklab/recipes/deepseek-v4.1-flash.json
+++ b/python/sparklab/recipes/deepseek-v4.1-flash.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.1.0",
+  "recipe_version": "0.2.0",
   "slug": "deepseek-v4.1-flash",
   "name": "DeepSeek V4.1 Flash",
   "model": "deepseek-ai/DeepSeek-V4.1-Flash",
@@ -30,16 +30,16 @@
     }
   },
   "profile": "research",
-  "description": "Native text-only Research decoder with bounded safetensors disk reads, a 24 GiB device weight LRU, row-wise Engram lookup and shared sparse attention. Reference: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash",
+  "description": "Native text-only Research decoder with layer-major prefill, direct packed kernels, a 64 GiB expert LRU and bounded safetensors reads. Reference: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash",
   "evidence": [],
   "limitations": [
-    "Experimental native text implementation; the complete-checkpoint short probe is measured in GB10-DSV41-PORTFOLIO-001. General quality, parser, agent and endurance gates remain unverified. No V4 performance evidence transfers to V4.1.",
-    "Eager TP=1, one request, 2048 total tokens, token-at-a-time prefill, naive cache with no prefix reuse. Vision and DSpark are not implemented.",
-    "Reads original safetensors directly. The model owns disk expert execution; the fused engine setting avoids generic MoE bank allocation. Generic FTW conversion and offload-cache controls do not apply.",
-    "The 32 GiB runtime budget is an engineering estimate for the bounded 24 GiB device weight cache, transient projections and request state, not a measured certification result.",
+    "Experimental native text implementation; the optimized complete-checkpoint short probe is measured in GB10-DSV41-OPT-002. General quality, parser, agent and endurance gates remain unverified. No V4 performance evidence transfers to V4.1.",
+    "Eager TP=1, one request and 2048 total tokens with a naive cache and no prefix reuse. Vision and DSpark are not implemented.",
+    "Reads original safetensors directly. The model owns a dedicated packed expert LRU; the fused engine setting avoids generic MoE bank allocation. Generic FTW conversion and offload-cache controls do not apply.",
+    "The 96 GiB runtime budget covers the measured 64 GiB expert bank, bounded dense-weight cache, transient projections and request state; it is not a certification result.",
     "Requires roughly 510 GB of local storage. Engram tables are read by row and never loaded whole. First-token and decode latency may be high."
   ],
   "runtime_memory": {
-    "total_bytes": 34359738368
+    "total_bytes": 103079215104
   }
 }

--- a/tests/dsv41/test_expert_cache.py
+++ b/tests/dsv41/test_expert_cache.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import torch
+
+from sparklab.models.deepseek_v41.expert_cache import ExpertBank
+
+
+def _metadata(args):
+    result = {}
+    for layer in range(2):
+        for expert in range(3):
+            root = f"layers.{layer}.ffn.experts.{expert}"
+            for projection, shape in {
+                "w1": (args.moe_inter_dim, args.dim // 2),
+                "w3": (args.moe_inter_dim, args.dim // 2),
+                "w2": (args.dim, args.moe_inter_dim // 2),
+            }.items():
+                result[root + f".{projection}.weight"] = (0, 0, shape, torch.uint8)
+                result[root + f".{projection}.scale"] = (
+                    0, 0, (shape[0], shape[1] // 16), torch.uint8
+                )
+    return result
+
+
+def test_expert_bank_lru_and_gate_up_order(monkeypatch):
+    args = SimpleNamespace(dim=64, moe_inter_dim=32, n_activated_experts=2,
+                           n_routed_experts=3, n_layers=2)
+    store = SimpleNamespace(device=torch.device("cpu"), metadata=_metadata(args))
+
+    def read(name):
+        shape = store.metadata[name][2]
+        value = 3 if ".w3." in name else 2 if ".w2." in name else 1
+        return torch.full(shape, value, dtype=torch.uint8)
+
+    store._read_host = read
+    monkeypatch.setenv("SPARKLAB_DSV41_EXPERT_CACHE_GB", "1")
+    bank = ExpertBank(args, store)
+    bank.capacity = 2
+    assert bank.slots(0, torch.tensor([[2, 1]])).tolist() == [[0, 1]]
+    assert torch.all(bank.gate_up[0, :32] == 1)
+    assert torch.all(bank.gate_up[0, 32:] == 3)
+    assert torch.all(bank.down[0] == 2)
+    assert bank.slots(0, torch.tensor([[1, 0]])).tolist() == [[1, 0]]
+    assert (0, 2) not in bank.entries
+
+
+def test_expert_bank_deduplicates_batch_misses(monkeypatch):
+    args = SimpleNamespace(dim=64, moe_inter_dim=32, n_activated_experts=2,
+                           n_routed_experts=3, n_layers=2)
+    store = SimpleNamespace(device=torch.device("cpu"), metadata=_metadata(args))
+    calls = []
+
+    def read(name):
+        calls.append(name)
+        return torch.zeros(store.metadata[name][2], dtype=torch.uint8)
+
+    store._read_host = read
+    monkeypatch.setenv("SPARKLAB_DSV41_EXPERT_CACHE_GB", "1")
+    bank = ExpertBank(args, store)
+    bank.capacity = 9
+    slots = bank.slots(0, torch.tensor([[2, 1], [2, 1], [0, 2]]))
+    assert slots.tolist() == [[0, 1], [0, 1], [2, 0]]
+    assert len(calls) == 3 * 6
+
+
+def test_expert_bank_does_not_evict_rows_used_by_current_batch(monkeypatch):
+    args = SimpleNamespace(dim=64, moe_inter_dim=32, n_activated_experts=1,
+                           n_routed_experts=3, n_layers=2)
+    store = SimpleNamespace(device=torch.device("cpu"), metadata=_metadata(args))
+    store._read_host = lambda name: torch.zeros(store.metadata[name][2], dtype=torch.uint8)
+    monkeypatch.setenv("SPARKLAB_DSV41_EXPERT_CACHE_GB", "1")
+    bank = ExpertBank(args, store)
+    bank.capacity = 2
+    assert bank.slots(0, torch.tensor([[0], [1]])).tolist() == [[0], [1]]
+    slots = bank.slots(0, torch.tensor([[1], [2]]))
+    assert slots.tolist() == [[1], [0]]
+    assert bank.entries == {(0, 1): 1, (0, 2): 0}

--- a/tests/dsv41/test_native.py
+++ b/tests/dsv41/test_native.py
@@ -64,6 +64,15 @@ def test_complete_tiny_decoder_matches_pinned_reference_and_resets(decoder):
         decoder.reset()
 
 
+def test_layer_major_prefill_matches_sequential_reference(decoder):
+    golden = json.loads((FIXTURE / "expected.json").read_text())
+    expected = torch.cat([decoder.step(token) for token in golden["tokens"]])[-1:]
+    decoder.reset()
+    actual = decoder.prefill(golden["tokens"])
+    torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
+    assert decoder.position == len(golden["tokens"])
+
+
 def test_context_and_image_inputs_fail_before_state_is_advanced(decoder):
     with pytest.raises(ValueError, match="text token"):
         decoder.step(decoder.args.image_token_id)
@@ -179,5 +188,7 @@ def test_native_recipe_is_experimental_and_skips_ftw(tmp_path):
     assert recipe.status == "experimental" and recipe.performance is None
     assert recipe.evidence == () and recipe.runtime_artifact is None
     assert recipe.deployment.runtime_format == "safetensors"
+    assert recipe.recipe_version == "0.2.0"
+    assert recipe.runtime_memory == {"total_bytes": 96 * 2**30}
     with pytest.raises(AcquisitionError, match="omit --prepare"):
         acquire_recipe(recipe, root=str(tmp_path), prepare=True)

--- a/tests/kernels/test_dsv41_packed_linear.py
+++ b/tests/kernels/test_dsv41_packed_linear.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from sparklab.models.deepseek_v41.ops import dequant, fp8_roundtrip
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@pytest.mark.parametrize("rows,out_features,in_features", [(1, 96, 256), (3, 65, 256)])
+def test_mxfp4_linear_matches_reference(rows, out_features, in_features):
+    from sparklab.kernels.triton.dsv41_linear import mxfp4_linear
+
+    torch.manual_seed(411)
+    x = torch.randn(rows, in_features, dtype=torch.bfloat16, device="cuda")
+    packed = torch.randint(0, 256, (out_features, in_features // 2), dtype=torch.uint8, device="cuda")
+    codes = torch.randint(120, 132, (out_features, in_features // 32), dtype=torch.uint8, device="cuda")
+    rounded = fp8_roundtrip(x)
+    expected = torch.nn.functional.linear(
+        rounded.float(), dequant(packed, codes.view(torch.float8_e8m0fnu), fp4=True)
+    ).to(torch.bfloat16)
+    actual = mxfp4_linear(rounded, packed, codes)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=1.5e-2)
+
+
+def test_v41_head_skinny_linear_matches_fp32_reference():
+    from sparklab.kernels.triton.dsv4.skinny import bf16_skinny_linear
+
+    torch.manual_seed(412)
+    x = torch.randn(1, 5120, dtype=torch.bfloat16, device="cuda")
+    weight = torch.randn(129280, 5120, dtype=torch.bfloat16, device="cuda")
+    actual = bf16_skinny_linear(x, weight, out_dtype=torch.float32)
+    expected = torch.nn.functional.linear(x.float(), weight.float())
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-3)
+
+
+def test_dense_tile_scales_expand_once_per_output_row():
+    from types import SimpleNamespace
+
+    from sparklab.models.deepseek_v41.weight import DiskWeights
+
+    store = DiskWeights.__new__(DiskWeights)
+    store.derived = {}
+    store.fds = {}
+    store.cache = {}
+    store.cache_bytes = 0
+    compact = torch.tensor([[120, 121], [122, 123]], dtype=torch.uint8, device="cuda")
+    store.get = lambda name: compact.view(torch.float8_e8m0fnu)
+    actual = store.linear_scale_codes("scale", 33)
+    assert actual.shape == (33, 2)
+    torch.testing.assert_close(actual[:32], compact[:1].expand(32, 2))
+    torch.testing.assert_close(actual[32:], compact[1:2])
+    assert store.linear_scale_codes("scale", 33).data_ptr() == actual.data_ptr()


### PR DESCRIPTION
The native DeepSeek V4.1 Flash path repeatedly dequantized packed weights and loaded routed experts directly from disk, leaving the fixed 74-input/128-output probe at 0.244 decode tok/s and 343.131 seconds TTFT.

This change adds layer-major prompt execution, direct packed MXFP4/MXFP8 linears, an eight-reader 64 GiB packed expert LRU, and an FP32-output small-row head. On the same complete-checkpoint workload, the three-trial median reaches 0.969 decode tok/s, 74.387 seconds TTFT, and 205.420 seconds total: 3.98x decode throughput, 4.61x faster TTFT, and 4.21x lower total time. The recipe moves to version 0.2.0 with a 96 GiB runtime reservation.

The optimized trials share one output hash, but packed/fused rounding changes it from the earlier implementation. Both 128-token outputs stop before the answer, so the evidence remains a performance probe and does not claim quality parity.

Validation:

- `64 passed` across DeepSeek V4.1, shared DSV4 kernel, packed-linear, and catalog tests
- Four successful complete-checkpoint streaming requests: one full warmup and three measured trials
- Source hashes, JSON parsing, bytecode compilation, and `git diff --check`
- Full repository run: 2,220 passed, 24 skipped; 58 unrelated failures from unavailable installed `_pinned_tensor`/CPU-MoE extensions and existing runtime fixtures missing `vision_model`
