### PR TITLE
Add native DeepSeek V4.1 DSpark decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ may still work through native runtime fallbacks, but it is not a SparkLab suppor
       <th colspan="7" align="left">Research — bounded execution outside the interactive envelope</th>
     </tr>
     <tr>
-      <td><a href="https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash">DeepSeek V4.1 Flash</a></td>
-      <td>522B total / 8–16B active</td>
-      <td>MXFP4 / MXFP8 · native disk streaming</td>
+      <td><a href="https://huggingface.co/oakmindai/DeepSeek-V4.1-Flash-FTW">DeepSeek V4.1 Flash</a></td>
+      <td>552B total / 8–16B active</td>
+      <td>MXFP4 / MXFP8 · disk streaming + optional DSpark5</td>
       <td>Experimental</td>
-      <td align="right">0.24</td>
-      <td align="right">343.131</td>
+      <td align="right">1.05</td>
+      <td align="right">76.329</td>
       <td><a href="docs/models/deepseek-v4.1-flash.md">Instructions</a></td>
     </tr>
     <tr>

--- a/benchmarks/gb10/README.md
+++ b/benchmarks/gb10/README.md
@@ -109,6 +109,10 @@ recipes. Raw logs and large result streams stay outside the source repository.
   commits: a three-trial median of 7.77 tok/s and 6.395 s warm TTFT, 3.4% above the
   fresh MTP3 control. Every trial preserved its output and eliminated rejection replay,
   at an additional 0.55 GiB of device allocation with fixed expert-cache capacity.
+- `results/GB10-DSV41-DSPARK-003.json` records the opt-in native DeepSeek V4.1
+  DSpark-5 prototype: 1.053 decode tok/s on the fixed 74-input/128-output probe,
+  8.6% above the target-only median. Accepted-prefix state commits eliminated all
+  rejection replay and both measured trials matched the target-only output hash.
 - `results/GB10-KIMI-001.json` records the full Kimi K3 ModelOpt NVFP4 FTW
   capacity experiment with SparkLab's GB10 resident FP8 profile: 0.161 decode tok/s,
   395.405 s warm TTFT, exact 256-token completion, and zero runtime OOM/swap-out.

--- a/benchmarks/gb10/results/GB10-DSV41-DSPARK-003.json
+++ b/benchmarks/gb10/results/GB10-DSV41-DSPARK-003.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "1.0",
+  "result_id": "GB10-DSV41-DSPARK-003",
+  "status": "measured",
+  "date": "2026-09-12",
+  "recipe": {
+    "slug": "deepseek-v4.1-flash",
+    "recipe_version": "0.3.0",
+    "revision": "df42c109f1defefcbfcedbe7d905718a12266e40"
+  },
+  "engine": {
+    "name": "SparkLab",
+    "base_git_revision": "9c3b2965df9b07bfcbcafad826aea28856b3665a",
+    "profile": "uncommitted native DSpark prototype"
+  },
+  "hardware": {
+    "platform": "NVIDIA GB10",
+    "unified_memory_gib": 128,
+    "machine": "aarch64"
+  },
+  "checkpoint": {
+    "repository": "deepseek-ai/DeepSeek-V4.1-Flash",
+    "revision": "df42c109f1defefcbfcedbe7d905718a12266e40",
+    "format": "safetensors",
+    "bytes": 510313345254
+  },
+  "workload": {
+    "name": "Original AIME-25 problem 0 portfolio probe",
+    "prompt_sha256": "51e1235f1c85cf333085c9e2889a20fb7e7ef65f320856975bac705eb04e43d4",
+    "prompt_tokens": 74,
+    "completion_tokens": 128,
+    "clients": 1,
+    "temperature": 0,
+    "thinking": true,
+    "ignore_eos": true,
+    "warmup_requests": 1,
+    "measured_trials": 2,
+    "aggregation": "median",
+    "metric": "(completion_tokens - 1) / (last content event - first content event)"
+  },
+  "configuration": {
+    "backend": "native",
+    "expert_cache_gib": 64,
+    "context_tokens": 2048,
+    "speculative_method": "dspark",
+    "speculative_tokens": 5,
+    "draft_sample_method": "greedy",
+    "verification": "layer-major target pass with model-owned accepted-prefix commit"
+  },
+  "metrics": {
+    "decode_tokens_per_second_trials": [
+      1.0488766566257035,
+      1.0563955253971997
+    ],
+    "decode_tokens_per_second_median": 1.0526360910114516,
+    "warm_ttft_seconds_trials": [
+      75.85293513000943,
+      76.80458605499007
+    ],
+    "warm_ttft_seconds_median": 76.32876059249975,
+    "elapsed_seconds_trials": [
+      196.93515756493434,
+      197.02550676907413
+    ],
+    "elapsed_seconds_median": 196.98033216700424,
+    "target_only_decode_tokens_per_second_median": 0.9692250183829233,
+    "decode_speedup": 1.0860595538151638,
+    "elapsed_reduction": 0.04108575523588831,
+    "accepted_drafts": 94,
+    "drafted_tokens": 118,
+    "acceptance_rate": 0.7966101694915254,
+    "outputs_per_target_forward": 3.76,
+    "prefix_commits": 9,
+    "replay_calls": 0
+  },
+  "validation": {
+    "focused_tests_passed": 67,
+    "all_measured_output_hashes_match": true,
+    "target_only_output_hash_matches": true,
+    "output_sha256": "4d81d182dc00c34a3e6ae7934832dbc23a6eac9ede6bf61c27cf82e204f286a5"
+  },
+  "source": {
+    "upstream_recipe": "https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash",
+    "raw_artifacts": [
+      "/tmp/dsv41-dspark-commit-128.jsonl",
+      "/tmp/dsv41-dspark-commit-128-repeat.jsonl",
+      "/tmp/dsv41-dspark-commit.log"
+    ],
+    "target_only_evidence": "GB10-DSV41-OPT-002"
+  },
+  "limitations": [
+    "Two measured trials on one fixed short-context prompt; this is optimization evidence, not quality or endurance certification.",
+    "The prototype implements greedy DSpark. The upstream vLLM recipe uses probabilistic draft sampling, block rejection, and adaptive verification.",
+    "Single-request TP=1 execution remains required."
+  ]
+}

--- a/docs/huggingface/deepseek-v4.1-flash-ftw.md
+++ b/docs/huggingface/deepseek-v4.1-flash-ftw.md
@@ -1,0 +1,109 @@
+---
+pipeline_tag: text-generation
+base_model: deepseek-ai/DeepSeek-V4.1-Flash
+license: mit
+library_name: sparklab
+tags:
+- deepseek-v4.1
+- mxfp4
+- mxfp8
+- sparklab
+- ftw
+- speculative-decoding
+---
+
+# DeepSeek V4.1 Flash — SparkLab disk-ready checkpoint
+
+This repository is a byte-preserving mirror of
+[`deepseek-ai/DeepSeek-V4.1-Flash`](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash)
+at revision `df42c109f1defefcbfcedbe7d905718a12266e40`, published for the
+[SparkLab](https://github.com/sixteen-miles-labs/sparklab) native NVIDIA DGX Spark
+research path.
+
+The tensors retain DeepSeek's original mixed checkpoint representation: routed experts
+are MXFP4, dense projections are MXFP8 with UE8M0 scales, and embeddings and the output
+head are BF16. No training, tensor conversion, or additional quantization was performed.
+Although the repository uses the `FTW` deployment label, DeepSeek V4.1 currently runs
+through SparkLab's model-owned safetensors reader and packed expert cache rather than the
+generic FTW container format.
+
+## Validated scope
+
+SparkLab currently supports text-only, TP=1, batch-one eager execution with a 2,048-token
+total context on one 128 GB NVIDIA GB10. The model owns a 64 GiB packed expert LRU and a
+bounded 24 GiB weight cache, reading the remaining checkpoint from local NVMe.
+
+The default target-only profile measured 0.969 decode tokens/s and 74.387 seconds warm
+TTFT on a fixed 74-input/128-output greedy probe. Opt-in native greedy DSpark-5 measured
+1.053 decode tokens/s and 76.329 seconds warm TTFT, an 8.6% decode improvement. Both
+DSpark trials reproduced the target-only output hash. These are narrow performance
+measurements, not general quality, concurrency, long-context, or endurance certification.
+
+The upstream vLLM recipe uses probabilistic draft sampling, block rejection, and adaptive
+verification. SparkLab's current V4.1 path implements greedy drafting and exact
+accepted-prefix state commits; probabilistic sampling and adaptive verification remain
+out of scope.
+
+## Download and run
+
+The repository is approximately 480 GiB. Download it to local NVMe:
+
+```bash
+hf download oakmindai/DeepSeek-V4.1-Flash-FTW \
+  --local-dir ~/models/DeepSeek-V4.1-Flash-FTW
+```
+
+Install SparkLab from source, then start the target-only server:
+
+```bash
+git clone https://github.com/sixteen-miles-labs/sparklab.git
+cd sparklab
+./install.sh
+
+SPARKLAB_DSV41_EXPERT_CACHE_GB=64 sparklab serve \
+  --model ~/models/DeepSeek-V4.1-Flash-FTW \
+  --dtype bfloat16 \
+  --max-running-requests 1 \
+  --max-seq-len-override 2048 \
+  --num-tokens 2048 \
+  --attention-backend triton \
+  --cache-type naive \
+  --moe-backend fused \
+  --cuda-graph-max-bs 0 \
+  --disable-startup-prefill-warmup \
+  --port 8000
+```
+
+Enable the measured DSpark profile by adding:
+
+```bash
+--speculative-method dspark \
+--speculative-tokens 5 \
+--draft-sample-method greedy
+```
+
+Send a request:
+
+```bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "DeepSeek-V4.1-Flash-FTW",
+    "messages": [{"role": "user", "content": "What is 17*19?"}],
+    "temperature": 0,
+    "max_tokens": 32
+  }'
+```
+
+## Provenance and license
+
+DeepSeek AI developed and released the architecture, code, tokenizer, and weights. This
+mirror preserves the upstream MIT license and source files. SparkLab supplies the native
+runtime, direct packed MXFP4/MXFP8 kernels, bounded disk-backed execution, DSpark
+integration, validation, and model recipe. Oakmind AI publishes this mirror.
+
+- Upstream model: https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash
+- Exact upstream revision: https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/tree/df42c109f1defefcbfcedbe7d905718a12266e40
+- SparkLab: https://github.com/sixteen-miles-labs/sparklab
+- vLLM architecture recipe: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash
+

--- a/docs/models.md
+++ b/docs/models.md
@@ -38,17 +38,16 @@ coding-agent task, and versioned benchmark evidence. Status means:
 | [DeepSeek V4 Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | 284B total / 13B active | DS-FP4 · FTW + optional DSpark5 | `deepseek-v4` | Preview | 14.02 | 0.515 |
 | [GLM-5.3 Flash](https://huggingface.co/oakmindai/GLM-5.3-Flash-NVFP4-FTW) | 320B total / 18B active | NVFP4 + KDA FP8 · FTW + optional MTP3 | `glm-5.3-flash` | Experimental | 7.77 | 6.395 |
 | **Research — complete or novel models outside the interactive envelope** |  |  |  |  |  |  |
-| [DeepSeek V4.1 Flash](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash) | 522B total / 8–16B active | MXFP4 / MXFP8 · native disk streaming | `deepseek-v4.1-flash` | Experimental | — | — |
+| [DeepSeek V4.1 Flash](https://huggingface.co/oakmindai/DeepSeek-V4.1-Flash-FTW) | 552B total / 8–16B active | MXFP4 / MXFP8 · disk streaming + optional DSpark5 | `deepseek-v4.1-flash` | Experimental | 1.05 | 76.329 |
 | [GLM-5.3](https://huggingface.co/oakmindai/GLM-5.3-NVFP4-FTW) | 753B total / 40B active | NVFP4 + resident FP8 · FTW + optional DFlash2-4 | `glm-5.3` | Experimental fallback | 1.29 | 2.085 |
 | [Kimi K3](https://huggingface.co/oakmindai/Kimi-K3-NVFP4-FTW) | 2.8T total / 16 of 896 experts | ModelOpt NVFP4/FP8 · FTW | `kimi-k3` | Experimental | 0.16 | 395.405 |
 
 Model links point to the selected source or published FTW checkpoint. GLM-5.3
 and Kimi K3 use pinned prebuilt artifacts with reproducible source-conversion paths.
 Qwen3.6 converts its pinned NVIDIA source into a separate Marlin FTW inside its container.
-DeepSeek V4.1 Flash links to its architecture recipe; SparkLab implements a native
-text-only Research path with direct safetensors disk reads, bounded Engram lookups,
-and no FTW conversion. See its [run instructions](models/deepseek-v4.1-flash.md).
-Full-checkpoint inference and performance are unverified; dashes mean unmeasured.
+DeepSeek V4.1 Flash uses a byte-preserving Oakmind mirror of the original mixed
+MXFP4/MXFP8 checkpoint; its model-owned safetensors path does not use the generic FTW
+container. See its [run instructions](models/deepseek-v4.1-flash.md).
 The current Qwen3.8-Flash-Next recipe requires a
 [source installation](install.md#method-2-install-from-source); the released 0.1.2 wheel
 lacks its required runtime support.

--- a/docs/models/deepseek-v4.1-flash.md
+++ b/docs/models/deepseek-v4.1-flash.md
@@ -7,9 +7,14 @@ is the architecture reference; this SparkLab recipe does not launch vLLM or Dock
 
 The source is `deepseek-ai/DeepSeek-V4.1-Flash`, pinned to
 `df42c109f1defefcbfcedbe7d905718a12266e40`. The complete snapshot is
-510,313,345,254 bytes (about 475 GiB). Publisher parameter counts are 522B total,
+510,313,345,254 bytes (about 475 GiB). Publisher parameter counts are 552B total,
 8B active per prompt token and 16B active per generated token; these describe the
 publisher model, including capabilities beyond this initial text path.
+
+A byte-preserving copy of that pinned checkpoint is published at
+[`oakmindai/DeepSeek-V4.1-Flash-FTW`](https://huggingface.co/oakmindai/DeepSeek-V4.1-Flash-FTW).
+It keeps the original safetensors layout; the `FTW` name identifies the SparkLab
+deployment artifact and does not imply conversion to the generic FTW container.
 
 ## Run
 
@@ -26,8 +31,20 @@ Omit `--prepare`: the decoder reads the original safetensors snapshot directly.
 FTW conversion is unsupported. The native engine fixes this path to TP=1, one
 request, BF16 computation, eager execution, naive prefix caching and a 2,048-token
 total context. Prompt-wide Engram, hyper-connection and MoE work runs
-layer-by-layer; attention and its projections still advance causally. Vision, prefix reuse, CUDA
-graphs and DSpark speculation are not implemented.
+layer-by-layer; attention and its projections still advance causally. Vision,
+prefix reuse, and CUDA graphs are not implemented. Native greedy DSpark-5 is available as an opt-in
+single-request profile:
+
+```bash
+SPARKLAB_DSV41_EXPERT_CACHE_GB=64 sparklab serve \
+  --model /path/to/DeepSeek-V4.1-Flash-FTW \
+  --dtype bfloat16 --max-running-requests 1 \
+  --max-seq-len-override 2048 --num-tokens 2048 \
+  --attention-backend triton --cache-type naive --moe-backend fused \
+  --cuda-graph-max-bs 0 --disable-startup-prefill-warmup \
+  --speculative-method dspark --speculative-tokens 5 \
+  --draft-sample-method greedy
+```
 
 The model owns a 64 GiB packed-expert LRU plus a bounded 24 GiB device-weight LRU,
 and reads Engram embedding rows from disk only when requested. MXFP4 experts run
@@ -82,6 +99,14 @@ generates 128 output tokens, with greedy sampling, thinking enabled and EOS igno
 This is 3.98x the prior decode rate, with 4.61x faster TTFT and 4.21x lower total
 time. See [optimized evidence](../../benchmarks/gb10/results/GB10-DSV41-OPT-002.json)
 and the [prior baseline](../../benchmarks/gb10/results/GB10-DSV41-PORTFOLIO-001.json).
+
+The opt-in DSpark-5 profile measured **1.053 decode tok/s**, **76.329 s warm
+TTFT**, and **196.980 s total request time**, medians of two trials after one
+warmup. This is 8.6% faster decode and 4.1% lower total time than target-only.
+DSpark accepted 94 of 118 drafts, emitted 3.76 tokens per target forward, and
+used exact accepted-prefix commits with no target replay. Both trials reproduced
+the target-only output hash. See the
+[DSpark evidence](../../benchmarks/gb10/results/GB10-DSV41-DSPARK-003.json).
 
 All optimized trials produced the same output hash. The packed/fused arithmetic
 did not reproduce the prior decoder's output hash, and both 128-token traces end

--- a/python/sparklab/models/deepseek_v41/args.py
+++ b/python/sparklab/models/deepseek_v41/args.py
@@ -87,8 +87,7 @@ class ModelArgs:
     vision_max_wh_ratio: int | None = None
     # raw id of <｜deepseek_image｜>; every position of an image span carries this id in input_ids
     image_token_id: int = 129264
-    # dspark draft head. Only the forward pass is implemented here -- nothing calls forward_spec,
-    # so these are read but the speculative-decoding loop itself is out of scope for this repo.
+    # DSpark draft head stored under the mtp.* checkpoint namespace.
     dspark_block_size: int = 0
     dspark_noise_token_id: int = 0
     dspark_target_layer_ids: tuple[int, ...] = ()

--- a/python/sparklab/models/deepseek_v41/config.py
+++ b/python/sparklab/models/deepseek_v41/config.py
@@ -21,7 +21,6 @@ def load_args(path):
     args.max_seq_len = MAX_CONTEXT
     args.max_batch_size = 1
     args.vision_n_layers = 0
-    args.dspark_block_size = 0
     if len(args.compress_ratios) < args.n_layers or any(
         ratio not in (0, 1, 2) for ratio in args.compress_ratios[:args.n_layers]
     ):
@@ -51,5 +50,5 @@ def parse_config(hf_config):
         moe_intermediate_size=args.moe_inter_dim, norm_topk_prob=args.norm_topk_prob,
         model_type="deepseek_v41", architectures=["DeepseekV41ForCausalLM"],
         moe_enabled=True, expert_quant="ds_fp4", single_stream_only=True,
-        dsv41_args=args,
+        dsv41_args=args, speculative_method="none", speculative_tokens=0,
     )

--- a/python/sparklab/models/deepseek_v41/dspark.py
+++ b/python/sparklab/models/deepseek_v41/dspark.py
@@ -1,0 +1,224 @@
+"""Checkpoint-native DSpark drafter for the V4.1 disk decoder."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from .ops import apply_rotary_emb, dequant, fp8_roundtrip, hc_split_sinkhorn
+
+
+class DSparkDraft:
+    """Three-stage, parallel five-token drafter stored under ``mtp.*``."""
+
+    def __init__(self, decoder, steps: int):
+        self.decoder = decoder
+        self.args = decoder.args
+        self.store = decoder.store
+        self.steps = min(int(steps), self.args.dspark_block_size)
+        self.windows = {}
+        self.last_position = -1
+        self.last_confidence = None
+
+    def reset(self):
+        self.windows = {}
+        self.last_position = -1
+        self.last_confidence = None
+
+    def snapshot(self):
+        return {
+            "windows": {stage: value.clone() for stage, value in self.windows.items()},
+            "last_position": self.last_position,
+        }
+
+    def restore(self, snapshot):
+        self.windows = snapshot["windows"]
+        self.last_position = snapshot["last_position"]
+        self.last_confidence = None
+
+    def commit_prefix(self, snapshot, current, start: int, length: int):
+        self.restore(snapshot)
+        device = next(iter(current["windows"].values())).device
+        positions = torch.arange(
+            start, start + length, dtype=torch.long, device=device
+        )
+        for stage, window in self.windows.items():
+            window[positions % self.args.window_size] = current["windows"][stage][
+                positions % self.args.window_size
+            ]
+        self.last_position = start + length - 1
+
+    def _linear(self, name, x):
+        return self.decoder._linear(name, x)
+
+    def _norm(self, name, x):
+        return self.decoder._norm(name, x)
+
+    def _rope(self, x, positions, inverse=False):
+        rd = self.args.rope_head_dim
+        apply_rotary_emb(
+            x[..., -rd:], self.decoder.freqs[False][positions], inverse
+        )
+        return x
+
+    def _mixes(self, name, kind, h):
+        a = self.args
+        root = f"{name}.hc_{kind}"
+        x = h.flatten(2).float()
+        mixes = F.linear(x, self.store.get(root + "_fn").float())
+        mixes *= torch.rsqrt(x.square().mean(-1, keepdim=True) + a.norm_eps)
+        pre, post, comb = hc_split_sinkhorn(
+            mixes.reshape(-1, mixes.shape[-1]),
+            self.store.get(root + "_scale"),
+            self.store.get(root + "_base"),
+            a.hc_mult,
+            a.hc_sinkhorn_iters,
+            a.hc_eps,
+        )
+        lead = mixes.shape[:-1]
+        return (
+            pre.reshape(*lead, a.hc_mult),
+            post.reshape(*lead, a.hc_mult),
+            comb.reshape(*lead, a.hc_mult, a.hc_mult),
+        )
+
+    def store_target(self, aux, start_pos: int):
+        if len(aux) != len(self.args.dspark_target_layer_ids):
+            raise RuntimeError("V4.1 DSpark target features are incomplete")
+        main = self._norm(
+            "mtp.0.main_norm",
+            self._linear("mtp.0.main_proj", torch.cat(aux, dim=-1)),
+        )
+        positions = torch.arange(
+            start_pos,
+            start_pos + main.shape[1],
+            dtype=torch.long,
+            device=main.device,
+        )
+        for stage in range(self.args.n_mtp_layers):
+            name = f"mtp.{stage}.attn"
+            kv = self._norm(name + ".kv_norm", self._linear(name + ".wkv", main))
+            kv = fp8_roundtrip(self._rope(kv, positions)).reshape(-1, self.args.head_dim)
+            window = self.windows.get(stage)
+            if window is None:
+                window = self.windows[stage] = torch.empty(
+                    self.args.window_size,
+                    self.args.head_dim,
+                    dtype=kv.dtype,
+                    device=kv.device,
+                )
+            window[positions % self.args.window_size] = kv
+        self.last_position = start_pos + main.shape[1] - 1
+
+    def _visible(self, stage):
+        window = self.windows[stage]
+        pos, width = self.last_position, self.args.window_size
+        if pos < width - 1:
+            return window[: pos + 1]
+        slot = (pos + 1) % width
+        return torch.cat((window[slot:], window[:slot]))
+
+    def _attention(self, stage, x, positions):
+        a = self.args
+        name = f"mtp.{stage}.attn"
+        qr = self._norm(name + ".q_norm", self._linear(name + ".wq_a", x))
+        q = self._linear(name + ".wq_b", qr).view(
+            1, self.steps, a.n_heads, a.head_dim
+        )
+        q = self._rope(q, positions)[0]
+        kv = self._norm(name + ".kv_norm", self._linear(name + ".wkv", x))
+        kv = fp8_roundtrip(self._rope(kv, positions)).reshape(self.steps, a.head_dim)
+        visible = torch.cat((self._visible(stage), kv))
+        scores = torch.einsum("shd,td->sht", q.float(), visible.float())
+        scores *= a.head_dim**-0.5
+        sink = self.store.get(name + ".attn_sink").float()
+        scores = torch.cat((scores, sink.view(1, -1, 1).expand(self.steps, -1, -1)), -1)
+        weights = scores.softmax(-1)[..., :-1]
+        output = torch.einsum("sht,td->shd", weights, visible.float()).to(x.dtype)
+        output = self._rope(output.unsqueeze(0), positions, inverse=True)
+        weight = self.store.get(name + ".wo_a.weight")
+        if name + ".wo_a.scale" in self.store.metadata:
+            weight = dequant(weight, self.store.get(name + ".wo_a.scale")).to(torch.bfloat16)
+        weight = weight.view(a.o_groups, a.o_lora_rank, -1)
+        output = torch.einsum(
+            "bsgd,grd->bsgr",
+            output.view(1, self.steps, a.o_groups, -1),
+            weight.to(output.dtype),
+        )
+        return self._linear(name + ".wo_b", output.flatten(2))
+
+    @torch.inference_mode()
+    def propose(self, anchor: torch.Tensor):
+        if self.last_position < 0 or self.steps <= 0:
+            return None
+        a = self.args
+        anchor = anchor.reshape(1).long()
+        ids = torch.cat((
+            anchor.cpu(),
+            torch.full(
+                (self.steps - 1,), a.dspark_noise_token_id, dtype=torch.long
+            ),
+        )).view(1, -1)
+        h = self.store.rows("embed.weight", ids).to(torch.bfloat16)
+        h = h.unsqueeze(2).repeat(1, 1, a.hc_mult, 1)
+        pre = torch.zeros(
+            (1, self.steps, a.hc_mult), device=h.device, dtype=torch.float32
+        )
+        pre[..., 0] = 1
+        positions = torch.arange(
+            self.last_position + 1,
+            self.last_position + 1 + self.steps,
+            dtype=torch.long,
+            device=h.device,
+        )
+        for stage in range(a.n_mtp_layers):
+            name = f"mtp.{stage}"
+            residual = h
+            attn_pre, post, comb = self._mixes(name, "attn", h)
+            x = self._norm(name + ".attn_norm", self.decoder._pre(h, pre))
+            h = self.decoder._post(
+                self._attention(stage, x, positions), residual, post, comb
+            )
+            residual = h
+            pre, post, comb = self._mixes(name, "ffn", h)
+            x = self._norm(name + ".ffn_norm", self.decoder._pre(h, attn_pre))
+            output = self.decoder._moe(
+                a.n_layers + stage,
+                x,
+                name=name + ".ffn",
+                n_activated_experts=a.dspark_n_activated_experts,
+            )
+            h = self.decoder._post(output, residual, post, comb)
+
+        # A block returns its FFN pre-mix for the following sublayer.  The
+        # terminal head consumes that value directly; there is no hc_head.
+        hidden = self.decoder._pre(h, pre)
+        hidden = self._norm(f"mtp.{a.n_mtp_layers - 1}.norm", hidden)[0]
+        from sparklab.kernels.triton.dsv4.skinny import bf16_skinny_linear
+
+        base_logits = bf16_skinny_linear(
+            hidden, self.store.get("head.weight"), out_dtype=torch.float32
+        )
+        final = a.n_mtp_layers - 1
+        markov_embed = self.store.get(f"mtp.{final}.markov_head.embed.weight")
+        markov_head = self.store.get(f"mtp.{final}.markov_head.head.weight")
+        previous = anchor.to(h.device)
+        drafts = []
+        markov_features = []
+        for row in range(self.steps):
+            markov = F.embedding(previous, markov_embed)
+            markov_features.append(markov.squeeze(0))
+            bias = bf16_skinny_linear(markov, markov_head, out_dtype=torch.float32)
+            token = (base_logits[row : row + 1] + bias).argmax(-1)
+            drafts.append(token.squeeze(0).to(torch.int32))
+            previous = token
+        features = torch.cat((hidden.float(), torch.stack(markov_features).float()), -1)
+        confidence = F.linear(
+            features,
+            self.store.get(f"mtp.{final}.confidence_head.proj.weight").float(),
+        ).squeeze(-1)
+        self.last_confidence = confidence
+        return torch.stack(drafts)
+
+
+__all__ = ["DSparkDraft"]

--- a/python/sparklab/models/deepseek_v41/expert_cache.py
+++ b/python/sparklab/models/deepseek_v41/expert_cache.py
@@ -70,7 +70,11 @@ class ExpertBank:
 
     def _read_expert(self, key):
         layer, expert = key
-        root = f"layers.{layer}.ffn.experts.{expert}"
+        root = (
+            f"layers.{layer}.ffn.experts.{expert}"
+            if layer < self.args.n_layers
+            else f"mtp.{layer - self.args.n_layers}.ffn.experts.{expert}"
+        )
         return [self.store._read_host(root + suffix) for suffix in (
             ".w1.weight", ".w3.weight", ".w1.scale", ".w3.scale",
             ".w2.weight", ".w2.scale",

--- a/python/sparklab/models/deepseek_v41/model.py
+++ b/python/sparklab/models/deepseek_v41/model.py
@@ -45,14 +45,93 @@ class Decoder:
         self.expert_bank = (
             ExpertBank(args, store) if self.device.type == "cuda" and packed_experts else None
         )
+        self.dspark = None
+        self._verify_carries = None
         self.reset()
 
     def reset(self):
         self.position = 0
+        self._verify_carries = None
         self.windows = {}
         self.compressed = {}
         self.keys = {}
         self.carry = {}
+        if self.hash is not None:
+            self.hash.cache.zero_()
+        if self.dspark is not None:
+            self.dspark.reset()
+
+    def enable_dspark(self, steps):
+        from .dspark import DSparkDraft
+
+        self.dspark = DSparkDraft(self, steps)
+
+    @staticmethod
+    def _clone_tree(value):
+        if isinstance(value, torch.Tensor):
+            return value.clone()
+        if isinstance(value, dict):
+            return {key: Decoder._clone_tree(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [Decoder._clone_tree(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(Decoder._clone_tree(item) for item in value)
+        return value
+
+    def snapshot(self):
+        return {
+            "position": self.position,
+            "windows": self._clone_tree(self.windows),
+            "compressed": self._clone_tree(self.compressed),
+            "keys": self._clone_tree(self.keys),
+            "carry": self._clone_tree(self.carry),
+            "hash": self.hash.cache.clone() if self.hash is not None else None,
+            "dspark": self.dspark.snapshot() if self.dspark is not None else None,
+        }
+
+    def restore(self, snapshot):
+        self.position = snapshot["position"]
+        self.windows = snapshot["windows"]
+        self.compressed = snapshot["compressed"]
+        self.keys = snapshot["keys"]
+        self.carry = snapshot["carry"]
+        if self.hash is not None:
+            self.hash.cache.copy_(snapshot["hash"])
+        if self.dspark is not None:
+            self.dspark.restore(snapshot["dspark"])
+
+    def commit_prefix(self, snapshot, length):
+        """Retain an accepted verification prefix without replaying the model."""
+        start = snapshot["position"]
+        current = self.snapshot()
+        positions = torch.arange(start, start + length, device=self.device)
+        self.restore(snapshot)
+        for layer, window in self.windows.items():
+            slots = positions % self.args.window_size
+            window[slots] = current["windows"][layer][slots]
+        for layer, values in self.compressed.items():
+            ratio = self.args.compress_ratios[layer]
+            old_count, new_count = start // ratio, (start + length) // ratio
+            if new_count > old_count:
+                values[old_count:new_count] = current["compressed"][layer][
+                    old_count:new_count
+                ]
+                self.keys[layer][old_count:new_count] = current["keys"][layer][
+                    old_count:new_count
+                ]
+        if self._verify_carries is not None:
+            for layer, states in self._verify_carries.items():
+                self.carry[layer] = self._clone_tree(states[length - 1])
+        if self.hash is not None:
+            self.hash.cache[:, start:start + length] = current["hash"][
+                :, start:start + length
+            ]
+        if self.dspark is not None:
+            self.dspark.commit_prefix(
+                snapshot["dspark"], current["dspark"], start, length
+            )
+        self.position = start + length
+        self._verify_carries = None
 
     def _linear(self, name, x):
         return linear(self.store, name, x)
@@ -150,9 +229,17 @@ class Decoder:
             hidden = hidden * routing_weight
         return self._linear(name + ".w2", hidden.to(x.dtype))
 
-    def _moe(self, layer, x):
+    def _moe(
+        self,
+        layer,
+        x,
+        *,
+        name=None,
+        n_activated_experts=None,
+    ):
         a, store = self.args, self.store
-        name = f"layers.{layer}.ffn"
+        name = name or f"layers.{layer}.ffn"
+        n_activated_experts = n_activated_experts or a.n_activated_experts
         scores = F.linear(x.float(), store.get(name + ".gate.weight").float()) / a.gate_temp
         if a.score_func == "sqrtsoftplus":
             scores = F.softplus(scores).sqrt()
@@ -160,9 +247,11 @@ class Decoder:
             scores = scores.sigmoid()
         else:
             scores = scores.softmax(-1)
-        indices = (scores + store.get(name + ".gate.bias")).topk(a.n_activated_experts, dim=-1).indices
+        indices = (scores + store.get(name + ".gate.bias")).topk(
+            n_activated_experts, dim=-1
+        ).indices
         weights = scores.gather(-1, indices)
-        if a.norm_topk_prob and a.n_activated_experts > 1:
+        if a.norm_topk_prob and n_activated_experts > 1:
             weights = weights / (weights.sum(-1, keepdim=True) + 1e-20)
         weights = weights * a.route_scale
         if self.expert_bank is not None:
@@ -254,9 +343,12 @@ class Decoder:
         pre = torch.zeros((1, 1, a.hc_mult), device=self.device, dtype=torch.float32)
         pre[..., 0] = 1
         shared = {}
+        aux = []
         for layer in range(a.n_layers):
             if self.layout and layer in self.layout.layer_ids:
                 h = self._engram(layer, h, hashes)
+            if self.dspark is not None and layer in a.dspark_target_layer_ids:
+                aux.append(h.mean(2))
             attn_pre, post, comb = self._mixes(layer, "attn", h)
             x = self._norm(f"layers.{layer}.attn_norm", self._pre(h, pre))
             h = self._post(self._attention(layer, x, pos, shared), h, post, comb)
@@ -271,11 +363,13 @@ class Decoder:
             logits = bf16_skinny_linear(h[:, -1], head, out_dtype=torch.float32)
         else:
             logits = F.linear(h[:, -1].float(), head.float())
+        if self.dspark is not None:
+            self.dspark.store_target(aux, pos)
         self.position += 1
         return logits
 
     @torch.inference_mode()
-    def prefill(self, tokens):
+    def prefill(self, tokens, *, return_all_logits=False):
         """Evaluate a prompt layer-by-layer while retaining sequential state.
 
         Attention and its projections still advance each query causally, while
@@ -296,28 +390,42 @@ class Decoder:
         pre = torch.zeros((1, len(tokens), a.hc_mult), device=self.device, dtype=torch.float32)
         pre[..., 0] = 1
         shared = [{} for _ in tokens]
+        self._verify_carries = {} if return_all_logits else None
+        aux = []
         for layer in range(a.n_layers):
             if self.layout and layer in self.layout.layer_ids:
                 h = self._engram(layer, h, hashes)
+            if self.dspark is not None and layer in a.dspark_target_layer_ids:
+                aux.append(h.mean(2))
             attn_pre, post, comb = self._mixes(layer, "attn", h)
             x = self._norm(f"layers.{layer}.attn_norm", self._pre(h, pre))
-            attention = torch.cat([
-                self._attention(layer, x[:, local:local + 1], start + local, shared[local])
-                for local in range(len(tokens))
-            ], dim=1)
+            pieces, carry_states = [], []
+            for local in range(len(tokens)):
+                pieces.append(
+                    self._attention(
+                        layer, x[:, local:local + 1], start + local, shared[local]
+                    )
+                )
+                if return_all_logits and layer in a.kv_source_layers:
+                    carry_states.append(self._clone_tree(self.carry.get(layer, [])))
+            attention = torch.cat(pieces, dim=1)
+            if carry_states:
+                self._verify_carries[layer] = carry_states
             h = self._post(attention, h, post, comb)
             pre, post, comb = self._mixes(layer, "ffn", h)
             x = self._norm(f"layers.{layer}.ffn_norm", self._pre(h, attn_pre))
             h = self._post(self._moe(layer, x), h, post, comb)
         h = self._norm("norm", self._pre(h, pre))
         head = self.store.get("head.weight")
-        last = h[:, -1]
-        if last.is_cuda and head.is_cuda:
+        output = h[0] if return_all_logits else h[:, -1]
+        if output.is_cuda and head.is_cuda:
             from sparklab.kernels.triton.dsv4.skinny import bf16_skinny_linear
 
-            logits = bf16_skinny_linear(last, head, out_dtype=torch.float32)
+            logits = bf16_skinny_linear(output, head, out_dtype=torch.float32)
         else:
-            logits = F.linear(last.float(), head.float())
+            logits = F.linear(output.float(), head.float())
+        if self.dspark is not None:
+            self.dspark.store_target(aux, start)
         self.position += len(tokens)
         return logits
 
@@ -325,6 +433,7 @@ class Decoder:
 class DeepseekV41ForCausalLM(BaseLLMModel):
     def __init__(self, config):
         self.args = config.dsv41_args
+        self.speculative_tokens = int(getattr(config, "speculative_tokens", 0) or 0)
         self.decoder = None
         self.uid = None
 
@@ -336,6 +445,8 @@ class DeepseekV41ForCausalLM(BaseLLMModel):
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=False)
         store = DiskWeights(model_path, device=torch.device("cuda", torch.cuda.current_device()), cache_bytes=CACHE_BYTES)
         self.decoder = Decoder(self.args, store, tokenizer)
+        if self.speculative_tokens:
+            self.decoder.enable_dspark(self.speculative_tokens)
 
     def state_dict(self, **kwargs):
         return {}
@@ -356,11 +467,30 @@ class DeepseekV41ForCausalLM(BaseLLMModel):
         if positions != list(range(self.decoder.position, self.decoder.position + len(positions))):
             raise ValueError("DeepSeek V4.1 state requires consecutive tokens without prefix reuse")
         tokens = batch.input_ids.cpu().tolist()
-        if len(tokens) > 1 and not batch.return_all_logits:
-            return self.decoder.prefill(tokens)
+        if len(tokens) > 1:
+            return self.decoder.prefill(
+                tokens, return_all_logits=batch.return_all_logits
+            )
         outputs = []
         for token in tokens:
             result = self.decoder.step(token)
             if batch.return_all_logits:
                 outputs.append(result)
         return torch.cat(outputs) if outputs else result
+
+    def propose_mtp(self, batch, next_token):
+        if self.decoder.dspark is None or batch.size != 1:
+            return None
+        return self.decoder.dspark.propose(next_token)
+
+    def take_speculative_probs(self):
+        return None
+
+    def snapshot_speculative_state(self):
+        return self.decoder.snapshot()
+
+    def restore_speculative_state(self, snapshot):
+        self.decoder.restore(snapshot)
+
+    def commit_speculative_prefix(self, snapshot, length):
+        self.decoder.commit_prefix(snapshot, length)

--- a/python/sparklab/recipes/deepseek-v4.1-flash.json
+++ b/python/sparklab/recipes/deepseek-v4.1-flash.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2.0",
-  "recipe_version": "0.2.0",
+  "recipe_version": "0.3.0",
   "slug": "deepseek-v4.1-flash",
   "name": "DeepSeek V4.1 Flash",
   "model": "deepseek-ai/DeepSeek-V4.1-Flash",
-  "parameters": "522B total / 8-16B active",
+  "parameters": "552B total / 8-16B active",
   "revision": "df42c109f1defefcbfcedbe7d905718a12266e40",
   "source_bytes": 510313345254,
   "intended_tier": "research",
@@ -31,10 +31,10 @@
   },
   "profile": "research",
   "description": "Native text-only Research decoder with layer-major prefill, direct packed kernels, a 64 GiB expert LRU and bounded safetensors reads. Reference: https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash",
-  "evidence": [],
+  "evidence": ["GB10-DSV41-DSPARK-003"],
   "limitations": [
     "Experimental native text implementation; the optimized complete-checkpoint short probe is measured in GB10-DSV41-OPT-002. General quality, parser, agent and endurance gates remain unverified. No V4 performance evidence transfers to V4.1.",
-    "Eager TP=1, one request and 2048 total tokens with a naive cache and no prefix reuse. Vision and DSpark are not implemented.",
+    "Eager TP=1, one request and 2048 total tokens with a naive cache and no prefix reuse. Vision is not implemented. Native greedy DSpark-5 is available as an opt-in prototype and is measured in GB10-DSV41-DSPARK-003; it is not the default profile.",
     "Reads original safetensors directly. The model owns a dedicated packed expert LRU; the fused engine setting avoids generic MoE bank allocation. Generic FTW conversion and offload-cache controls do not apply.",
     "The 96 GiB runtime budget covers the measured 64 GiB expert bank, bounded dense-weight cache, transient projections and request state; it is not a certification result.",
     "Requires roughly 510 GB of local storage. Engram tables are read by row and never loaded whole. First-token and decode latency may be high."

--- a/python/sparklab/runtime/engine/engine.py
+++ b/python/sparklab/runtime/engine/engine.py
@@ -317,6 +317,14 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         and tuple(getattr(dsv4_args, "dspark_target_layer_ids", ()) or ())
         and int(getattr(dsv4_args, "dspark_markov_rank", 0) or 0) > 0
     )
+    dsv41_args = getattr(model_config, "dsv41_args", None)
+    dsv41_dspark = bool(
+        dsv41_args is not None
+        and int(getattr(dsv41_args, "n_mtp_layers", 0) or 0) > 0
+        and int(getattr(dsv41_args, "dspark_block_size", 0) or 0) > 0
+        and tuple(getattr(dsv41_args, "dspark_target_layer_ids", ()) or ())
+        and int(getattr(dsv41_args, "dspark_markov_rank", 0) or 0) > 0
+    )
     draft_model = getattr(config, "speculative_draft_model", None) or os.getenv(
         "SPARKLAB_DFLASH2_PATH"
     )
@@ -325,7 +333,7 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
             "dflash2"
             if draft_model
             else "dspark"
-            if dsv4_dspark
+            if (dsv4_dspark or dsv41_dspark)
             else "mtp"
             if (qwen_mtp or glm5_mtp or glm_dsa_mtp)
             else "none"
@@ -338,10 +346,31 @@ def _adjust_speculative_config(config: EngineConfig, override) -> None:
         )
 
     if method == "dspark":
-        if not dsv4_dspark:
+        if not (dsv4_dspark or dsv41_dspark):
             raise ValueError(
-                "--speculative-method dspark requires a fused DeepSeek-V4 DSpark checkpoint"
+                "--speculative-method dspark requires a DeepSeek DSpark checkpoint"
             )
+        if dsv41_dspark:
+            if speculative_tokens > dsv41_args.dspark_block_size:
+                raise ValueError(
+                    "DeepSeek-V4.1 DSpark exceeds the checkpoint's trained block size"
+                )
+            if getattr(config, "draft_sample_method", "greedy") != "greedy":
+                raise ValueError(
+                    "DeepSeek-V4.1 native DSpark currently requires greedy draft sampling"
+                )
+            if float(getattr(config, "dspark_confidence_threshold", 0.0) or 0.0):
+                raise ValueError(
+                    "DeepSeek-V4.1 native DSpark does not yet support adaptive verification"
+                )
+            object.__setattr__(model_config, "speculative_method", "dspark")
+            object.__setattr__(model_config, "speculative_tokens", speculative_tokens)
+            object.__setattr__(model_config, "draft_sample_method", "greedy")
+            override("speculative_method", "dspark")
+            override("max_running_req", 1)
+            override("cuda_graph_bs", [])
+            override("cuda_graph_max_bs", 0)
+            return
         if speculative_tokens > 7:
             raise ValueError("DeepSeek-V4 DSpark supports at most 7 speculative tokens")
         if getattr(config, "draft_sample_method", "greedy") not in {
@@ -1483,6 +1512,7 @@ class Engine:
             self.mtp_stats["target_forwards"] += 1
         state_snapshots: list[tuple[int, int]] = []
         kv_snapshot = None
+        model_snapshot = None
         append_only_speculation = (
             getattr(self.config, "speculative_method", None) in {"mtp", "dflash2"}
             and getattr(getattr(self.config, "model_config", None), "glm_dsa_args", None) is not None
@@ -1493,12 +1523,16 @@ class Engine:
                 if batch.size != 1:
                     raise RuntimeError("DSpark verification currently supports batch size 1")
                 start = batch.verify_cached_lens[0]
-                kv_snapshot = self.kv_cache.snapshot_speculative(
-                    batch.reqs[0].table_idx, start, start + batch.input_ids.numel()
-                )
-                self.kv_cache.begin_speculative_carry_capture(
-                    all_prefixes=os.getenv("SPARKLAB_DSPARK_PREFIX_COMMIT", "1") == "1"
-                )
+                snapshotter = getattr(self.model, "snapshot_speculative_state", None)
+                if snapshotter is not None:
+                    model_snapshot = snapshotter()
+                else:
+                    kv_snapshot = self.kv_cache.snapshot_speculative(
+                        batch.reqs[0].table_idx, start, start + batch.input_ids.numel()
+                    )
+                    self.kv_cache.begin_speculative_carry_capture(
+                        all_prefixes=os.getenv("SPARKLAB_DSPARK_PREFIX_COMMIT", "1") == "1"
+                    )
             elif append_only_speculation:
                 # Full GLM has append-only latent/index KV, not recurrent state.
                 # Causal verification leaves every retained prefix row valid.
@@ -1577,9 +1611,19 @@ class Engine:
             if accepted < drafts.numel():
                 dspark_prefix_committed = False
                 if self.config.speculative_method == "dspark":
-                    dspark_prefix_committed = self._commit_dspark_prefix(
-                        kv_snapshot, accepted + 1
-                    )
+                    if model_snapshot is not None:
+                        committer = getattr(
+                            self.model, "commit_speculative_prefix", None
+                        )
+                        if committer is None:
+                            self.model.restore_speculative_state(model_snapshot)
+                        else:
+                            committer(model_snapshot, accepted + 1)
+                            dspark_prefix_committed = True
+                    else:
+                        dspark_prefix_committed = self._commit_dspark_prefix(
+                            kv_snapshot, accepted + 1
+                        )
                     if dspark_prefix_committed:
                         self.mtp_stats["fast_carry_commits"] += 1
                 elif not batch.cache_verify_states and not append_only_speculation:
@@ -1634,7 +1678,7 @@ class Engine:
                     take_probs() if take_probs is not None else None
                 )
             req.cached_len = start + accepted + 1
-            if self.config.speculative_method == "dspark":
+            if self.config.speculative_method == "dspark" and model_snapshot is None:
                 self.kv_cache.end_speculative_carry_capture()
             req.device_len = req.cached_len + 1
             # Accepted draft rows already occupy token_pool. The correction or
@@ -2107,16 +2151,16 @@ def _adjust_config(config: EngineConfig):
             override("cuda_graph_max_bs", 1)
 
     if getattr(model_config, "dsv41_args", None) is not None:
-        # V4.1's initial native research decoder owns disk reads and state. It
-        # cannot share V4's expert banks, prefix snapshots or captured graphs.
+        # V4.1's native decoder owns disk reads and state. DSpark uses the
+        # decoder's own snapshots rather than V4's paged-cache snapshots.
         from sparklab.models.deepseek_v41.config import MAX_CONTEXT
 
         if config.tp_info.size != 1:
             raise ValueError("DeepSeek V4.1 native research requires TP=1")
         if config.dtype != torch.bfloat16:
             raise ValueError("DeepSeek V4.1 native research requires bfloat16 computation")
-        if config.speculative_tokens or config.speculative_method not in ("auto", "none"):
-            raise ValueError("DeepSeek V4.1 native research does not support speculation")
+        if config.speculative_method not in ("auto", "none", "dspark"):
+            raise ValueError("DeepSeek V4.1 native research only supports DSpark speculation")
         if config.max_seq_len > MAX_CONTEXT:
             raise ValueError(f"DeepSeek V4.1 native research is limited to {MAX_CONTEXT} tokens")
         override("moe_backend", "fused")  # model-owned disk experts, no generic bank allocation

--- a/python/sparklab/serving/args.py
+++ b/python/sparklab/serving/args.py
@@ -336,7 +336,7 @@ def parse_args(
         default=ServerArgs.speculative_tokens,
         help=(
             "Draft block size (0 disables; Qwen MTP supports 1-3, DSV4 DSpark "
-            "1-7, Qwen3.8 DFlash2 2-16)."
+            "1-7, DSV4.1 DSpark 1-5, Qwen3.8 DFlash2 2-16)."
         ),
     )
     parser.add_argument(

--- a/tests/dsv41/test_native.py
+++ b/tests/dsv41/test_native.py
@@ -73,6 +73,29 @@ def test_layer_major_prefill_matches_sequential_reference(decoder):
     assert decoder.position == len(golden["tokens"])
 
 
+def test_layer_major_verification_returns_every_logit(decoder):
+    golden = json.loads((FIXTURE / "expected.json").read_text())
+    expected = torch.tensor(golden["logits"], dtype=torch.float32)
+    actual = decoder.prefill(golden["tokens"], return_all_logits=True)
+    torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
+
+
+def test_verification_prefix_commit_matches_sequential_state(decoder):
+    tokens = json.loads((FIXTURE / "expected.json").read_text())["tokens"]
+    for token in tokens[:2]:
+        decoder.step(token)
+    snapshot = decoder.snapshot()
+    decoder.prefill(tokens[2:6], return_all_logits=True)
+    decoder.commit_prefix(snapshot, 2)
+    committed = decoder.step(tokens[4])
+
+    decoder.reset()
+    golden = None
+    for token in tokens[:5]:
+        golden = decoder.step(token)
+    torch.testing.assert_close(committed, golden, atol=1e-6, rtol=1e-6)
+
+
 def test_context_and_image_inputs_fail_before_state_is_advanced(decoder):
     with pytest.raises(ValueError, match="text token"):
         decoder.step(decoder.args.image_token_id)
@@ -160,6 +183,37 @@ def test_registration_and_engine_reconcile_native_constraints(monkeypatch):
         _adjust_config(multi)
 
 
+def test_dspark_opt_in_uses_checkpoint_block_size():
+    from sparklab.runtime.engine.engine import _adjust_speculative_config
+
+    model_config = parse_config(RawConfigShim(_name_or_path=str(FIXTURE)))
+    object.__setattr__(model_config, "dsv41_args", replace(
+        model_config.dsv41_args,
+        n_mtp_layers=3,
+        dspark_block_size=5,
+        dspark_target_layer_ids=(1, 2, 3),
+        dspark_markov_rank=256,
+    ))
+    options = SimpleNamespace(
+        model_config=model_config,
+        speculative_method="auto",
+        speculative_tokens=5,
+        speculative_draft_model=None,
+        draft_sample_method="greedy",
+        max_running_req=4,
+        cuda_graph_bs=[1, 2, 4],
+        cuda_graph_max_bs=4,
+    )
+    _adjust_speculative_config(
+        options, lambda name, value: setattr(options, name, value)
+    )
+    assert options.speculative_method == "dspark"
+    assert model_config.speculative_method == "dspark"
+    assert model_config.speculative_tokens == 5
+    assert options.max_running_req == 1
+    assert options.cuda_graph_bs == [] and options.cuda_graph_max_bs == 0
+
+
 def test_engine_adapter_handles_chunk_continuation_and_new_requests(decoder, monkeypatch):
     model = DeepseekV41ForCausalLM(SimpleNamespace(dsv41_args=decoder.args))
     model.decoder = decoder
@@ -186,9 +240,10 @@ def test_native_recipe_is_experimental_and_skips_ftw(tmp_path):
     recipe = get_recipe("deepseek-v4.1-flash")
     assert recipe.backend == "native" and recipe.intended_tier == "research"
     assert recipe.status == "experimental" and recipe.performance is None
-    assert recipe.evidence == () and recipe.runtime_artifact is None
+    assert recipe.evidence == ("GB10-DSV41-DSPARK-003",)
+    assert recipe.runtime_artifact is None
     assert recipe.deployment.runtime_format == "safetensors"
-    assert recipe.recipe_version == "0.2.0"
+    assert recipe.recipe_version == "0.3.0"
     assert recipe.runtime_memory == {"total_bytes": 96 * 2**30}
     with pytest.raises(AcquisitionError, match="omit --prepare"):
         acquire_recipe(recipe, root=str(tmp_path), prepare=True)

--- a/tests/sparklab/test_catalog.py
+++ b/tests/sparklab/test_catalog.py
@@ -42,7 +42,7 @@ def test_catalog_contains_requested_portfolio_without_overclaiming_status():
         "qwen3.6-35b-a3b": "35B total / 3B active",
         "qwen3.8-27b": "27B dense",
         "deepseek-v4": "284B total / 13B active",
-        "deepseek-v4.1-flash": "522B total / 8-16B active",
+        "deepseek-v4.1-flash": "552B total / 8-16B active",
         "glm-5.3-flash": "320B total / 18B active",
         "qwen3.8-flash-next": "125B LM + 55B aux / 6B active",
         "glm-5.2": "753B total / 40B active",

--- a/tests/sparklab/test_cli.py
+++ b/tests/sparklab/test_cli.py
@@ -29,7 +29,7 @@ def test_models_json_exposes_tier_and_admission_status(capsys):
         "kimi-k3",
     ]
     assert all(recipe["status"] == "experimental" for recipe in payload["recipes"])
-    assert payload["recipes"][0]["parameters"] == "522B total / 8-16B active"
+    assert payload["recipes"][0]["parameters"] == "552B total / 8-16B active"
 
 
 def test_models_can_select_primary_portfolio(capsys):


### PR DESCRIPTION
DeepSeek V4.1 had a trained five-token DSpark head in its checkpoint, but SparkLab forced it off and decoded every token through the target model. This adds an opt-in native greedy DSpark-5 path for the model-owned disk decoder, batches target verification layer-by-layer, and commits accepted state directly after partial rejection.

On the fixed 74-input/128-output GB10 probe, DSpark measured 1.053 decode tok/s versus the existing 0.969 tok/s target-only median. Both measured trials matched the target-only output hash; 94/118 drafts were accepted and all nine partial rejections committed without replay.

The documentation now links the byte-preserving Oakmind checkpoint mirror and records the exact runtime scope. The model card makes clear that V4.1 retains its original safetensors layout and does not use SparkLab's generic FTW container.

Validation: `67 passed` across the V4.1 decoder, expert cache, DSpark engine, packed kernels, and catalog tests.
